### PR TITLE
Update ENS registry address

### DIFF
--- a/_data/chains/1.json
+++ b/_data/chains/1.json
@@ -20,6 +20,6 @@
   "networkId": 1,
   "slip44": 60,
   "ens": {
-    "registry":"0x314159265dd8dbb310642f98f50c066173c1259b"
+    "registry":"0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e"
   }
 }


### PR DESCRIPTION
ENS migrated to a new address a while ago. [0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e](https://etherscan.io/address/0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e) is the current ENS registry address.

* https://docs.ens.domains/ens-deployments
* https://docs.ens.domains/ens-migration/guide-for-dapp-developers