### PR TITLE
Avalanche short name incorrect

### DIFF
--- a/_data/chains/eip155-43114.json
+++ b/_data/chains/eip155-43114.json
@@ -11,7 +11,7 @@
     "decimals": 18
   },
   "infoURL": "https://www.avax.network/",
-  "shortName": "Avalanche",
+  "shortName": "avax",
   "chainId": 43114,
   "networkId": 43114,
   "slip44": 9005,


### PR DESCRIPTION
 Avalanche short name should not be "Avalanche", it shoud be "avax".