### PR TITLE
Change Sokol chain symbol SKL => SPOA

### DIFF
--- a/_data/chains/eip155-77.json
+++ b/_data/chains/eip155-77.json
@@ -8,15 +8,15 @@
     "ws://sokol.poa.network:8546"
   ],
   "faucets": [
-    "https://faucet-sokol.herokuapp.com"
+    "https://faucet.poa.network"
   ],
   "nativeCurrency": {
     "name": "POA Sokol Ether",
-    "symbol": "SKL",
+    "symbol": "SPOA",
     "decimals": 18
   },
   "infoURL": "https://poa.network",
-  "shortName": "skl",
+  "shortName": "spoa",
   "chainId": 77,
   "networkId": 77,
   


### PR DESCRIPTION
The official Sokol chain coin name is SPOA.

References:
https://www.poa.network/v/master-1/for-developers/getting-tokens-for-tests/sokol-testnet-faucet#interacting-with-spoa
https://blockscout.com/poa/sokol/

Chore:
- faucet link changed to https://faucet.poa.network