### PR TITLE
Remove free arbitrum one websocket endpoints

### DIFF
--- a/_data/chains/eip155-42161.json
+++ b/_data/chains/eip155-42161.json
@@ -12,8 +12,7 @@
   "rpc": [
     "https://arbitrum-mainnet.infura.io/v3/${INFURA_API_KEY}",
     "https://arb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}",
-    "https://arb1.arbitrum.io/rpc",
-    "wss://arb1.arbitrum.io/ws"
+    "https://arb1.arbitrum.io/rpc"
   ],
   "faucets": [],
   "explorers": [

--- a/_data/chains/eip155-421611.json
+++ b/_data/chains/eip155-421611.json
@@ -11,8 +11,7 @@
     "decimals": 18
   },
   "rpc": [  
-    "https://rinkeby.arbitrum.io/rpc",
-    "wss://rinkeby.arbitrum.io/ws"
+    "https://rinkeby.arbitrum.io/rpc"
   ],
   "faucets": [
     "http://fauceth.komputing.org?chain=421611&address=${ADDRESS}"


### PR DESCRIPTION
The Arbitrum One free public endpoint no longer supports websockets, see
https://mobile.twitter.com/arbitrum/status/1530288743474659328