### PR TITLE
Adding NEAR EVM

### DIFF
--- a/_data/chains/1313161554.json
+++ b/_data/chains/1313161554.json
@@ -1,0 +1,19 @@
+{
+  "name": "NEAR MainNet",
+  "chain": "NEAR",
+  "network": "mainnet",
+  "rpc": [
+    "https://rpc.mainnet.near.org"
+  ],
+  "faucets": [
+  ],
+  "nativeCurrency": {
+    "name": "NEAR",
+    "symbol": "NEAR",
+    "decimals": 24
+  },
+  "infoURL": "https://near.org/",
+  "shortName": "near",
+  "chainId": 1313161554,
+  "networkId": 1313161554
+}

--- a/_data/chains/1313161555.json
+++ b/_data/chains/1313161555.json
@@ -6,6 +6,7 @@
     "https://rpc.testnet.near.org"
   ],
   "faucets": [
+    "https://wallet.testnet.near.org"
   ],
   "nativeCurrency": {
     "name": "NEAR",

--- a/_data/chains/1313161555.json
+++ b/_data/chains/1313161555.json
@@ -1,0 +1,19 @@
+{
+  "name": "NEAR TestNet",
+  "chain": "NEAR",
+  "network": "testnet",
+  "rpc": [
+    "https://rpc.testnet.near.org"
+  ],
+  "faucets": [
+  ],
+  "nativeCurrency": {
+    "name": "NEAR",
+    "symbol": "NEAR",
+    "decimals": 24
+  },
+  "infoURL": "https://near.org/",
+  "shortName": "near",
+  "chainId": 1313161555,
+  "networkId": 1313161555
+}


### PR DESCRIPTION
NEAR EVM behaves like Ethereum shard on NEAR and support set of tools like Truffle / Metamask, hence the chain-id requirement.

Details about NEAR EVM can be found in WIP spec: https://github.com/nearprotocol/NEPs/pull/106

The id for MainNet is hex("NEAR")