### PR TITLE
fix: rename oe to optimism

### DIFF
--- a/_data/chains/eip155-10.json
+++ b/_data/chains/eip155-10.json
@@ -1,5 +1,5 @@
 {
-  "name": "Optimistic Ethereum",
+  "name": "Optimism",
   "chain": "ETH",
   "rpc": ["https://mainnet.optimism.io/"],
   "faucets": [],

--- a/_data/chains/eip155-69.json
+++ b/_data/chains/eip155-69.json
@@ -1,6 +1,6 @@
 {
-  "name": "Optimistic Kovan",
-  "title": "Optimistic Ethereum Testnet Kovan",
+  "name": "Optimism Kovan",
+  "title": "Optimism Testnet Kovan",
   "chain": "ETH",
   "rpc": ["https://kovan.optimism.io/"],
   "faucets": [


### PR DESCRIPTION
Hello! This is just a minor name change. Optimism has decided to call "Optimistic Ethereum" just "Optimism" from now on, since everyone was calling it that anyway. More context [here](https://optimismpbc.medium.com/to-optimism-4f01cc0eaa10). 