### PR TITLE
Remove faucets for optimistic goerli

### DIFF
--- a/_data/chains/eip155-420.json
+++ b/_data/chains/eip155-420.json
@@ -3,10 +3,7 @@
   "chain": "ETH",
   "network": "goerli",
   "rpc": [],
-  "faucets": [
-    "https://goerli-faucet.slock.it/?address=${ADDRESS}",
-    "https://faucet.goerli.mudit.blog"
-  ],
+  "faucets": [],
   "nativeCurrency": {
     "name": "Görli Ether",
     "symbol": "GOR",


### PR DESCRIPTION
These faucets are for goerli - but not for optimistic goerli as far as I see. Currently this leads to weird UX in WallETH as after you request funds from the faucet you do have them on the current chain:

![image](https://user-images.githubusercontent.com/111600/104830355-77904800-587e-11eb-99f2-05960f9d5694.png)

Wondering if there are faucets for optimistic goerli currently