### PR TITLE
Ubiq has switched Network ID to 8 to match Chain ID

### DIFF
--- a/_data/chains/eip155-8.json
+++ b/_data/chains/eip155-8.json
@@ -15,6 +15,6 @@
   "infoURL": "https://ubiqsmart.com",
   "shortName": "ubq",
   "chainId": 8,
-  "networkId": 88,
+  "networkId": 8,
   "slip44": 108
 }


### PR DESCRIPTION
Announcement links:
* https://blog.ubiqsmart.com/announcing-gubiq-5-1-e4c5a9982073
* https://github.com/ubiq/UIPs/issues/9