### PR TITLE
Update eip155-108.json

### DIFF
--- a/_data/chains/eip155-108.json
+++ b/_data/chains/eip155-108.json
@@ -12,7 +12,7 @@
     "symbol": "TT",
     "decimals": 18
   },
-  "infoURL": "https://thundercore.com",
+  "infoURL": "https://scan.thundercore.com/",
   "shortName": "TT",
   "chainId": 108,
   "networkId": 108,


### PR DESCRIPTION
Changing the info url allows metamask to trace transactions when clicked.
currently in metamask if you trace the transaction when clicked it just goes to the main thundercore page instead of the scanner