### PR TITLE
update rpc urls for Moonbase Alpha

### DIFF
--- a/_data/chains/eip155-1287.json
+++ b/_data/chains/eip155-1287.json
@@ -3,8 +3,8 @@
   "chain": "MOON",
   "network": "moonbase",
   "rpc": [
-    "https://rpc.testnet.moonbeam.network",
-    "wss://wss.testnet.moonbeam.network"
+    "https://rpc.api.moonbase.moonbeam.network",
+    "wss://wss.api.moonbase.moonbeam.network"
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
This PR updates the rpc urls for the Moonbase Alpha TestNet 

https://docs.moonbeam.network/learn/platform/networks/moonbase/#network-endpoints