### PR TITLE
Rootstock spelling

### DIFF
--- a/chains.json
+++ b/chains.json
@@ -64,7 +64,7 @@
     "network_id": 1
   },
   {
-    "name": "Rootsock Mainnet",
+    "name": "Rootstock Mainnet",
     "short_name": "rsk",
     "chain": "RSK",
     "network": "mainnet",
@@ -72,7 +72,7 @@
     "network_id": 1
   },
   {
-    "name": "Rootsock Testnet",
+    "name": "Rootstock Testnet",
     "short_name": "trsk",
     "chain": "RSK",
     "network": "testnet",


### PR DESCRIPTION
Fixed spelling of Rootstock