### PR TITLE
Updated PHI Symbol

### DIFF
--- a/_data/chains/eip155-4181.json
+++ b/_data/chains/eip155-4181.json
@@ -9,7 +9,7 @@
   "faucets": [],
   "nativeCurrency": {
     "name": "PHI",
-    "symbol": "Φ",
+    "symbol": "PHI",
     "decimals": 18
   },
   "infoURL": "https://phi.network",


### PR DESCRIPTION
Updated PHI Symbol ϕ to PHI because of error on web browsers to automatically add chain if symbol is less than 2 characters