### PR TITLE
Added klc testnet (https://kaibadefi.com)

### DIFF
--- a/_data/chains/eip155-104.json
+++ b/_data/chains/eip155-104.json
@@ -1,0 +1,25 @@
+{
+    "name": "Kaiba Lightning Chain Testnet",
+    "chain": "tKLC",
+    "network": "testnet",
+    "rpc": [
+        "https://klc.live/"
+      ],
+      "faucets": [],
+      "nativeCurrency": {
+        "name": "Kaiba Testnet Token",
+        "symbol": "tKAIBA",
+        "decimals": 18
+      },
+      "infoURL": "https://kaibadefi.com",
+      "shortName": "tklc",
+      "chainId": 104,
+      "networkId": 104,
+      "icon": "kaiba",
+      "explorers": [{
+        "name": "kaibascan",
+        "url": "https://kaibascan.io",
+        "icon": "kaibascan",
+        "standard": "EIP3091"
+      }]
+    }

--- a/_data/icons/kaiba.json
+++ b/_data/icons/kaiba.json
@@ -1,0 +1,8 @@
+[
+    {
+      "url": "ipfs://bafybeihbsw3ky7yf6llpww6fabo4dicotcgwjpefscoxrppstjx25dvtea",
+      "width": 932,
+      "height": 932,
+      "format": "png"
+    }
+]

--- a/_data/icons/kaibascan.json
+++ b/_data/icons/kaibascan.json
@@ -1,0 +1,8 @@
+[
+    {
+      "url": "ipfs://bafybeihbsw3ky7yf6llpww6fabo4dicotcgwjpefscoxrppstjx25dvtea",
+      "width": 932,
+      "height": 932,
+      "format": "png"
+    }
+]


### PR DESCRIPTION
As per https://kaibadefi.com , added KLC Testnet that will be followed shortly by KLC Mainnet (both will cohexists).
KLC is a gas-free EVM compatible QBFT blockchain with DAO based rewards and an active ecosystem spacing from ETH mainnet to KLC, gamefi and more