### PR TITLE
HECO chain (128): Change infoURL to explorer URL. Fix infoURL.

### DIFF
--- a/_data/chains/eip155-128.json
+++ b/_data/chains/eip155-128.json
@@ -12,8 +12,13 @@
     "symbol": "HT",
     "decimals": 18
   },
-  "infoURL": "https://hecoinfo.com",
+  "infoURL": "https://www.hecochain.com",
   "shortName": "heco",
   "chainId": 128,
-  "networkId": 128
+  "networkId": 128,
+  "explorers": [{
+    "name": "hecoinfo",
+    "url": "https://hecoinfo.com",
+    "standard": "EIP3091"
+  }]
 }


### PR DESCRIPTION
The infoURL seems to be an explorer URL rather than a URL for the information of the chain. <https://www.hecochain.com> was added back as it provides information of the chain.