### PR TITLE
Update Arbitrum chain info

### DIFF
--- a/_data/chains/eip155-42161.json
+++ b/_data/chains/eip155-42161.json
@@ -6,7 +6,7 @@
   "networkId": 42161,
   "nativeCurrency": {
     "name": "Ether",
-    "symbol": "AETH",
+    "symbol": "ETH",
     "decimals": 18
   },
   "rpc": [


### PR DESCRIPTION
Opening a PR to update the base currency symbol used in Arbitrum (for the same reasons as discussed in https://github.com/ethereum-lists/chains/pull/843)