### PR TITLE
Generate Icon list JSON in build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ _site
 .env
 node_modules
 .idea
+output
+.gradle
+model/bin
+model/build
+processor/bin
+processor/build

--- a/processor/src/main/kotlin/org/ethereum/lists/chains/Main.kt
+++ b/processor/src/main/kotlin/org/ethereum/lists/chains/Main.kt
@@ -22,6 +22,9 @@ val chainsPath = File(dataPath, "chains")
 private val allFiles = chainsPath.listFiles() ?: error("${chainsPath.absolutePath} must contain the chain json files - but it does not")
 private val allChainFiles = allFiles.filter { !it.isDirectory }
 
+private val allIconFilesList = iconsPath.listFiles() ?:  error("${iconsPath.absolutePath} must contain the icon json files - but it does not")
+private val allIconFiles = allIconFilesList.filter { !it.isDirectory }
+
 fun main(args: Array<String>) {
 
     doChecks(doRPCConnect = args.contains("rpcConnect"), doIconDownload = args.contains("iconDownload"))
@@ -33,6 +36,10 @@ private fun createOutputFiles() {
 
     val chainJSONArray = JsonArray<JsonObject>()
     val miniChainJSONArray = JsonArray<JsonObject>()
+
+    val chainIconJSONArray = JsonArray<JsonObject>()
+    val miniChainIconJSONArray = JsonArray<JsonObject>()
+    
     val shortNameMapping = JsonObject()
 
     // copy raw data so e.g. icons are available - SKIP errors
@@ -42,7 +49,6 @@ private fun createOutputFiles() {
         .sortedBy { (it["chainId"] as Number).toLong() }
         .forEach { jsonObject ->
             chainJSONArray.add(jsonObject)
-
 
             val miniJSON = JsonObject()
             listOf("name", "chainId", "shortName", "networkId", "nativeCurrency", "rpc", "faucets", "infoURL").forEach { field ->
@@ -55,12 +61,30 @@ private fun createOutputFiles() {
             shortNameMapping[jsonObject["shortName"] as String] = "eip155:" + jsonObject["chainId"]
 
         }
+    
+    allIconFiles
+        .forEach { iconLocation -> 
+
+            val jsonData = Klaxon().parseJsonArray(iconLocation.reader())
+            val iconName = iconLocation.toString().replace("../_data/icons/","").replace(".json","")
+
+            val iconJson = JsonObject()
+            iconJson["name"] = iconName
+            iconJson["icons"] = jsonData
+
+            chainIconJSONArray.add(iconJson)
+        }
+
+    File(buildPath, "chains.json").writeText(chainJSONArray.toJsonString())
 
     File(buildPath, "chains.json").writeText(chainJSONArray.toJsonString())
     File(buildPath, "chains_pretty.json").writeText(chainJSONArray.toJsonString(prettyPrint = true))
 
     File(buildPath, "chains_mini.json").writeText(miniChainJSONArray.toJsonString())
     File(buildPath, "chains_mini_pretty.json").writeText(miniChainJSONArray.toJsonString(prettyPrint = true))
+
+    File(buildPath, "chain_icons_mini.json").writeText(chainIconJSONArray.toJsonString())
+    File(buildPath, "chain_icons.json").writeText(chainIconJSONArray.toJsonString(prettyPrint = true))
 
     File(buildPath, "shortNameMapping.json").writeText(shortNameMapping.toJsonString(prettyPrint = true))
     File(buildPath, "index.html").writeText(


### PR DESCRIPTION
As of now, we can list the chains using the data from the build but there was no way to list all the icons. 

This PR generates `chain_icons.json` and `chain_icons_mini.json` at the build time so we can list down all the icons that were defined in `_data/chains/eip155*.json`
