### PR TITLE
Add ChainID for Klaytn

### DIFF
--- a/_data/chains/eip155-1001.json
+++ b/_data/chains/eip155-1001.json
@@ -14,7 +14,7 @@
     "decimals": 18
   },
   "infoURL": "https://www.klaytn.com/",
-  "shortName": "Klaytn",
+  "shortName": "Baobab",
   "chainId": 1001,
   "networkId": 1001
 }

--- a/_data/chains/eip155-1001.json
+++ b/_data/chains/eip155-1001.json
@@ -1,0 +1,20 @@
+{
+  "name": "Klaytn Testnet Baobab",
+  "chain": "KLAY",
+  "network": "baobab",
+  "rpc": [
+    "https://node-api.klaytnapi.com/v1/klaytn"
+  ],
+  "faucets": [
+    "https://baobab.wallet.klaytn.com/access?next=faucet"
+  ],
+  "nativeCurrency": {
+    "name": "KLAY",
+    "symbol": "KLAY",
+    "decimals": 18
+  },
+  "infoURL": "https://www.klaytn.com/",
+  "shortName": "Klaytn",
+  "chainId": 1001,
+  "networkId": 1001
+}

--- a/_data/chains/eip155-8217.json
+++ b/_data/chains/eip155-8217.json
@@ -12,7 +12,7 @@
     "decimals": 18
   },
   "infoURL": "https://www.klaytn.com/",
-  "shortName": "Klaytn",
+  "shortName": "Cypress",
   "chainId": 8217,
   "networkId": 8217,
   "slip44": 8217

--- a/_data/chains/eip155-8217.json
+++ b/_data/chains/eip155-8217.json
@@ -1,0 +1,19 @@
+{
+  "name": "Klaytn Mainnet Cypress",
+  "chain": "KLAY",
+  "network": "cypress",
+  "rpc": [
+    "https://node-api.klaytnapi.com/v1/klaytn"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "KLAY",
+    "symbol": "KLAY",
+    "decimals": 18
+  },
+  "infoURL": "https://www.klaytn.com/",
+  "shortName": "Klaytn",
+  "chainId": 8217,
+  "networkId": 8217,
+  "slip44": 8217
+}


### PR DESCRIPTION
Klaytn is an enterprise-grade, service-centric blockchain platform developed by
Ground X, the blockchain subsidiary of Korea's largest mobile platform Kakao.

Klaytn uses two chain IDs:
- 8217 for Klaytn Mainnet Cypress
- 1001 for Klaytn Testnet Baobab