### PR TITLE
Fix on Fantom Public RPCs.

### DIFF
--- a/_data/chains/eip155-250.json
+++ b/_data/chains/eip155-250.json
@@ -2,7 +2,7 @@
   "name": "Fantom Opera",
   "chain": "FTM",
   "network": "mainnet",
-  "rpc": ["https://rpc.fantom.network", "https://fantomscan.io/rpc"],
+  "rpc": ["https://rpcapi.fantom.network"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Fantom",


### PR DESCRIPTION
In previous PR did not look into the RPC values, at the moment only working public one is https://rpcapi.fantom.network, so that's the only one in the list now.
References to it:
https://ftmscan.com/apis#rpc
https://docs.fantom.foundation/tutorials/set-up-metamask