### PR TITLE
Update Cronos name and URLs

### DIFF
--- a/_data/chains/eip155-25.json
+++ b/_data/chains/eip155-25.json
@@ -2,21 +2,21 @@
   "name": "Cronos Mainnet Beta",
   "chain": "CRO",
   "rpc": [
-    "https://evm-cronos.crypto.org"
+    "https://evm.cronos.org"
   ],
   "faucets": [],
   "nativeCurrency": {
-    "name": "Crypto.org Coin",
+    "name": "Cronos",
     "symbol": "CRO",
     "decimals": 18
   },
-  "infoURL": "https://cronos.crypto.org",
+  "infoURL": "https://cronos.org/",
   "shortName": "cro",
   "chainId": 25,
   "networkId": 25,
   "explorers": [{
     "name": "Cronos Explorer",
-    "url": "https://cronos.crypto.org/explorer",
+    "url": "https://cronos.org/explorer",
     "standard": "none"
   }]
 }


### PR DESCRIPTION
Inline with rename: https://medium.com/cronos-chain/cro-is-now-cronos-bf103c257bd

Details found here: https://cronos.org/docs/getting-started/metamask.html#connecting-to-the-cronos-mainnet-beta