### PR TITLE
added RPC endpoint for Bitgert

### DIFF
--- a/_data/chains/eip155-32520.json
+++ b/_data/chains/eip155-32520.json
@@ -2,6 +2,7 @@
   "name": "Bitgert Mainnet",
   "chain": "Brise",
   "rpc": [
+    "https://rpc.icecreamswap.com",
     "https://mainnet-rpc.brisescan.com",
     "https://chainrpc.com",
     "https://serverrpc.com"


### PR DESCRIPTION
added the rpc.icecreamswap.com endpoint for the Bitgert (Brise) Blockchain.