### PR TITLE
Update currency name and add block explorer

### DIFF
--- a/_data/chains/eip155-14.json
+++ b/_data/chains/eip155-14.json
@@ -7,12 +7,17 @@
   "faucets": [
   ],
   "nativeCurrency": {
-    "name": "Spark",
+    "name": "FLR",
     "symbol": "FLR",
     "decimals": 18
   },
   "infoURL": "https://flare.xyz",
   "shortName": "flr",
   "chainId": 14,
-  "networkId": 14
+  "networkId": 14,
+   "explorers": [{
+    "name": "blockscout",
+    "url": "https://flare-explorer.flare.network",
+    "standard": "EIP3091"
+  }]
 }


### PR DESCRIPTION
Flare Network has launched and is now in observation mode. The block explorer has been made publicly available. The native asset name has been determined to "FLR", same as the native asset symbol.