### PR TITLE
Update Optimism chain info

### DIFF
--- a/_data/chains/eip155-10.json
+++ b/_data/chains/eip155-10.json
@@ -5,11 +5,11 @@
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
-    "symbol": "OETH",
+    "symbol": "ETH",
     "decimals": 18
   },
   "infoURL": "https://optimism.io",
-  "shortName": "oeth",
+  "shortName": "eth",
   "chainId": 10,
   "networkId": 10,
 

--- a/_data/chains/eip155-10.json
+++ b/_data/chains/eip155-10.json
@@ -9,7 +9,7 @@
     "decimals": 18
   },
   "infoURL": "https://optimism.io",
-  "shortName": "eth",
+  "shortName": "oeth",
   "chainId": 10,
   "networkId": 10,
 


### PR DESCRIPTION
Following up on conversation in https://github.com/ethereum-lists/chains/pull/203 – updating Optimism's currency symbol to keep in line with emerging standard across wallets & apps. 

cc @ligi 