### PR TITLE
Edit typo eip155-356256156.json

### DIFF
--- a/_data/chains/eip155-356256156.json
+++ b/_data/chains/eip155-356256156.json
@@ -1,5 +1,5 @@
 {
-  "name": "Gather Tesnet Network",
+  "name": "Gather Testnet Network",
   "chain": "GTH",
   "rpc": [
     "https://testnet.gather.network"


### PR DESCRIPTION
Edit typo in title: `Testnet` not `Tesnet`