### PR TITLE
Add chain-list.org to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,4 +91,5 @@ There are also aggregated json files with all chains automatically assembled:
  * [FaucETH](https://github.com/komputing/FaucETH)
  * [Sourcify playground](https://playground.sourcify.dev)
  * [chaindirectory.xyz](https://www.chaindirectory.xyz)
+ * [chain-list.org](https://chain-list.org)
  * Your project - contact us to add it here!


### PR DESCRIPTION
I forked chainlist repo and launched https://chain-list.org 

### Improvement

- `add to wallet` bugfix
- WalletConnect support (but some mobile wallet not support custom network)
- icons update for bsc, near, solana, evmos, harmony, etc.
- search debounce
- UI fix