### PR TITLE
Update Optimism Mainnet info

### DIFF
--- a/_data/chains/eip155-10.json
+++ b/_data/chains/eip155-10.json
@@ -14,8 +14,8 @@
   "networkId": 10,
 
   "explorers": [{
-    "name": "etherscan",
-    "url": "https://optimistic.etherscan.io",
+    "name": "proxy explorer",
+    "url": "https://explorer.optimism.io",
     "standard": "none"
   }]
 }


### PR DESCRIPTION
Updates the explorer link to the Optimism hosted explorer link, which currently proxies requests through to https://optimistic.etherscan.io/, but can proxy requests through to other explorers if Etherscan ever has issues or goes down.