### PR TITLE
Add Polyjuice chain testnet

### DIFF
--- a/_data/chains/eip155-71393.json
+++ b/_data/chains/eip155-71393.json
@@ -1,0 +1,20 @@
+{
+  "name": "Polyjuice Testnet",
+  "chain": "CKB",
+  "network": "testnet",
+  "icon": "polyjuice",
+  "rpc": [
+    "https://godwoken-testnet-web3-rpc.ckbapp.dev",
+    "ws://godwoken-testnet-web3-rpc.ckbapp.dev/ws"
+  ],
+  "faucets": ["https://faucet.nervos.org/"],
+  "nativeCurrency": {
+    "name": "CKB",
+    "symbol": "CKB",
+    "decimals": 8
+  },
+  "infoURL": "https://github.com/nervosnetwork/godwoken",
+  "shortName": "ckb",
+  "chainId": 71393,
+  "networkId": 1
+}

--- a/_data/icons/polyjuice.json
+++ b/_data/icons/polyjuice.json
@@ -1,0 +1,8 @@
+[
+    {
+	"url":"ipfs://QmZ5gFWUxLFqqT3DkefYfRsVksMwMTc5VvBjkbHpeFMsNe",
+	"width":1000,
+	"height":1628,
+	"format":"png"
+    }
+]


### PR DESCRIPTION
Hi guys, polyjuice is an Ethereum compatible chain. Currently, only testnet is available.