### PR TITLE
Update Optimistic Ethereum ChainID for mainnet

### DIFF
--- a/_data/chains/eip155-10.json
+++ b/_data/chains/eip155-10.json
@@ -1,7 +1,7 @@
 {
-  "name": "Optimistic Ethereum Testnet Goerli",
+  "name": "Optimistic Ethereum",
   "chain": "ETH",
-  "network": "goerli",
+  "network": "mainnet",
   "rpc": [],
   "faucets": [],
   "nativeCurrency": {
@@ -11,6 +11,6 @@
   },
   "infoURL": "https://optimism.io",
   "shortName": "oeth",
-  "chainId": 420,
-  "networkId": 420
+  "chainId": 10,
+  "networkId": 10
 }

--- a/_data/chains/eip155-420.json
+++ b/_data/chains/eip155-420.json
@@ -3,14 +3,17 @@
   "chain": "ETH",
   "network": "goerli",
   "rpc": [],
-  "faucets": [],
+  "faucets": [
+    "https://goerli-faucet.slock.it/?address=${ADDRESS}",
+    "https://faucet.goerli.mudit.blog"
+  ],
   "nativeCurrency": {
-    "name": "Ether",
-    "symbol": "OETH",
+    "name": "Görli Ether",
+    "symbol": "GOR",
     "decimals": 18
   },
   "infoURL": "https://optimism.io",
-  "shortName": "oeth",
+  "shortName": "ogor",
   "chainId": 420,
   "networkId": 420
 }


### PR DESCRIPTION
We're shipping a fresh chain to mainnet tomorrow & therefore have to change the chainID. I believe you suggested this when I submitted my first PR but we foolishly did not heed your advice. It seems 420 for mainnet was not meant to be.

Updated 420 to forever be our Goerli testnet & now 10 as the mainnet!

Thanks again for maintaining this repo @ligi 😊