### PR TITLE
Update README.md: Chainlink docs uses this reference data

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ There are also aggregated json files with all chains automatically assembled:
  * [chainmap.io](https://chainmap.io) 
  * [chainlist.in](https://www.chainlist.in)
  * [chainz.me](https://chainz.me)
+ * [Chainlink docs](https://docs.chain.link/)
 
 ### Other
  * [FaucETH](https://github.com/komputing/FaucETH)


### PR DESCRIPTION
An "Add link to wallet" feature is available in Chainlink docs. see [here](https://docs.chain.link/docs/link-token-contracts/)
This feature uses this repo as reference data