### PR TITLE
Add NxtMeta Blockchain Mainnet and Testnet

### DIFF
--- a/_data/chains/eip155-111111.json
+++ b/_data/chains/eip155-111111.json
@@ -1,0 +1,18 @@
+{
+  "name": "NxtMeta Mainnet",
+  "chain": "NXT",
+  "rpc": [
+    "https://api.xntmeta.com/prod"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "NxtMeta Mainnet Ether",
+    "symbol": "NXT",
+    "decimals": 18
+  },
+  "infoURL": "https://nxtmeta.com",
+  "shortName": "nxt",
+  "chainId": 111111,
+  "networkId": 111111,
+  "slip44": 901
+}

--- a/_data/chains/eip155-111112.json
+++ b/_data/chains/eip155-111112.json
@@ -1,0 +1,18 @@
+{
+  "name": "NxtMeta Testnet",
+  "chain": "NXT",
+  "rpc": [
+    "https://api.xntmeta.com/dev"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "NxtMeta Testnet Ether",
+    "symbol": "NXT",
+    "decimals": 18
+  },
+  "infoURL": "https://nxtmeta.com",
+  "shortName": "nxt",
+  "chainId": 111112,
+  "networkId": 111112,
+  "slip44": 901
+}


### PR DESCRIPTION
Please add NxtMeta Blockchain Mainnet and Testnet.
Testnet will be available by July 1, 2022.