### PR TITLE
Updated Elastos RPC/Info

### DIFF
--- a/_data/chains/eip155-20.json
+++ b/_data/chains/eip155-20.json
@@ -16,6 +16,6 @@
   "networkId": 20,
   "explorers": [{
     "name": "elastos eth explorer",
-    "url": "https://eth.elastos.io/",
+    "url": "https://eth.elastos.io",
     "standard": "EIP3091"
   }]

--- a/_data/chains/eip155-20.json
+++ b/_data/chains/eip155-20.json
@@ -1,10 +1,10 @@
 {
-  "name": "ELA-ETH-Sidechain Mainnet",
+  "name": "Elastos Smart Chain",
   "chain": "ETH",
   "rpc": [
-    "https://mainrpc.elaeth.io"
+    "https://api.elastos.io/eth"
   ],
-  "faucets": [],
+  "faucets": ["https://faucet.elastos.org/"],
   "nativeCurrency": {
     "name": "Elastos",
     "symbol": "ELA",
@@ -13,5 +13,9 @@
   "infoURL": "https://www.elastos.org/",
   "shortName": "elaeth",
   "chainId": 20,
-  "networkId": 20
-}
+  "networkId": 20,
+  "explorers": [{
+    "name": "elastos eth explorer",
+    "url": "https://eth.elastos.io/",
+    "standard": "EIP3091"
+  }]

--- a/_data/chains/eip155-20.json
+++ b/_data/chains/eip155-20.json
@@ -19,3 +19,4 @@
     "url": "https://eth.elastos.io",
     "standard": "EIP3091"
   }]
+}


### PR DESCRIPTION
The rpc was no longer active, so updated this and the other chain info to https://api.elastos.io/eth, the faucet https://faucet.elastos.org/, and the explorer https://eth.elastos.io/