### PR TITLE
update IoTeX RPC and faucet

### DIFF
--- a/_data/chains/eip155-4689.json
+++ b/_data/chains/eip155-4689.json
@@ -3,7 +3,7 @@
   "chain": "iotex.io",
   "network": "mainnet",
   "rpc": [
-    "https://babel-api.mainnet.iotex.one"
+    "https://babel-api.mainnet.iotex.io"
   ],
   "faucets": [
   ],

--- a/_data/chains/eip155-4690.json
+++ b/_data/chains/eip155-4690.json
@@ -3,9 +3,10 @@
   "chain": "iotex.io",
   "network": "testnet",
   "rpc": [
-    "https://babel-api.testnet.iotex.one"
+    "https://babel-api.testnet.iotex.io"
   ],
   "faucets": [
+    "https://faucet.iotex.io/"
   ],
   "nativeCurrency": {
     "name": "IoTeX",


### PR DESCRIPTION
Update IoTeX chain's public RPC endpoints for mainnet and testnet.
Also adding faucet for testnet.