### PR TITLE
Add Valorbit (VAL) network chain (#38)

### DIFF
--- a/_data/chains/38.json
+++ b/_data/chains/38.json
@@ -1,0 +1,19 @@
+{
+  "name": "Valorbit",
+  "chain": "VAL",
+  "network": "mainnet",
+  "rpc": [
+    "https://rpc.valorbit.com/v2"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Valorbit",
+    "symbol": "VAL",
+    "decimals": 18
+  },
+  "infoURL": "https://valorbit.com",
+  "shortName": "val",
+  "chainId": 38,
+  "networkId": 38,
+  "slip44": 538
+}


### PR DESCRIPTION
This is a request to add the Valorbit VAL network chain with the #38 . 

https://github.com/valorbit/go-ethereum/blob/release/1.9-val/params/config.go#L97

Thank you.