### PR TITLE
Add Otterscan to the usages section

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,4 +101,5 @@ There are also aggregated json files with all chains automatically assembled:
  * [chainmap.io](https://chainmap.io) 
  * [chainlist.in](https://www.chainlist.in)
  * [chainz.me](https://chainz.me)
+ * [Otterscan](https://otterscan.io)
  * Your project - contact us to add it here!


### PR DESCRIPTION
I started using this repo's data in Otterscan to automatically discover the native currency name/symbol/decimals.

reference: https://twitter.com/wmitsuda/status/1509284311211679745
