### PR TITLE
Add Bloxberg (8995)

### DIFF
--- a/_data/chains/8995.json
+++ b/_data/chains/8995.json
@@ -1,0 +1,20 @@
+{
+  "name": "bloxberg",
+  "chain": "bloxberg",
+  "network": "mainnet",
+  "rpc": [
+    "https://core.bloxberg.org"
+  ],
+  "faucets": [
+    "https://faucet.bloxberg.org/"
+  ],
+  "nativeCurrency": {
+    "name": "BERG",
+    "symbol": "U+25B3",
+    "decimals": 18
+  },
+  "infoURL": "https://bloxberg.org",
+  "shortName": "berg",
+  "chainId": 8995,
+  "networkId": 8995
+}


### PR DESCRIPTION
Add bloxberg blockchain. Bloxberg is a PoA AuRa EVM chain governed by research institutes with the goal of providing researchers with decentralized services. See bloxberg.org