### PR TITLE
Add  ChainId 2559 for kortho mainnet

### DIFF
--- a/_data/chains/eip155-2559.json
+++ b/_data/chains/eip155-2559.json
@@ -1,0 +1,19 @@
+{
+    "name": "Kortho Mainnet",
+    "chain": "Kortho",
+    "network": "mainnet",
+    "rpc": [
+        "https://www.kortho-chain.com"
+    ],
+    "faucets": [
+    ],
+    "nativeCurrency": {
+    "name": "Kortho",
+    "symbol": "KTO",
+    "decimals": 11
+    },
+    "infoURL": "https://www.kortho.io/",
+    "shortName": "Kortho",
+    "chainId": 2559,
+    "networkId": 2559
+}

--- a/_data/chains/eip155-2559.json
+++ b/_data/chains/eip155-2559.json
@@ -1,6 +1,6 @@
 {
     "name": "Kortho Mainnet",
-    "chain": "Kortho",
+    "chain": "Kortho Chain",
     "network": "mainnet",
     "rpc": [
         "https://www.kortho-chain.com"
@@ -8,7 +8,7 @@
     "faucets": [
     ],
     "nativeCurrency": {
-    "name": "Kortho",
+    "name": "KorthoChain",
     "symbol": "KTO",
     "decimals": 11
     },

--- a/_data/chains/eip155-2559.json
+++ b/_data/chains/eip155-2559.json
@@ -13,7 +13,7 @@
     "decimals": 11
     },
     "infoURL": "https://www.kortho.io/",
-    "shortName": "Kortho",
+    "shortName": "ktoc",
     "chainId": 2559,
     "networkId": 2559
 }

--- a/_data/chains/eip155-8285.json
+++ b/_data/chains/eip155-8285.json
@@ -1,0 +1,19 @@
+{
+    "name": "KorthoTest",
+    "chain": "Kortho",
+    "network": "Test",
+    "rpc": [
+        "https://www.krotho-test.net"
+    ],
+    "faucets": [
+    ],
+    "nativeCurrency": {
+    "name": "Kortho Test",
+    "symbol": "KTO",
+    "decimals": 11
+    },
+    "infoURL": "https://www.kortho.io/",
+    "shortName": "Kortho",
+    "chainId": 8285,
+    "networkId": 8285
+    }

--- a/_data/chains/eip155-8285.json
+++ b/_data/chains/eip155-8285.json
@@ -16,4 +16,4 @@
     "shortName": "Kortho",
     "chainId": 8285,
     "networkId": 8285
-    }
+}


### PR DESCRIPTION
{
    "name": "Kortho Mainnet",
    "chain": "Kortho Chain",
    "network": "mainnet",
    "rpc": [
        "https://www.kortho-chain.com"
    ],
    "faucets": [
    ],
    "nativeCurrency": {
    "name": "KorthoChain",
    "symbol": "KTO",
    "decimals": 11
    },
    "infoURL": "https://www.kortho.io/",
    "shortName": "Kortho",
    "chainId": 2559,
    "networkId": 2559
}