### PR TITLE
Fix Palm RPC Endpoints

### DIFF
--- a/_data/chains/eip155-11297108099.json
+++ b/_data/chains/eip155-11297108099.json
@@ -3,7 +3,7 @@
   "chain": "Palm",
   "icon": "palm",
   "rpc": [
-    "https://palm-testnet.infura.io/v3/{INFURA_API_KEY}"
+    "https://palm-testnet.infura.io/v3/${INFURA_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-11297108109.json
+++ b/_data/chains/eip155-11297108109.json
@@ -3,7 +3,7 @@
   "chain": "Palm",
   "icon": "palm",
   "rpc": [
-    "https://palm-mainnet.infura.io/v3/{INFURA_API_KEY}"
+    "https://palm-mainnet.infura.io/v3/${INFURA_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
### Description
Fix Palm network RPC endpoints - use  proper string interpolation syntax: `${INFURA_API_KEY}`.

The invalid endpoints were added in #832,  thanks to @ptescher for pointing out the error. 