### PR TITLE
Add chain ID for the cheapETH blockchain

### DIFF
--- a/_data/chains/eip155-777.json
+++ b/_data/chains/eip155-777.json
@@ -1,18 +1,18 @@
 {
-  "name": "Ethermint Testnet",
-  "chain": "ETHERMINT",
-  "network": "testnet",
+  "name": "cheapETH",
+  "chain": "cheapETH",
+  "network": "cheapnet",
   "rpc": [
-    "http://54.210.246.165:8545"
+    "https://node.cheapeth.org/rpc"
   ],
   "faucets": [],
   "nativeCurrency": {
-    "name": "Photon",
-    "symbol": "Photon",
+    "name": "cTH",
+    "symbol": "cTH",
     "decimals": 18
   },
-  "infoURL": "https://docs.ethermint.zone",
-  "shortName": "emint",
+  "infoURL": "https://cheapeth.org/",
+  "shortName": "cth",
   "chainId": 777,
   "networkId": 777
 }


### PR DESCRIPTION
cheapETH is alive and well and using chain ID 777!

Learn more at https://cheapeth.org, perhaps more legit than the Ethermint Testnet?