### PR TITLE
Update the NEAR chains

### DIFF
--- a/_data/chains/eip155-1313161554.json
+++ b/_data/chains/eip155-1313161554.json
@@ -8,7 +8,7 @@
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
-    "symbol": "ETH",
+    "symbol": "aETH",
     "decimals": 18
   },
   "infoURL": "https://aurora.dev",

--- a/_data/chains/eip155-1313161554.json
+++ b/_data/chains/eip155-1313161554.json
@@ -1,18 +1,18 @@
 {
-  "name": "NEAR MainNet",
+  "name": "Aurora MainNet",
   "chain": "NEAR",
   "network": "mainnet",
   "rpc": [
+    "https://rpc.mainnet.aurora.dev:8545"
   ],
-  "faucets": [
-  ],
+  "faucets": [],
   "nativeCurrency": {
-    "name": "NEAR",
-    "symbol": "NEAR",
-    "decimals": 24
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
   },
-  "infoURL": "https://near.org/",
-  "shortName": "near",
+  "infoURL": "https://aurora.dev",
+  "shortName": "aurora",
   "chainId": 1313161554,
   "networkId": 1313161554
 }

--- a/_data/chains/eip155-1313161555.json
+++ b/_data/chains/eip155-1313161555.json
@@ -8,7 +8,7 @@
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
-    "symbol": "ETH",
+    "symbol": "aETH",
     "decimals": 18
   },
   "infoURL": "https://aurora.dev",

--- a/_data/chains/eip155-1313161555.json
+++ b/_data/chains/eip155-1313161555.json
@@ -1,19 +1,18 @@
 {
-  "name": "NEAR TestNet",
+  "name": "Aurora TestNet",
   "chain": "NEAR",
   "network": "testnet",
   "rpc": [
+    "https://rpc.testnet.aurora.dev:8545"
   ],
-  "faucets": [
-    "https://wallet.testnet.near.org"
-  ],
+  "faucets": [],
   "nativeCurrency": {
-    "name": "NEAR",
-    "symbol": "tNEAR",
-    "decimals": 24
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
   },
-  "infoURL": "https://near.org/",
-  "shortName": "neart",
+  "infoURL": "https://aurora.dev",
+  "shortName": "aurora-testnet",
   "chainId": 1313161555,
   "networkId": 1313161555
 }

--- a/_data/chains/eip155-1313161556.json
+++ b/_data/chains/eip155-1313161556.json
@@ -8,7 +8,7 @@
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
-    "symbol": "ETH",
+    "symbol": "aETH",
     "decimals": 18
   },
   "infoURL": "https://aurora.dev",

--- a/_data/chains/eip155-1313161556.json
+++ b/_data/chains/eip155-1313161556.json
@@ -1,18 +1,18 @@
 {
-  "name": "NEAR BetaNet",
+  "name": "Aurora BetaNet",
   "chain": "NEAR",
   "network": "betanet",
   "rpc": [
+    "https://rpc.betanet.aurora.dev:8545"
   ],
-  "faucets": [
-  ],
+  "faucets": [],
   "nativeCurrency": {
-    "name": "NEAR",
-    "symbol": "bNEAR",
-    "decimals": 24
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
   },
-  "infoURL": "https://near.org/",
-  "shortName": "nearb",
+  "infoURL": "https://aurora.dev",
+  "shortName": "aurora-betanet",
   "chainId": 1313161556,
   "networkId": 1313161556
 }


### PR DESCRIPTION
[EVM on NEAR](https://github.com/aurora-is-near/aurora-engine) is now called [Aurora](https://github.com/aurora-is-near), and has launched as of yesterday:

- https://near.org/blog/aurora-launches-near/
- https://aurora.dev
- https://doc.aurora.dev/develop/networks
