### PR TITLE
Update the Outdated Details for Cronos Testnet

### DIFF
--- a/_data/chains/eip155-338.json
+++ b/_data/chains/eip155-338.json
@@ -2,24 +2,23 @@
   "name": "Cronos Testnet",
   "chain": "CRO",
   "rpc": [
-    "https://cronos-testnet-3.crypto.org:8545",
-    "wss://cronos-testnet-3.crypto.org:8546"
+    "https://evm-t3.cronos.org"
   ],
   "faucets": [
-    "https://cronos.crypto.org/faucet"
+    "https://cronos.org/faucet"
   ],
   "nativeCurrency": {
-    "name": "Crypto.org Test Coin",
+    "name": "Cronos Test Coin",
     "symbol": "TCRO",
     "decimals": 18
   },
-  "infoURL": "https://cronos.crypto.org",
+  "infoURL": "https://cronos.org",
   "shortName": "tcro",
   "chainId": 338,
   "networkId": 338,
   "explorers": [{
     "name": "Cronos Testnet Explorer",
-    "url": "https://cronos.crypto.org/explorer/testnet3",
+    "url": "https://testnet.cronoscan.com/",
     "standard": "none"
   }]
 }


### PR DESCRIPTION
Update to the latest Block explorer URL for Cronos Testnet. 
Official Cronos RPC URLs page: https://docs.cronos.org/for-users/metamask