### PR TITLE
Add smartBCH

### DIFF
--- a/_data/chains/eip155-10000.json
+++ b/_data/chains/eip155-10000.json
@@ -1,0 +1,18 @@
+{
+  "name": "Smart Bitcoin Cash",
+  "chain": "smartBCH",
+  "network": "mainnet",
+  "rpc": [
+    "https://rpc-mainnet.smartbch.org"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Bitcoin Cash",
+    "symbol": "BCH",
+    "decimals": 18
+  },
+  "infoURL": "http://smartbch.org/",
+  "shortName": "smartbch",
+  "chainId": 10000,
+  "networkId": 10000
+}

--- a/_data/chains/eip155-10001.json
+++ b/_data/chains/eip155-10001.json
@@ -1,0 +1,18 @@
+{
+  "name": "Smart Bitcoin Cash Testnet",
+  "chain": "smartBCHTest",
+  "network": "testnet",
+  "rpc": [
+    "https://rpc-testnet.smartbch.org"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Bitcoin Cash Test Token",
+    "symbol": "BCHT",
+    "decimals": 18
+  },
+  "infoURL": "http://smartbch.org/",
+  "shortName": "smartbchtest",
+  "chainId": 10001,
+  "networkId": 10001
+}


### PR DESCRIPTION
Hi, 

We are developing smartBCH, a sidechain of Bitcoin Cash which is compatible with EVM and Web3.

It's testnet is launching now, so we'd like to make a note about the chainid it uses.

You can learn more about our project at https://smartbch.org/ and https://docs.smartbch.org/

Thank you very much!