### PR TITLE
Add ChainDirectory to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,5 @@ There are also aggregated json files with all chains automatically assembled:
  * [EVM-BOX](https://github.com/izayl/evm-box)
  * [FaucETH](https://github.com/komputing/FaucETH)
  * [Sourcify playground](https://playground.sourcify.dev)
+ * [chaindirectory.xyz](https://www.chaindirectory.xyz)
  * Your project - contact us to add it here!


### PR DESCRIPTION
A few hours ago I forked Chainlist and set it up on chaindirectory.xyz. Will update the logo soon, already mentions credits to the original site.

Same code, open source, anyone can contribute with improvements.

If you agree, I think it makes sense to add it as Chainlist will no longer work after April 3.