### PR TITLE
add harmony mainnet chain IDs

### DIFF
--- a/_data/chains/eip155-1666600000.json
+++ b/_data/chains/eip155-1666600000.json
@@ -1,0 +1,19 @@
+{
+  "name": "Harmony Mainnet Shard 0",
+  "chain": "Harmony",
+  "network": "mainnet",
+  "rpc": [
+    "https://rpc.s0.t.hmny.io"
+  ],
+  "faucets": [
+  ],
+  "nativeCurrency": {
+    "name": "ONE",
+    "symbol": "ONE",
+    "decimals": 18
+  },
+  "infoURL": "https://www.harmony.one/",
+  "shortName": "hmy",
+  "chainId": 1666600000,
+  "networkId": 1666600000
+}

--- a/_data/chains/eip155-1666600000.json
+++ b/_data/chains/eip155-1666600000.json
@@ -13,7 +13,7 @@
     "decimals": 18
   },
   "infoURL": "https://www.harmony.one/",
-  "shortName": "hmy",
+  "shortName": "hmy-s0",
   "chainId": 1666600000,
   "networkId": 1666600000
 }

--- a/_data/chains/eip155-1666600001.json
+++ b/_data/chains/eip155-1666600001.json
@@ -13,7 +13,7 @@
     "decimals": 18
   },
   "infoURL": "https://www.harmony.one/",
-  "shortName": "hmy",
+  "shortName": "hmy-s1",
   "chainId": 1666600001,
   "networkId": 1666600001
 }

--- a/_data/chains/eip155-1666600001.json
+++ b/_data/chains/eip155-1666600001.json
@@ -1,0 +1,19 @@
+{
+  "name": "Harmony Mainnet Shard 1",
+  "chain": "Harmony",
+  "network": "mainnet",
+  "rpc": [
+    "https://rpc.s1.t.hmny.io"
+  ],
+  "faucets": [
+  ],
+  "nativeCurrency": {
+    "name": "ONE",
+    "symbol": "ONE",
+    "decimals": 18
+  },
+  "infoURL": "https://www.harmony.one/",
+  "shortName": "hmy",
+  "chainId": 1666600001,
+  "networkId": 1666600001
+}

--- a/_data/chains/eip155-1666600002.json
+++ b/_data/chains/eip155-1666600002.json
@@ -1,0 +1,19 @@
+{
+  "name": "Harmony Mainnet Shard 2",
+  "chain": "Harmony",
+  "network": "mainnet",
+  "rpc": [
+    "https://rpc.s2.t.hmny.io"
+  ],
+  "faucets": [
+  ],
+  "nativeCurrency": {
+    "name": "ONE",
+    "symbol": "ONE",
+    "decimals": 18
+  },
+  "infoURL": "https://www.harmony.one/",
+  "shortName": "hmy",
+  "chainId": 1666600002,
+  "networkId": 1666600002
+}

--- a/_data/chains/eip155-1666600002.json
+++ b/_data/chains/eip155-1666600002.json
@@ -13,7 +13,7 @@
     "decimals": 18
   },
   "infoURL": "https://www.harmony.one/",
-  "shortName": "hmy",
+  "shortName": "hmy-s2",
   "chainId": 1666600002,
   "networkId": 1666600002
 }

--- a/_data/chains/eip155-1666600003.json
+++ b/_data/chains/eip155-1666600003.json
@@ -13,7 +13,7 @@
     "decimals": 18
   },
   "infoURL": "https://www.harmony.one/",
-  "shortName": "hmy",
+  "shortName": "hmy-s3",
   "chainId": 1666600003,
   "networkId": 1666600003
 }

--- a/_data/chains/eip155-1666600003.json
+++ b/_data/chains/eip155-1666600003.json
@@ -1,0 +1,19 @@
+{
+  "name": "Harmony Mainnet Shard 3",
+  "chain": "Harmony",
+  "network": "mainnet",
+  "rpc": [
+    "https://rpc.s3.t.hmny.io"
+  ],
+  "faucets": [
+  ],
+  "nativeCurrency": {
+    "name": "ONE",
+    "symbol": "ONE",
+    "decimals": 18
+  },
+  "infoURL": "https://www.harmony.one/",
+  "shortName": "hmy",
+  "chainId": 1666600003,
+  "networkId": 1666600003
+}


### PR DESCRIPTION
Harmony is evm-compatible and sharded blockchain where each shard can act as a individual ethereum-compatible chain. 

The chainIDs we reserved for the 4 shards in Harmony mainnets are:

shard 0: 1666600000
shard 1: 1666600001
shard 2: 1666600002
shard 3: 1666600003