### PR TITLE
Add eip155-62621.json for MultiVAC mainnet

### DIFF
--- a/_data/chains/eip155-62621.json
+++ b/_data/chains/eip155-62621.json
@@ -1,0 +1,24 @@
+{
+  "name": "MultiVAC Mainnet",
+  "chain": "MultiVAC",
+  "icon": "multivac",
+  "rpc": [
+    "https://rpc.mtv.ac",
+    "https://rpc-eu.mtv.ac"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "MultiVAC",
+    "symbol": "MTV",
+    "decimals": 18
+  },
+  "infoURL": "https://mtv.ac",
+  "shortName": "mtv",
+  "chainId": 62621,
+  "networkId": 62621,
+  "explorers": [{
+    "name": "MultiVAC Explorer",
+    "url": "https://e.mtv.ac",
+    "standard": "none"
+  }]
+}

--- a/_data/icons/multivac.json
+++ b/_data/icons/multivac.json
@@ -1,0 +1,8 @@
+[
+    {
+	"url":"ipfs://QmWb1gthhbzkiLdgcP8ccZprGbJVjFcW8Rn4uJjrw4jd3B",
+	"width":200,
+	"height":200,
+	"format":"png"
+    }
+]


### PR DESCRIPTION
I would be grateful if the MultiVAC chain could be added. The current explorer is custom, but a possible blockscout instance and integration with sourcify.eth in the near future.