### PR TITLE
Block 0xEB for Ethereum Beacon Chain

### DIFF
--- a/_data/chains/235.json
+++ b/_data/chains/235.json
@@ -1,0 +1,16 @@
+{
+  "name": "Ethereum Beacon Chain",
+  "chain": "EBC",
+  "network": "beaconchain",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/beacon-chain.md",
+  "shortName": "eth",
+  "chainId": 235,
+  "networkId": 235
+}


### PR DESCRIPTION
The ChainId for the Beacon Chain is not decided yet - this PR is intended just to signal to other chains that this *migh* be the one