### PR TITLE
Update currency name

### DIFF
--- a/_data/chains/eip155-16.json
+++ b/_data/chains/eip155-16.json
@@ -7,7 +7,7 @@
     "https://fauceth.komputing.org?chain=16&address=${ADDRESS}"
   ],
   "nativeCurrency": {
-    "name": "Coston Spark",
+    "name": "Coston Flare",
     "symbol": "CFLR",
     "decimals": 18
   },


### PR DESCRIPTION
The native asset has been renamed from Spark to Flare, this also applies to the test network Coston. Also see https://flare.xyz/update-for-exchanges/