### PR TITLE
Update URLs for WAGMI

### DIFF
--- a/_data/chains/eip155-11111.json
+++ b/_data/chains/eip155-11111.json
@@ -3,20 +3,20 @@
   "chain": "WAGMI",
   "icon": "wagmi",
   "rpc": ["https://subnets.avax.network/wagmi/wagmi-chain-testnet/rpc"],
-  "faucets": ["https://faucet.trywagmi.xyz"],
+  "faucets": ["https://faucet.avax.network/?subnet=wagmi"],
   "nativeCurrency": {
     "name": "WAGMI",
     "symbol": "WGM",
     "decimals": 18
   },
-  "infoURL": "https://trywagmi.xyz",
+  "infoURL": "https://subnets-test.avax.network/wagmi/details",
   "shortName": "WAGMI",
   "chainId": 11111,
   "networkId": 11111,
   "explorers": [
     {
-      "name": "WAGMI Explorer",
-      "url": "https://subnets.avax.network/wagmi/wagmi-chain-testnet/explorer",
+      "name": "Avalanche Subnet Explorer",
+      "url": "https://subnets-test.avax.network/wagmi",
       "standard": "EIP3091"
     }
   ]


### PR DESCRIPTION
This PR updates a few out of date URLs for the WAGMI network. If you check the URLs, you can see that all of the old URLs redirect to the new replacements.