### PR TITLE
Update 71401 and 71402 details (Godwoken)

### DIFF
--- a/_data/chains/eip155-71401.json
+++ b/_data/chains/eip155-71401.json
@@ -8,8 +8,8 @@
     "https://testnet.bridge.godwoken.io"
   ],
   "nativeCurrency": {
-    "name": "CKB",
-    "symbol": "CKB",
+    "name": "pCKB",
+    "symbol": "pCKB",
     "decimals": 18
   },
   "infoURL": "https://www.nervos.org",

--- a/_data/chains/eip155-71401.json
+++ b/_data/chains/eip155-71401.json
@@ -24,7 +24,7 @@
     },
     {
       "name": "GWScan Block Explorer",
-      "url": "https://v1.betanet.gwscan.com",
+      "url": "https://v1.testnet.gwscan.com",
       "standard": "none"
     }
   ]

--- a/_data/chains/eip155-71401.json
+++ b/_data/chains/eip155-71401.json
@@ -19,7 +19,7 @@
   "explorers": [
     {
       "name": "GWScan Block Explorer",
-      "url": "https://v1.aggron.gwscan.com",
+      "url": "https://v1.betanet.gwscan.com",
       "standard": "none"
     }
   ]

--- a/_data/chains/eip155-71401.json
+++ b/_data/chains/eip155-71401.json
@@ -21,6 +21,11 @@
       "name": "GWScan Block Explorer",
       "url": "https://v1.betanet.gwscan.com",
       "standard": "none"
+    },
+    {
+      "name": "GWScout Explorer",
+      "url": "https://gw-testnet-explorer.nervosdao.community",
+      "standard": "none"
     }
   ]
 }

--- a/_data/chains/eip155-71401.json
+++ b/_data/chains/eip155-71401.json
@@ -18,13 +18,13 @@
   "networkId": 71401,
   "explorers": [
     {
-      "name": "GWScan Block Explorer",
-      "url": "https://v1.betanet.gwscan.com",
+      "name": "GWScout Explorer",
+      "url": "https://gw-testnet-explorer.nervosdao.community",
       "standard": "none"
     },
     {
-      "name": "GWScout Explorer",
-      "url": "https://gw-testnet-explorer.nervosdao.community",
+      "name": "GWScan Block Explorer",
+      "url": "https://v1.betanet.gwscan.com",
       "standard": "none"
     }
   ]

--- a/_data/chains/eip155-71402.json
+++ b/_data/chains/eip155-71402.json
@@ -2,10 +2,10 @@
   "name": "Godwoken Mainnet",
   "chain": "GWT",
   "rpc": [
-    "https://godwoken-testnet-v1.ckbapp.dev"
+    "https://v1.mainnet.godwoken.io/rpc"
   ],
   "faucets": [
-    "https://testnet.bridge.godwoken.io"
+    "https://bridge.godwoken.io"
   ],
   "nativeCurrency": {
     "name": "CKB",
@@ -19,7 +19,7 @@
   "explorers": [
     {
       "name": "GWScan Block Explorer",
-      "url": "https://v1.aggron.gwscan.com",
+      "url": "https://v1.gwscan.com",
       "standard": "none"
     }
   ]

--- a/_data/chains/eip155-71402.json
+++ b/_data/chains/eip155-71402.json
@@ -19,6 +19,11 @@
       "name": "GWScan Block Explorer",
       "url": "https://v1.gwscan.com",
       "standard": "none"
+    },
+    {
+      "name": "GWScout Explorer",
+      "url": "https://gw-mainnet-explorer.nervosdao.community",
+      "standard": "none"
     }
   ]
 }

--- a/_data/chains/eip155-71402.json
+++ b/_data/chains/eip155-71402.json
@@ -4,12 +4,10 @@
   "rpc": [
     "https://v1.mainnet.godwoken.io/rpc"
   ],
-  "faucets": [
-    "https://bridge.godwoken.io"
-  ],
+  "faucets": [],
   "nativeCurrency": {
-    "name": "CKB",
-    "symbol": "CKB",
+    "name": "pCKB",
+    "symbol": "pCKB",
     "decimals": 18
   },
   "infoURL": "https://www.nervos.org",

--- a/_data/chains/eip155-71402.json
+++ b/_data/chains/eip155-71402.json
@@ -16,13 +16,13 @@
   "networkId": 71402,
   "explorers": [
     {
-      "name": "GWScan Block Explorer",
-      "url": "https://v1.gwscan.com",
+      "name": "GWScout Explorer",
+      "url": "https://gw-mainnet-explorer.nervosdao.community",
       "standard": "none"
     },
     {
-      "name": "GWScout Explorer",
-      "url": "https://gw-mainnet-explorer.nervosdao.community",
+      "name": "GWScan Block Explorer",
+      "url": "https://v1.gwscan.com",
       "standard": "none"
     }
   ]


### PR DESCRIPTION
With the release of Godwoken Mainnet the RPC link is available. The previous URL for Godwoken Mainnet was a placeholder.

Also, fixing block explorer links for both Godwoken Testnet and Mainnet.

You can cross-check Mainnet RPC URL correctness by taking a look at this official nervosnetwork organization repository pull request: https://github.com/nervosnetwork/godwoken-info/pull/36 or here: https://docs.godwoken.io/connectionInfo

Also, pCKB is correct name for native token on Godwoken. It is different from CKB because CKB has 8 decimals, and pCKB has 18 decimals.