### PR TITLE
Add Fuse Explorer information

### DIFF
--- a/_data/chains/eip155-122.json
+++ b/_data/chains/eip155-122.json
@@ -14,5 +14,12 @@
   "infoURL": "https://fuse.io/",
   "shortName": "fuse",
   "chainId": 122,
-  "networkId": 122
+  "networkId": 122,
+  "explorers": [
+      {
+        "name": "Fuse Explorer",
+        "url": "https://explorer.fuse.io",
+        "standard": "EIP3091"
+      }
+    ]
 }


### PR DESCRIPTION
The wrong Explorer URL is used on https://chainlist.org/