### PR TITLE
Adding Auxilium network

### DIFF
--- a/_data/chains/28945486.json
+++ b/_data/chains/28945486.json
@@ -1,0 +1,16 @@
+{
+  "name": "Auxilium Network Mainnet",
+  "chain": "AUX",
+  "network": "mainnet",
+  "rpc": ["https://rpc.auxilium.global"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Auxilium coin",
+    "symbol": "AUX",
+    "decimals": 18
+  },
+  "infoURL": "https://auxilium.global",
+  "shortName": "aux",
+  "chainId": 28945486,
+  "networkId": 28945486
+}


### PR DESCRIPTION
Auxilium (AUX) is a cryptocurrency foundation of a philantropic company Auxilium Global. Its current main network started in summer of 2018, after performing swap from Sprouts blockchain and running a modified fork of Ethereum Go implementation.

Blockchain explorer is here: https://explore.auxilium.global
More information about Auxilium Global can be found here: https://auxilium.global

Gracias!
