### PR TITLE
Add RPC URLs, and show the current name "Polygon"

### DIFF
--- a/_data/chains/eip155-137.json
+++ b/_data/chains/eip155-137.json
@@ -1,10 +1,12 @@
 {
-    "name": "Matic Mainnet",
-    "chain": "Matic",
+    "name": "Matic(Polygon) Mainnet",
+    "chain": "Matic(Polygon)",
     "network": "mainnet",
     "rpc": [
         "https://rpc-mainnet.matic.network",
-        "wss://ws-mainnet.matic.network"
+        "wss://ws-mainnet.matic.network",
+        "https://rpc-mainnet.matic.quiknode.pro",
+        "https://matic-mainnet.chainstacklabs.com"
     ],
     "faucets": [],
     "nativeCurrency": {


### PR DESCRIPTION
The original RPC has been unusable for a long time and the has not been resolved, we should add new alternative URLs from the MATIC documentation(https://docs.matic.network/docs/develop/network-details/network/).