### PR TITLE
Update eip155-18.json

### DIFF
--- a/_data/chains/eip155-18.json
+++ b/_data/chains/eip155-18.json
@@ -12,7 +12,7 @@
     "symbol": "TST",
     "decimals": 18
   },
-  "infoURL": "https://thundercore.com",
+  "infoURL": "https://scan-testnet.thundercore.com",
   "shortName": "TST",
   "chainId": 18,
   "networkId": 18


### PR DESCRIPTION
Change the info url to the thundercore scanner.
This means when in metamask and a user clicks the trace transaction button it takes them to the scanning link of the transaction.
Currently leaving it as the thundercore.com website means clicking the scan in metamask just takes the user to thundercores website