### PR TITLE
Add ARTIS (ATS) sigma1 & tau1 networks

### DIFF
--- a/_data/chains.json
+++ b/_data/chains.json
@@ -182,5 +182,21 @@
     "network": "mainnet",
     "chain_id": 2018,
     "network_id": 1
+  },
+  {
+    "name": "ARTIS sigma1",
+    "short_name": "ats",
+    "chain": "ARTIS",
+    "network": "sigma1",
+    "chain_id": 246529,
+    "network_id": 246529
+  },
+  {
+    "name": "ARTIS tau1",
+    "short_name": "ats",
+    "chain": "ARTIS",
+    "network": "tau1",
+    "chain_id": 246785,
+    "network_id": 246785
   }
 ]


### PR DESCRIPTION
Website: https://artis.eco
Block explorers: https://explorer.sigma1.artis.network/ http://explorer.tau1.artis.network/
chainIds: [246529](https://github.com/lab10-coop/sigma1/blob/1881ea80b475c10765d7a763ca6afd93df005b52/spec.json#L30) (sigma1) & [246785](https://github.com/lab10-coop/tau1/blob/master/spec.json#L30) (tau1) See also: https://github.com/satoshilabs/slips/pull/495

/cc: @d10r