### PR TITLE
Update Optimism Goerli chain info

### DIFF
--- a/_data/chains/eip155-420.json
+++ b/_data/chains/eip155-420.json
@@ -1,11 +1,11 @@
 {
-  "name": "Optimistic Ethereum Testnet Goerli",
+  "name": "Optimism Goerli Testnet",
   "chain": "ETH",
   "rpc": ["https://goerli.optimism.io/"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Görli Ether",
-    "symbol": "GOR",
+    "symbol": "ETH",
     "decimals": 18
   },
   "infoURL": "https://optimism.io",


### PR DESCRIPTION
Minor tweaks to Optimism Goerli's chain info:
- Updating currency name to ETH
- Updating chain name to "Optimism Goerli" for consistency, since we no longer use the "Optimistic Ethereum" naming

Thank you!