### PR TITLE
Lowercase MATIC shortName to matic to adhere to https://eips.ethereum.org/EIPS/eip-3770

### DIFF
--- a/_data/chains/eip155-137.json
+++ b/_data/chains/eip155-137.json
@@ -16,7 +16,7 @@
         "decimals": 18
     },
     "infoURL": "https://polygon.technology/",
-    "shortName": "MATIC",
+    "shortName": "matic",
     "chainId": 137,
     "networkId": 137,
     "slip44": 966,


### PR DESCRIPTION
Again, gnosis is leading the way with this standard so will open a few PRs to follow their shortNames.

https://gnosis-safe.io/app/matic: