### PR TITLE
adding Meter mainnet chain id

### DIFF
--- a/_data/chains/82.json
+++ b/_data/chains/82.json
@@ -1,0 +1,19 @@
+{
+  "name": "Meter Mainnet",
+  "chain": "METER",
+  "network": "mainnet",
+  "rpc": [
+    "https://rpc.meter.io",
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Meter",
+    "symbol": "MTR",
+    "decimals": 18
+  },
+  "infoURL": "https://www.meter.io",
+  "shortName": "Meter",
+  "chainId": 82,
+  "networkId": 82
+}
+

--- a/_data/chains/82.json
+++ b/_data/chains/82.json
@@ -3,7 +3,7 @@
   "chain": "METER",
   "network": "mainnet",
   "rpc": [
-    "https://rpc.meter.io",
+    "https://rpc.meter.io"
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
Adding the Meter mainnet chainID, which is set as 82 (0x52) 