### PR TITLE
Update Fantom RPC URL to https://rpc.ftm.tools

### DIFF
--- a/_data/chains/eip155-250.json
+++ b/_data/chains/eip155-250.json
@@ -2,7 +2,7 @@
   "name": "Fantom Opera",
   "chain": "FTM",
   "network": "mainnet",
-  "rpc": ["https://rpcapi.fantom.network"],
+  "rpc": ["https://rpc.ftm.tools"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Fantom",


### PR DESCRIPTION
https://twitter.com/FantomFDN/status/1432824921613340680

Updating https://rpcapi.fantom.network
to https://rpc.ftm.tools

Signed-off-by: antonnell <antonnell.crypto@gmail.com>