### PR TITLE
Add NEAR betanet to chain IDs

### DIFF
--- a/_data/chains/eip155-1313161556.json
+++ b/_data/chains/eip155-1313161556.json
@@ -1,0 +1,18 @@
+{
+  "name": "NEAR BetaNet",
+  "chain": "NEAR",
+  "network": "betanet",
+  "rpc": [
+  ],
+  "faucets": [
+  ],
+  "nativeCurrency": {
+    "name": "NEAR",
+    "symbol": "bNEAR",
+    "decimals": 24
+  },
+  "infoURL": "https://near.org/",
+  "shortName": "nearb",
+  "chainId": 1313161556,
+  "networkId": 1313161556
+}


### PR DESCRIPTION
This is a trivial follow-up to #110, which omitted the NEAR betanet.

Note that there are no faucets on the betanet, and none are needed as new account creation automatically funds the wallet with sufficient funds.
