### PR TITLE
Update explorer on Avalanche

### DIFF
--- a/_data/chains/eip155-43113.json
+++ b/_data/chains/eip155-43113.json
@@ -16,5 +16,12 @@
   "infoURL": "https://cchain.explorer.avax-test.network",
   "shortName": "Fuji",
   "chainId": 43113,
-  "networkId": 1
+  "networkId": 1,
+  "explorers": [
+    {
+      "name": "snowtrace",
+      "url": "https://testnet.snowtrace.io/",
+      "standard": "EIP3091"
+    }
+  ]
 }

--- a/_data/chains/eip155-43114.json
+++ b/_data/chains/eip155-43114.json
@@ -16,9 +16,11 @@
   "chainId": 43114,
   "networkId": 43114,
   "slip44": 9000,
-  "explorers": [{
-    "name": "blockscout",
-    "url": "https://cchain.explorer.avax.network",
-    "standard": "none"
-  }]
+  "explorers": [
+    {
+      "name": "snowtrace",
+      "url": "https://snowtrace.io/",
+      "standard": "EIP3091"
+    }
+  ]
 }


### PR DESCRIPTION
According to this: https://medium.com/avalancheavax/snowtrace-bringing-etherscan-to-the-avalanche-community-f8463e0d80d3

Avalanche team will shutdown https://cchain.explorer.avax.network/ and move to https://snowtrace.io/