### PR TITLE
Remove RPC endpoints that are not Ethereum compatible

### DIFF
--- a/_data/chains/1313161554.json
+++ b/_data/chains/1313161554.json
@@ -3,7 +3,6 @@
   "chain": "NEAR",
   "network": "mainnet",
   "rpc": [
-    "https://rpc.mainnet.near.org"
   ],
   "faucets": [
   ],

--- a/_data/chains/1313161555.json
+++ b/_data/chains/1313161555.json
@@ -3,7 +3,6 @@
   "chain": "NEAR",
   "network": "testnet",
   "rpc": [
-    "https://rpc.testnet.near.org"
   ],
   "faucets": [
     "https://wallet.testnet.near.org"


### PR DESCRIPTION
Will add compatible ones later when they are live.

This is done per https://github.com/ethereum-lists/chains/pull/110#issuecomment-735820550 conversation