### PR TITLE
Matic network

### DIFF
--- a/_data/chains/137.json
+++ b/_data/chains/137.json
@@ -1,0 +1,19 @@
+{
+    "name": "Matic Mainnet",
+    "chain": "Matic",
+    "network": "mainnet",
+    "rpc": [
+        "https://rpc-mainnet.matic.network",
+        "wss://ws-mainnet.matic.network"
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+        "name": "Matic",
+        "symbol": "MATIC",
+        "decimals": 18
+    },
+    "infoURL": "https://matic.network/",
+    "shortName": "matic",
+    "chainId": 137,
+    "networkId": 137
+}

--- a/_data/chains/80001.json
+++ b/_data/chains/80001.json
@@ -1,0 +1,21 @@
+{
+    "name": "Matic Mumbai",
+    "chain": "Matic",
+    "network": "testnet",
+    "rpc": [
+        "https://rpc-mumbai.matic.today",
+        "wss://ws-mumbai.matic.today"
+    ],
+    "faucets": [
+        "https://faucet.matic.network/"
+    ],
+    "nativeCurrency": {
+        "name": "Matic",
+        "symbol": "MATIC",
+        "decimals": 18
+    },
+    "infoURL": "https://matic.network/",
+    "shortName": "matic",
+    "chainId": 80001,
+    "networkId": 80001
+}


### PR DESCRIPTION
## changes

- I've added two entries for listing [Matic network](https://matic.network) on `chainid.network`
- Matic Mainnet ( chainId: 137 )
- Matic Mumbai Testnet ( chainId: 80001 )
