### PR TITLE
vision network :add eip155-666666 eip155-888888

### DIFF
--- a/_data/chains/eip155-666666.json
+++ b/_data/chains/eip155-666666.json
@@ -1,0 +1,20 @@
+{
+  "name": "Vision - Vpioneer Test Chain",
+  "chain": "Vision-Vpioneer",
+  "rpc": [
+    "https://vpioneer.infragrid.v.network/ethereum/compatible"
+  ],
+  "faucets": [
+      "https://vpioneerfaucet.visionscan.org"
+  ],
+  "nativeCurrency": {
+    "name": "VS",
+    "symbol": "VS",
+    "decimals": 6
+  },
+  "infoURL": "https://visionscan.org",
+  "shortName": "vpioneer",
+  "chainId": 666666,
+  "networkId": 666666,
+  "slip44": 60
+}

--- a/_data/chains/eip155-888888.json
+++ b/_data/chains/eip155-888888.json
@@ -1,0 +1,19 @@
+{
+    "name": "Vision - Mainnet",
+    "chain": "Vision",
+    "rpc": [
+      "https://infragrid.v.network/ethereum/compatible"
+    ],
+    "faucets": [
+    ],
+    "nativeCurrency": {
+      "name": "VS",
+      "symbol": "VS",
+      "decimals": 6
+    },
+    "infoURL": "https://visionscan.org",
+    "shortName": "vision",
+    "chainId": 888888,
+    "networkId": 888888,
+    "slip44": 60
+  }


### PR DESCRIPTION
eip155-666666  for vision vpioneer testnet ,already launched 


eip155-888888 for vision mainnet , will launch in 2022 H1


More detail:
Vision Native Currency VS decimal is 6 , but jrpc already compatible ,user use metamask send 1 (10**18) equal 1 vs (10**6)
https://www.visionscan.org/
https://developers.v.network/
