### PR TITLE
Update Thundercore faucets and testnet RPC URLs

### DIFF
--- a/_data/chains/108.json
+++ b/_data/chains/108.json
@@ -3,7 +3,7 @@
   "chain": "TT",
   "network": "mainnet",
   "rpc": ["https://mainnet-rpc.thundercore.com"],
-  "faucets": ["https://faucet-testnet.thundercore.com"],
+  "faucets": ["https://faucet.thundercore.com"],
   "nativeCurrency": {
     "name": "ThunderCore Mainnet Ether",
     "symbol": "TT",

--- a/_data/chains/18.json
+++ b/_data/chains/18.json
@@ -2,8 +2,8 @@
   "name": "ThunderCore Testnet",
   "chain": "TST",
   "network": "testnet",
-  "rpc": ["https://testnet-rpc.thundercore.com:8544"],
-  "faucets": [],
+  "rpc": ["https://testnet-rpc.thundercore.com"],
+  "faucets": ["https://faucet-testnet.thundercore.com"],
   "nativeCurrency": {
     "name": "ThunderCore Testnet Ether",
     "symbol": "TST",


### PR DESCRIPTION
1. Use the shorter RPC-endpoint URL,
https://testnet-rpc.thundercore.com,
for Thundercore testnet.

2. Correct the Thundercore mainnet and testnet faucet URLs.
The old data was mistakenly listing the Thundercore testnet faucet as the mainnet one.