### PR TITLE
Add Nepal Blockchain Network (977)

### DIFF
--- a/_data/chains.json
+++ b/_data/chains.json
@@ -536,8 +536,8 @@
   },
   {
     "name": "Nepal Blockchain Network",
-    "short_name": "nbft",
-    "chain": "NBFT",
+    "short_name": "yeti",
+    "chain": "YETI",
     "network": "mainnet",
     "chain_id": 977,
     "network_id": 977,

--- a/_data/chains.json
+++ b/_data/chains.json
@@ -533,5 +533,21 @@
       "https://churchill-rpc.pepchain.io/"
     ],
     "faucets": []
+  },
+  {
+    "name": "Nepal Blockchain Network",
+    "short_name": "nbft",
+    "chain": "NBFT",
+    "network": "mainnet",
+    "chain_id": 977,
+    "network_id": 977,
+    "rpc": [
+      "https://api.nepalblockchain.dev",
+      "https://api.nepalblockchain.network"
+    ],
+    "faucets": [
+      "https://faucet.nepalblockchain.network"
+    ],
+    "info_url": "https://nepalblockchain.network"
   }
 ]


### PR DESCRIPTION
Namaste  :pray:
I'm adding Nepal Blockchain Network, it's Open + FREE Blockchain as a Service using a community managed clique/POA consensus. We're currently running on Goerli Testnet to bootstrap our basic infrastructures that we'll replace with our chain's genesis in few days. 

Stats Page : https://stats.nepalblockchain.network/ 
Faucet, explorer and main page are still missing for now..

And thank you Mr. @ligi for pointing this repo on twitter. :vulcan_salute: 
Finally this closes walleth/walleth/issues/36 