### PR TITLE
Change "Avis Testnet" name to "Evanesco Testnet"

### DIFF
--- a/_data/chains/eip155-1201.json
+++ b/_data/chains/eip155-1201.json
@@ -1,6 +1,6 @@
 {
-  "name": "AVIS Testnet",
-  "chain": "AVIS Testnet",
+  "name": "Evanesco Testnet",
+  "chain": "Evanesco Testnet",
   "network": "avis",
   "rpc": [
     "https://seed5.evanesco.org:8547"


### PR DESCRIPTION
To make it easier to search our testnet on the Chainlist, we change name from "Avis Testnet" to "Evanesco Testnet".