### PR TITLE
Update Aurora explorer and symbol.

### DIFF
--- a/_data/chains/eip155-1313161554.json
+++ b/_data/chains/eip155-1313161554.json
@@ -1,5 +1,5 @@
 {
-  "name": "Aurora MainNet",
+  "name": "Aurora Mainnet",
   "chain": "NEAR",
   "rpc": [
     "https://mainnet.aurora.dev"
@@ -7,7 +7,7 @@
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
-    "symbol": "aETH",
+    "symbol": "ETH",
     "decimals": 18
   },
   "infoURL": "https://aurora.dev",
@@ -16,8 +16,8 @@
   "networkId": 1313161554,
   "explorers": [
     {
-      "name": "explorer.aurora.dev",
-      "url": "https://explorer.mainnet.aurora.dev",
+      "name": "aurorascan.dev",
+      "url": "https://aurorascan.dev",
       "standard": "EIP3091"
     }
   ]

--- a/_data/chains/eip155-1313161555.json
+++ b/_data/chains/eip155-1313161555.json
@@ -1,5 +1,5 @@
 {
-  "name": "Aurora TestNet",
+  "name": "Aurora Testnet",
   "chain": "NEAR",
   "rpc": [
     "https://testnet.aurora.dev/"
@@ -7,7 +7,7 @@
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
-    "symbol": "aETH",
+    "symbol": "ETH",
     "decimals": 18
   },
   "infoURL": "https://aurora.dev",
@@ -16,8 +16,8 @@
   "networkId": 1313161555,
   "explorers": [
     {
-      "name": "explorer.aurora.dev",
-      "url": "https://explorer.testnet.aurora.dev",
+      "name": "aurorascan.dev",
+      "url": "https://testnet.aurorascan.dev",
       "standard": "EIP3091"
     }
   ]

--- a/_data/chains/eip155-1313161556.json
+++ b/_data/chains/eip155-1313161556.json
@@ -1,5 +1,5 @@
 {
-  "name": "Aurora BetaNet",
+  "name": "Aurora Betanet",
   "chain": "NEAR",
   "rpc": [
     "https://betanet.aurora.dev/"
@@ -7,7 +7,7 @@
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
-    "symbol": "aETH",
+    "symbol": "ETH",
     "decimals": 18
   },
   "infoURL": "https://aurora.dev",


### PR DESCRIPTION
Aurora networks use ETH as the native currency to pay for gas so adding networks to MetaMask gave a warning because aETH is currently registered.
Update new explorer URLs.
