### PR TITLE
Update Optimism Kovan Explorer info

### DIFF
--- a/_data/chains/eip155-69.json
+++ b/_data/chains/eip155-69.json
@@ -12,8 +12,8 @@
     "decimals": 18
   },
   "explorers": [{
-    "name": "etherscan",
-    "url": "https://kovan-optimistic.etherscan.io",
+    "name": "proxy explorer",
+    "url": "https://kovan-explorer.optimism.io",
     "standard": "EIP3091"
   }],
   "infoURL": "https://optimism.io",


### PR DESCRIPTION
Updates the Kovan explorer link to the Optimism hosted explorer link, which currently proxies requests through to https://kovan-optimistic.etherscan.io/, but can proxy requests through to other explorers if Etherscan ever has issues or goes down.