### PR TITLE
Edit native currency symbol

### DIFF
--- a/_data/chains/eip155-13381.json
+++ b/_data/chains/eip155-13381.json
@@ -8,7 +8,7 @@
   "faucets": [],
   "nativeCurrency": {
     "name": "Phoenix",
-    "symbol": "Phoenix",
+    "symbol": "PHX",
     "decimals": 18
   },
   "infoURL": "https://cryptophoenix.org/phoenix",


### PR DESCRIPTION
Change "Phoenix" to "PHX" for native currency symbol due to "add network failed: Expected 2-6 character string 'nativeCurrency.symbol'. Received: Phoenix" error