### PR TITLE
Add ThunderCore's chainids to the chainids list

### DIFF
--- a/_data/chains.json
+++ b/_data/chains.json
@@ -353,5 +353,23 @@
     "chain_id": 385,
     "network_id": 385,
     "rpc": ["https://rpc-bitfalls1.lisinski.online"]
+  },
+  {
+    "name": "ThunderCore Mainnet",
+    "short_name": "TT",
+    "chain": "TT",
+    "network": "mainnet",
+    "chain_id": 108,
+    "network_id": 108,
+    "rpc": ["https://mainnet-rpc.thundercore.com"]
+  },
+  {
+    "name": "ThunderCore Testnet",
+    "short_name": "TST",
+    "chain": "TST",
+    "network": "testnet",
+    "chain_id": 18,
+    "network_id": 18,
+    "rpc": ["https://testnet-rpc.thundercore.com:8544"]
   }
 ]


### PR DESCRIPTION
ThunderCore (ThunderCore.com) is an EVM compatible blockchain. It's testnet and mainnet are already live. We were redirected to this github page by the approver of this pull request: https://github.com/ethereum/EIPs/pull/1755 

Please merge these chainid changes to avoid any conflicts.