### PR TITLE
Add ChainID for GoodData Testnet

### DIFF
--- a/_data/chains/eip155-32.json
+++ b/_data/chains/eip155-32.json
@@ -1,0 +1,19 @@
+{
+  "name": "GoodData Testnet",
+  "chain": "GooD",
+  "network": "testnet",
+  "rpc": [
+    "https://test2.goodata.io"
+  ],
+  "faucets": [
+  ],
+  "nativeCurrency": {
+    "name": "GoodData Testnet Ether",
+    "symbol": "GooD",
+    "decimals": 18
+  },
+  "infoURL": "https://www.goodata.org",
+  "shortName": "GooD",
+  "chainId": 32,
+  "networkId": 32
+}

--- a/_data/chains/eip155-32.json
+++ b/_data/chains/eip155-32.json
@@ -13,7 +13,7 @@
     "decimals": 18
   },
   "infoURL": "https://www.goodata.org",
-  "shortName": "GooD",
+  "shortName": "GooDT",
   "chainId": 32,
   "networkId": 32
 }


### PR DESCRIPTION
GoodData is a machine learning based privacy protection platform.
This patch registers chainId 32 for GoodData Testnet.