### PR TITLE
Add Rinkeby Etherscan

### DIFF
--- a/_data/chains/eip155-4.json
+++ b/_data/chains/eip155-4.json
@@ -6,9 +6,7 @@
     "https://rinkeby.infura.io/v3/${INFURA_API_KEY}",
     "wss://rinkeby.infura.io/ws/v3/${INFURA_API_KEY}"
   ],
-  "faucets": [
-    "https://faucet.rinkeby.io"
-  ],
+  "faucets": ["https://faucet.rinkeby.io"],
   "nativeCurrency": {
     "name": "Rinkeby Ether",
     "symbol": "RIN",
@@ -19,6 +17,13 @@
   "chainId": 4,
   "networkId": 4,
   "ens": {
-    "registry":"0xe7410170f87102df0055eb195163a03b7f2bff4a"
-  }  
+    "registry": "0xe7410170f87102df0055eb195163a03b7f2bff4a"
+  },
+  "explorers": [
+    {
+      "name": "etherscan-rinkeby",
+      "url": "https://rinkeby.etherscan.io",
+      "standard": "EIP3091"
+    }
+  ]
 }


### PR DESCRIPTION
Update Rinkeby data with Etherscan URL: https://rinkeby.etherscan.io/

I was surprised that chains.json didn't has Rinkeby Etherscan URL, I almost started searching for a bug in my code