### PR TITLE
adding explorer urls for aurora main/test chains

### DIFF
--- a/_data/chains/eip155-1313161554.json
+++ b/_data/chains/eip155-1313161554.json
@@ -17,7 +17,7 @@
   "explorers": [
     {
       "name": "explorer.aurora.dev",
-      "url": "https://explorer.mainnet.aurora.dev/",
+      "url": "https://explorer.mainnet.aurora.dev",
       "standard": "EIP3091"
     }
   ]

--- a/_data/chains/eip155-1313161554.json
+++ b/_data/chains/eip155-1313161554.json
@@ -13,5 +13,12 @@
   "infoURL": "https://aurora.dev",
   "shortName": "aurora",
   "chainId": 1313161554,
-  "networkId": 1313161554
+  "networkId": 1313161554,
+  "explorers": [
+    {
+      "name": "explorer.aurora.dev",
+      "url": "https://explorer.mainnet.aurora.dev/",
+      "standard": "EIP3091"
+    }
+  ]
 }

--- a/_data/chains/eip155-1313161555.json
+++ b/_data/chains/eip155-1313161555.json
@@ -13,5 +13,12 @@
   "infoURL": "https://aurora.dev",
   "shortName": "aurora-testnet",
   "chainId": 1313161555,
-  "networkId": 1313161555
+  "networkId": 1313161555,
+  "explorers": [
+    {
+      "name": "explorer.aurora.dev",
+      "url": "https://explorer.testnet.aurora.dev/",
+      "standard": "EIP3091"
+    }
+  ]
 }

--- a/_data/chains/eip155-1313161555.json
+++ b/_data/chains/eip155-1313161555.json
@@ -17,7 +17,7 @@
   "explorers": [
     {
       "name": "explorer.aurora.dev",
-      "url": "https://explorer.testnet.aurora.dev/",
+      "url": "https://explorer.testnet.aurora.dev",
       "standard": "EIP3091"
     }
   ]


### PR DESCRIPTION
Add aurora's explorer urls for the Aurora Mainnet (1313161554) and TestNet (1313161555) chains.