### PR TITLE
Fixed Celo explorer URL

### DIFF
--- a/_data/chains/eip155-42220.json
+++ b/_data/chains/eip155-42220.json
@@ -13,4 +13,9 @@
   "rpc": ["https://forno.celo.org", "wss://forno.celo.org/ws"],
   "faucets": [],
   "infoURL": "https://explorer.celo.org/"
+  "explorers": [{
+    "name": "Celo Explorer",
+    "url": "https://explorer.celo.org/",
+    "standard": "EIP3091"
+  }]
 }

--- a/_data/chains/eip155-42220.json
+++ b/_data/chains/eip155-42220.json
@@ -12,7 +12,7 @@
   },
   "rpc": ["https://forno.celo.org", "wss://forno.celo.org/ws"],
   "faucets": [],
-  "infoURL": "https://explorer.celo.org/"
+  "infoURL": "https://docs.celo.org/"
   "explorers": [{
     "name": "Celo Explorer",
     "url": "https://explorer.celo.org/",

--- a/_data/chains/eip155-42220.json
+++ b/_data/chains/eip155-42220.json
@@ -12,5 +12,5 @@
   },
   "rpc": ["https://forno.celo.org", "wss://forno.celo.org/ws"],
   "faucets": [],
-  "infoURL": "https://docs.celo.org/"
+  "infoURL": "https://explorer.celo.org/"
 }


### PR DESCRIPTION
Added a Celo explorer URL.

Previously, Metamask used the infoURL which forwards users to a 'Page Not Found' page, instead of a block explorer.

![image](https://user-images.githubusercontent.com/61325205/134409456-3c35c183-19f9-42ee-90f3-7f6f17e9053d.png)
