### PR TITLE
Add Telos mainnet & testnet

### DIFF
--- a/_data/chains/eip155-40.json
+++ b/_data/chains/eip155-40.json
@@ -1,0 +1,21 @@
+{
+  "name": "Telos EVM Mainnet",
+  "chain": "TLOS",
+  "network": "mainnet",
+  "rpc": [
+    "https://mainnet.telos.net/evm"
+  ],
+  "faucets": [
+  ],
+  "nativeCurrency": {
+    "name": "Telos EVM TLOS",
+    "symbol": "TLOS",
+    "decimals": 18
+  },
+  "infoURL": "https://telos.net",
+  "shortName": "telosmainnet",
+  "chainId": 40,
+  "networkId": 40,
+  "ens": {
+  }    
+}

--- a/_data/chains/eip155-40.json
+++ b/_data/chains/eip155-40.json
@@ -15,7 +15,5 @@
   "infoURL": "https://telos.net",
   "shortName": "Telos EVM",
   "chainId": 40,
-  "networkId": 40,
-  "ens": {
-  }    
+  "networkId": 40
 }

--- a/_data/chains/eip155-40.json
+++ b/_data/chains/eip155-40.json
@@ -8,12 +8,12 @@
   "faucets": [
   ],
   "nativeCurrency": {
-    "name": "Telos EVM TLOS",
+    "name": "Telos",
     "symbol": "TLOS",
     "decimals": 18
   },
   "infoURL": "https://telos.net",
-  "shortName": "telosmainnet",
+  "shortName": "Telos EVM",
   "chainId": 40,
   "networkId": 40,
   "ens": {

--- a/_data/chains/eip155-41.json
+++ b/_data/chains/eip155-41.json
@@ -6,15 +6,16 @@
     "https://testnet.telos.net/evm"
   ],
   "faucets": [
-    "https://app.telos.net/testnet/developers"
+    "https://app.telos.net/testnet/developers",
+    "https://api.telos.net/v1/docs/index.html#/testnet/get_v1_testnet_evmFaucet__evmAddress_"
   ],
   "nativeCurrency": {
-    "name": "Telos EVM TLOS",
+    "name": "Telos",
     "symbol": "TLOS",
     "decimals": 18
   },
   "infoURL": "https://telos.net",
-  "shortName": "telostest",
+  "shortName": "Telos EVM Testnet",
   "chainId": 41,
   "networkId": 41,
   "ens": {

--- a/_data/chains/eip155-41.json
+++ b/_data/chains/eip155-41.json
@@ -6,8 +6,7 @@
     "https://testnet.telos.net/evm"
   ],
   "faucets": [
-    "https://app.telos.net/testnet/developers",
-    "https://api.telos.net/v1/docs/index.html#/testnet/get_v1_testnet_evmFaucet__evmAddress_"
+    "https://app.telos.net/testnet/developers"
   ],
   "nativeCurrency": {
     "name": "Telos",
@@ -17,7 +16,5 @@
   "infoURL": "https://telos.net",
   "shortName": "Telos EVM Testnet",
   "chainId": 41,
-  "networkId": 41,
-  "ens": {
-  }    
+  "networkId": 41
 }

--- a/_data/chains/eip155-41.json
+++ b/_data/chains/eip155-41.json
@@ -14,10 +14,9 @@
     "decimals": 18
   },
   "infoURL": "https://telos.net",
-  "shortName": "telos",
+  "shortName": "telostest",
   "chainId": 41,
   "networkId": 41,
   "ens": {
-    "registry":"0x112234455c3a32fd11230c42e7bccd4a84e02010"
   }    
 }

--- a/_data/chains/eip155-41.json
+++ b/_data/chains/eip155-41.json
@@ -1,0 +1,23 @@
+{
+  "name": "Telos EVM Testnet",
+  "chain": "TLOS",
+  "network": "testnet",
+  "rpc": [
+    "https://testnet.telos.net/evm"
+  ],
+  "faucets": [
+    "https://app.telos.net/testnet/developers"
+  ],
+  "nativeCurrency": {
+    "name": "Telos EVM TLOS",
+    "symbol": "TLOS",
+    "decimals": 18
+  },
+  "infoURL": "https://telos.net",
+  "shortName": "telos",
+  "chainId": 41,
+  "networkId": 41,
+  "ens": {
+    "registry":"0x112234455c3a32fd11230c42e7bccd4a84e02010"
+  }    
+}


### PR DESCRIPTION
Telos EVM is currently live on testnet and expected to deploy on the mainnet end of Q1 or early Q2.