### PR TITLE
Update of omChain Data

### DIFF
--- a/_data/chains/eip155-21816.json
+++ b/_data/chains/eip155-21816.json
@@ -3,21 +3,21 @@
   "chain": "OML",
   "icon": "omlira",
   "rpc": [
-    "https://seed.omlira.com"
+    "https://seed.omchain.io"
   ],
   "faucets": [],
   "nativeCurrency": {
-    "name": "Omlira",
-    "symbol": "OML",
+    "name": "omChain",
+    "symbol": "OMC",
     "decimals": 18
   },
-  "infoURL": "https://omlira.com",
-  "shortName": "oml",
+  "infoURL": "https://omchain.io",
+  "shortName": "omc",
   "chainId": 21816,
   "networkId": 21816,
   "explorers": [{
     "name": "omChain Explorer",
-    "url": "https://explorer.omlira.com",
+    "url": "https://explorer.omchain.io",
     "standard": "EIP3091"
   }]
 }


### PR DESCRIPTION
The omChain network have been rebranded and the base currency is now omChain instead of Omlira. 

https://omchain.medium.com/welcoming-omchain-9797d06da8ae

https://omchain.medium.com/rebranding-what-to-expect-401afeb69c3e