### PR TITLE
docs: add evmos icon to ipfs

### DIFF
--- a/_data/icons/evmos.json
+++ b/_data/icons/evmos.json
@@ -1,0 +1,8 @@
+[
+    {
+      "url": "ipfs://QmU1avSagPdrjV7YuDc4faj5cjezrdNDjDTohLCyw7fPku", 
+      "width": 1600,
+      "height": 1600,
+      "format": "png"
+    }
+]


### PR DESCRIPTION
Adding `ipfs://QmU1avSagPdrjV7YuDc4faj5cjezrdNDjDTohLCyw7fPku` icon for evmos