### PR TITLE
Update Flare Network native asset name

### DIFF
--- a/_data/chains/eip155-14.json
+++ b/_data/chains/eip155-14.json
@@ -7,7 +7,7 @@
   "faucets": [
   ],
   "nativeCurrency": {
-    "name": "FLR",
+    "name": "Flare",
     "symbol": "FLR",
     "decimals": 18
   },


### PR DESCRIPTION
The native asset name for Flare Network has been changed to "Flare". Deprecated names include "Spark" and "FLR". 

The official documentation will reflect this change. Wallets and exchanges listing Flare Network's native asset should use the name "Flare" and the symbol "FLR".