### PR TITLE
Add GeneChain mainnet

### DIFF
--- a/_data/chains/eip155-80.json
+++ b/_data/chains/eip155-80.json
@@ -5,6 +5,7 @@
   "rpc": [
     "https://rpc.genechain.io"
   ],
+  "faucets": [],
   "nativeCurrency": {
     "name": "RNA",
     "symbol": "RNA",

--- a/_data/chains/eip155-80.json
+++ b/_data/chains/eip155-80.json
@@ -1,0 +1,22 @@
+{
+  "name": "GeneChain",
+  "chain": "GeneChain",
+  "network": "mainnet",
+  "rpc": [
+    "https://rpc.genechain.io"
+  ],
+  "nativeCurrency": {
+    "name": "RNA",
+    "symbol": "RNA",
+    "decimals": 18
+  },
+  "infoURL": "https://scan.genechain.io/",
+  "shortName": "GeneChain",
+  "chainId": 80,
+  "networkId": 80,
+  "explorers": [{
+    "name": "GeneChain Scan",
+    "url": "https://scan.genechain.io",
+    "standard": "EIP3091"
+  }]
+}

--- a/_data/chains/eip155-8080.json
+++ b/_data/chains/eip155-8080.json
@@ -1,6 +1,6 @@
 {
   "name": "GeneChain Adenine Testnet",
-  "chain": "GeneChain",
+  "chain": "GeneChainAdn",
   "network": "adenine",
   "rpc": [
     "https://rpc-testnet.genechain.io"

--- a/_data/chains/eip155-8080.json
+++ b/_data/chains/eip155-8080.json
@@ -1,6 +1,6 @@
 {
   "name": "GeneChain Adenine Testnet",
-  "chain": "GeneChainAdn",
+  "chain": "GeneChain",
   "network": "adenine",
   "rpc": [
     "https://rpc-testnet.genechain.io"
@@ -14,7 +14,7 @@
     "decimals": 18
   },
   "infoURL": "https://scan-testnet.genechain.io/",
-  "shortName": "GeneChain",
+  "shortName": "GeneChainAdn",
   "chainId": 8080,
   "networkId": 8080,
   "explorers": [{


### PR DESCRIPTION
GeneChain mainnet is now ready for launching. The genesis block has been set to 2021/5/18 4:00 UTC.
Explorer is ensured the same version as our testnet. So it's EIP3091. Because the genesis block is in the future, only block 0 can be found on the scan at the moment.
Thanks for reviewing our pull request!