### PR TITLE
Add ChainID for GoodData

### DIFF
--- a/_data/chains/eip155-33.json
+++ b/_data/chains/eip155-33.json
@@ -1,0 +1,20 @@
+{
+  "name": "GoodData Mainnet",
+  "chain": "GooD",
+  "network": "mainnet",
+  "rpc": [
+    "https://rpc.goodata.io"
+  ],
+  "faucets": [
+  ],
+  "nativeCurrency": {
+    "name": "GoodData Mainnet Ether",
+    "symbol": "GooD",
+    "decimals": 18
+  },
+  "infoURL": "https://www.goodata.org",
+  "shortName": "GooD",
+  "chainId": 33,
+  "networkId": 33
+}
+

--- a/_data/chains/eip155-33.json
+++ b/_data/chains/eip155-33.json
@@ -17,4 +17,3 @@
   "chainId": 33,
   "networkId": 33
 }
-


### PR DESCRIPTION
GoodData is a machine learning based privacy protection platform.
This patch registers chainId: 33 (0x21) for GoodData Mainnet