### PR TITLE
Corrected RPC url for slock.it and added etherscan block explorer

### DIFF
--- a/_data/chains/eip155-5.json
+++ b/_data/chains/eip155-5.json
@@ -4,7 +4,8 @@
   "network": "goerli",
   "rpc": [
     "https://rpc.goerli.mudit.blog/",
-    "https://rpc.slock.it/goerl",
+    "https://rpc.slock.it/goerli",
+
     "https://goerli.prylabs.net/"
   ],
   "faucets": [


### PR DESCRIPTION
* Corrected RPC url for slock.it so it does not have a trailing space
* Added etherscan block explorer for Goerli