### PR TITLE
update Ethereum based off chains

### DIFF
--- a/_data/chains.json
+++ b/_data/chains.json
@@ -84,8 +84,8 @@
     "short_name": "go",
     "chain": "GO",
     "network": "mainnet",
-    "chain_id": 30,
-    "network_id": 1
+    "chain_id": 60,
+    "network_id": 60
   },
   {
     "name": "Ethereum Classic Mainnet",
@@ -109,7 +109,7 @@
     "chain": "ELLA",
     "network": "mainnet",
     "chain_id": 64,
-    "network_id": 1
+    "network_id": 64
   },
   {
     "name": "Mix",
@@ -117,7 +117,7 @@
     "chain": "MIX",
     "network": "mainnet",
     "chain_id": 76,
-    "network_id": 1
+    "network_id": 76
   },
   {
     "name": "POA Network Sokol",
@@ -165,7 +165,7 @@
     "chain": "ATH",
     "network": "mainnet",
     "chain_id": 1620,
-    "network_id": 1
+    "network_id": 11235813
   },
   {
     "name": "EtherGem",
@@ -173,7 +173,7 @@
     "chain": "EGEM",
     "network": "mainnet",
     "chain_id": 1987,
-    "network_id": 1
+    "network_id": 1987
   },
   {
     "name": "EOS Classic",
@@ -198,5 +198,77 @@
     "network": "tau1",
     "chain_id": 246785,
     "network_id": 246785
+  },
+  {
+    "name": "TomoChain",
+    "short_name": "tomo",
+    "chain": "TOMO",
+    "network": "mainnet",
+    "chain_id": 88,
+    "network_id": 88
+  },
+  {
+    "name": "Webchain",
+    "short_name": "web",
+    "chain": "WEB",
+    "network": "mainnet",
+    "chain_id": 101,
+    "network_id": 37129
+  },
+  {
+    "name": "EtherInc",
+    "short_name": "web",
+    "chain": "WEB",
+    "network": "mainnet",
+    "chain_id": 101,
+    "network_id": 1
+  },
+  {
+    "name": "Ethersocial Network",
+    "short_name": "esn",
+    "chain": "ESN",
+    "network": "mainnet",
+    "chain_id": 31102,
+    "network_id": 1
+  },
+  {
+    "name": "Akaroma",
+    "short_name": "aka",
+    "chain": "AKA",
+    "network": "mainnet",
+    "chain_id": 200625,
+    "network_id": 200625
+  },
+  {
+    "name": "Ether-1",
+    "short_name": "etho",
+    "chain": "ETHO",
+    "network": "mainnet",
+    "chain_id": 1313114,
+    "network_id": 1313114
+  },
+  {
+    "name": "Musicoin",
+    "short_name": "music",
+    "chain": "MUSIC",
+    "network": "mainnet",
+    "chain_id": 7762959,
+    "network_id": 7762959
+  },
+  {
+    "name": "IOLite",
+    "short_name": "ilt",
+    "chain": "ILT",
+    "network": "mainnet",
+    "chain_id": 18289463,
+    "network_id": 18289463
+  },
+  {
+    "name": "Pirl",
+    "short_name": "pirl",
+    "chain": "PIRL",
+    "network": "mainnet",
+    "chain_id": 3125659152,
+    "network_id": 3125659152
   }
 ]


### PR DESCRIPTION
NetworkID |CHAIN_ID | Chain(s) | CMC registered
-- | -- | -- | --
1 | 1 | Ethereum mainnet | ✔
2 | 2 | Morden (disused) | -
3 | 3 | Ropsten | -
4 | 4 | Rinkeby | -
? | 30 | Rootstock mainnet | -
? | 31 | Rootstock testnet | -
? | 42 | Kovan | -
1 | 61 | Ethereum Classic mainnet | ✔
3 | 62 | Ethereum Classic testnet | -
1 | 2 | Expanse mainnet ([[1]], [[2]], [[3]]) | ✔
1 | 8 | Ubiq mainnet ([[2]] , [[3]]) | ✔
60 | 60 | GoChain | ✔
76 | 76 | Mix | -
88 | 88 | TomoChain | ✔
99 | 99 | POA Network | ✔
37129 | 101 | webchain | ✔
1 | 101 | EtherInc | ✔
64 | 64 | Ellaism | ✔
1 | 820 | Callisto mainnet ([[2]] , [[3]]) | ✔
11235813 | 1620 | Atheios | ✔
1987 | 1987 | EtherGem | ✔
1 | 31102 | EtherSocial Network | ✔
200625 | 200625 | Akaroma | ✔
1313114 | 1313114 | Ether-1 | ✔
7762959 |  7762959 | Music | ✔
18289463 | 18289463 | IoLite | -
3125659152 | 3125659152 | Pirl | ✔

\[1] https://github.com/expanse-org/go-expanse/blob/master/eth/config.go#L42
\[2] https://www.ethernodes.org/network/1/nodes
\[3] https://github.com/kvhnuke/etherwallet/blob/mercury/app/scripts/nodes.js

[1]: https://github.com/expanse-org/go-expanse/blob/master/eth/config.go#L42
[2]: https://www.ethernodes.org/network/1/nodes
[3]: https://github.com/kvhnuke/etherwallet/blob/mercury/app/scripts/nodes.js

## RPC endpoints

- Webchain: https://node1.webchain.network
- Akroma: https://rpc.akroma.io
- Ethersocial Network: https://api.esn.gonspool.com
- Pirl: https://wallrpc.pirl.io
- Atheios: https://wallet.atheios.com:8797
- Ether-1: https://rpc.ether1.org
- EtherInc: https://api.einc.io/jsonrpc/mainnet
- Atheios: https://wallet.atheios.com:8797
- GoChain: https://rpc.gochain.io
- EtherGem: https://jsonrpc.egem.io/custom
- POA: https://poa.infura.io
- TomoChain: https://rpc.tomochain.com
- IoLite: https://net.iolite.io

## Inactive Chains
- Ethereum Social (ETSC)
- EOS Classic (EOSC) => rebranded REOSC