### PR TITLE
update dfk chain rpcs to new avax dns

### DIFF
--- a/_data/chains/eip155-335.json
+++ b/_data/chains/eip155-335.json
@@ -4,7 +4,7 @@
   "icon": "dfk",
   "network": "testnet",
   "rpc": [
-    "https://api-dfk.avax-test.network/rpc"
+    "https://subnets.avax.network/defi-kingdoms/dfk-chain-testnet/rpc"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-53935.json
+++ b/_data/chains/eip155-53935.json
@@ -4,7 +4,7 @@
   "icon": "dfk",
   "network": "mainnet",
   "rpc": [
-    "https://api-dfk.avax.network/rpc"
+    "https://subnets.avax.network/defi-kingdoms/dfk-chain/rpc"
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
The previous RPCs were removed by ava labs in support of this new DNS structure. Apologies for the extra PR