### PR TITLE
suppress vscode plugin generated bin folder and files for kotlin proj…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ _site
 .env
 node_modules
 .idea
+.gradle
+*/bin/*

--- a/_data/chains/eip155-160.json
+++ b/_data/chains/eip155-160.json
@@ -1,0 +1,23 @@
+{
+  "name": "Armonia Eva Chain Mainnet",
+  "chain": "Eva",
+  "rpc": [
+    "https://evachain.io/rpc/",
+    "wss://evachain.io/ws/"
+  ],
+  "faucets": [""],  
+  "nativeCurrency": {
+    "name": "Armonia Multichain Native Token",
+    "symbol": "AMAX",
+    "decimals": 8
+  },
+  "infoURL": "https://amax.network",
+  "shortName": "eva",
+  "chainId": 160,
+  "networkId": 160,
+  "explorers": [{
+    "name": "blockscout - evascan",
+    "url": "https://evascan.io",
+    "standard": "EIP3091"
+  }]
+}


### PR DESCRIPTION
Within vscode IDE, kotlin and gradle etc plugin will generated .gradle and bin folders for kotlin projects, which are not needed for source code versioning. Hence, excluding them by adding the info inside .gitignore will be helpful for other folkers who are in the same situation.