### PR TITLE
Add information for Arbitrum on xDai

### DIFF
--- a/_data/chains/eip155-200.json
+++ b/_data/chains/eip155-200.json
@@ -1,0 +1,21 @@
+{
+  "name": "Arbitrum on xDai",
+  "chain": "AOX",
+  "network": "xdai",
+  "rpc": ["https://arbitrum.xdaichain.com/"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "xDAI",
+    "symbol": "xDAI",
+    "decimals": 18
+  },
+  "infoURL": "https://xdaichain.com",
+  "shortName": "aox",
+  "chainId": 200,
+  "networkId": 200,
+  "explorers": [{
+    "name": "blockscout",
+    "url": "https://blockscout.com/xdai/arbitrum",
+    "standard": "EIP3091"
+  }]
+}


### PR DESCRIPTION
Consider to add the information about Arbitrum on xDai rollup which is associated with the chain id 200.