### PR TITLE
Updates RPC Information for Moonriver

### DIFF
--- a/_data/chains/eip155-1284.json
+++ b/_data/chains/eip155-1284.json
@@ -17,11 +17,6 @@
   "networkId": 1284,
   "explorers": [
     {
-      "name": "blockscout",
-      "url": "https://blockscout.moonbeam.network",
-      "standard": "none"
-    },
-    {
       "name": "moonscan",
       "url": "https://moonbeam.moonscan.io",
       "standard": "none"

--- a/_data/chains/eip155-1285.json
+++ b/_data/chains/eip155-1285.json
@@ -2,8 +2,8 @@
   "name": "Moonriver",
   "chain": "MOON",
   "rpc": [
-    "https://rpc.moonriver.moonbeam.network",
-    "wss://wss.moonriver.moonbeam.network"
+    "https://rpc.api.moonriver.moonbeam.network",
+    "wss://wss.api.moonriver.moonbeam.network"
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
Updates the RPC Endpoint for Moonriver. Also removes Blockscout as an explorer for Moonbeam