### PR TITLE
Flag ropsten/rinkeby/kovan/goerli/sepolia as testnets

### DIFF
--- a/_data/chains/eip155-11155111.json
+++ b/_data/chains/eip155-11155111.json
@@ -2,6 +2,7 @@
   "name": "Sepolia",
   "title": "Ethereum Testnet Sepolia",
   "chain": "ETH",
+  "network": "testnet",
   "rpc": [
   ],
   "faucets": [

--- a/_data/chains/eip155-3.json
+++ b/_data/chains/eip155-3.json
@@ -2,6 +2,7 @@
   "name": "Ropsten",
   "title": "Ethereum Testnet Ropsten",
   "chain": "ETH",
+  "network": "testnet",
   "rpc": [
     "https://ropsten.infura.io/v3/${INFURA_API_KEY}",
     "wss://ropsten.infura.io/ws/v3/${INFURA_API_KEY}"

--- a/_data/chains/eip155-4.json
+++ b/_data/chains/eip155-4.json
@@ -2,6 +2,7 @@
   "name": "Rinkeby",
   "title": "Ethereum Testnet Rinkeby",
   "chain": "ETH",
+  "network": "testnet",
   "rpc": [
     "https://rinkeby.infura.io/v3/${INFURA_API_KEY}",
     "wss://rinkeby.infura.io/ws/v3/${INFURA_API_KEY}"

--- a/_data/chains/eip155-42.json
+++ b/_data/chains/eip155-42.json
@@ -2,6 +2,7 @@
   "name": "Kovan",
   "title": "Ethereum Testnet Kovan",
   "chain": "ETH",
+  "network": "testnet",
   "rpc": [
     "https://kovan.poa.network",
     "http://kovan.poa.network:8545",

--- a/_data/chains/eip155-5.json
+++ b/_data/chains/eip155-5.json
@@ -2,6 +2,7 @@
   "name": "Görli",
   "title": "Ethereum Testnet Görli",
   "chain": "ETH",
+  "network": "testnet",
   "rpc": [
     "https://goerli.infura.io/v3/${INFURA_API_KEY}",      
     "wss://goerli.infura.io/v3/${INFURA_API_KEY}",      


### PR DESCRIPTION
This PR adds the network: "testnet" attribute to all known ethereum testnets.

There are other chains in the repository with this attribute, and potentially others not correctly flagged, this PR aims to fix this information only for ethereum chains.

My motivation to flag them is to properly filter them in my product (Otterscan), but I think other products can benefit of having this flag correctly set.

As an example, the chainlist fork of DefiLlama contains a "testnet" toggle in the UI and uses string parsing to guess the network is a testnet or not (see: https://github.com/DefiLlama/chainlist/blob/main/pages/index.js#L76).