### PR TITLE
Add chainID 8285 to KorthoTest

### DIFF
--- a/_data/chains/eip155-8285.json
+++ b/_data/chains/eip155-8285.json
@@ -1,0 +1,19 @@
+{
+    "name": "KorthoTest",
+    "chain": "Kortho",
+    "network": "Test",
+    "rpc": [
+        "https://www.krotho-test.net"
+    ],
+    "faucets": [
+    ],
+    "nativeCurrency": {
+    "name": "Kortho Test",
+    "symbol": "KTO",
+    "decimals": 11
+    },
+    "infoURL": "https://www.kortho.io/",
+    "shortName": "Kortho",
+    "chainId": 8285,
+    "networkId": 8285
+    }

--- a/_data/chains/eip155-8285.json
+++ b/_data/chains/eip155-8285.json
@@ -16,4 +16,4 @@
     "shortName": "Kortho",
     "chainId": 8285,
     "networkId": 8285
-    }
+}


### PR DESCRIPTION
{
    "name": "KorthoTest",
    "chain": "Kortho",
    "network": "Test",
    "rpc": [
        "https://www.krotho-test.net"
    ],
    "faucets": [
    ],
    "nativeCurrency": {
    "name": "Kortho Test",
    "symbol": "KTO",
    "decimals": 11
    },
    "infoURL": "https://www.kortho.io/",
    "shortName": "Kortho",
    "chainId": 8285,
    "networkId": 8285
}