### PR TITLE
Arbitrum:Rinkeby - Added block explorer and websocket rpc endpoint

### DIFF
--- a/_data/chains/eip155-421611.json
+++ b/_data/chains/eip155-421611.json
@@ -11,8 +11,16 @@
     "decimals": 18
   },
   "rpc": [
-    "https://rinkeby.arbitrum.io/rpc"
+    "https://rinkeby.arbitrum.io/rpc",
+    "wss://rinkeby.arbitrum.io/ws",
   ],
   "faucets": [],
-  "infoURL": "https://arbitrum.io"
+  "infoURL": "https://arbitrum.io",
+  "explorers": [
+    {
+      "name": "arbitrum-rinkeby",
+      "url": "https://rinkeby-explorer.arbitrum.io",
+      "standard": "EIP3091"
+    }
+  ]
 }

--- a/_data/chains/eip155-421611.json
+++ b/_data/chains/eip155-421611.json
@@ -12,7 +12,7 @@
   },
   "rpc": [
     "https://rinkeby.arbitrum.io/rpc",
-    "wss://rinkeby.arbitrum.io/ws",
+    "wss://rinkeby.arbitrum.io/ws"
   ],
   "faucets": [],
   "infoURL": "https://arbitrum.io",


### PR DESCRIPTION
* Added wss://rinkeby.arbitrum.io/ws to RPC Endpoints alongside the existing https one
* Added block explorer https://rinkeby-explorer.arbitrum.io