### PR TITLE
add explorer for matic

### DIFF
--- a/_data/chains/eip155-137.json
+++ b/_data/chains/eip155-137.json
@@ -15,5 +15,10 @@
     "infoURL": "https://matic.network/",
     "shortName": "matic",
     "chainId": 137,
-    "networkId": 137
+    "networkId": 137,
+    "explorers": [{
+        "name": "maticvigil",
+        "url": "https://explorer-mainnet.maticvigil.com",
+        "standard": "EIP3091"
+    }]
 }


### PR DESCRIPTION
Adds [https://explorer-mainnet.maticvigil.com](https://explorer-mainnet.maticvigil.com) for matic as explorer