### PR TITLE
add Filecoin networks.

### DIFF
--- a/_data/chains/eip155-314.json
+++ b/_data/chains/eip155-314.json
@@ -1,0 +1,34 @@
+{
+  "name": "Filecoin — Mainnet",
+  "chain": "FIL",
+  "status": "incubating",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "FIL",
+    "symbol": "FIL",
+    "decimals": 18
+  },
+  "infoURL": "https://filecoin.io",
+  "shortName": "filecoin",
+  "icon": "filecoin",
+  "chainId": 314,
+  "networkId": 314,
+  "explorers": [
+    {
+      "name": "Filfox",
+      "url": "https://filfox.info/en",
+      "standard": "none"
+    },
+    {
+      "name": "Filscan",
+      "url": "https://filscan.io/",
+      "standard": "none"
+    },
+    {
+      "name": "Filscout",
+      "url": "https://filscout.io/en/",
+      "standard": "none"
+    }
+  ]
+}

--- a/_data/chains/eip155-3141.json
+++ b/_data/chains/eip155-3141.json
@@ -1,0 +1,20 @@
+{
+  "name": "Filecoin — Buildernet",
+  "chain": "FIL",
+  "status": "incubating",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "FIL",
+    "symbol": "FIL",
+    "decimals": 18
+  },
+  "infoURL": "https://filecoin.io",
+  "shortName": "filecoin",
+  "icon": "filecoin",
+  "chainId": 3141,
+  "networkId": 3141,
+  "explorers": [
+    
+  ]
+}

--- a/_data/chains/eip155-31415.json
+++ b/_data/chains/eip155-31415.json
@@ -1,0 +1,24 @@
+{
+  "name": "Filecoin — Wallaby testnet",
+  "chain": "FIL",
+  "status": "incubating",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "tFIL",
+    "symbol": "tFIL",
+    "decimals": 18
+  },
+  "infoURL": "https://filecoin.io",
+  "shortName": "filecoin",
+  "icon": "filecoin",
+  "chainId": 31415,
+  "networkId": 31415,
+  "explorers": [
+    {
+      "name": "Filscan",
+      "url": "http://wallaby.filscan.io/",
+      "standard": "none"
+    }
+  ]
+}

--- a/_data/chains/eip155-314159.json
+++ b/_data/chains/eip155-314159.json
@@ -1,0 +1,29 @@
+{
+  "name": "Filecoin — Calibration testnet",
+  "chain": "FIL",
+  "status": "incubating",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "tFIL",
+    "symbol": "tFIL",
+    "decimals": 18
+  },
+  "infoURL": "https://filecoin.io",
+  "shortName": "filecoin",
+  "icon": "filecoin",
+  "chainId": 314159,
+  "networkId": 314159,
+  "explorers": [
+    {
+      "name": "Filscan",
+      "url": "https://calibration.filscan.io/",
+      "standard": "none"
+    },
+    {
+      "name": "Filscout",
+      "url": "https://calibration.filscout.com/en",
+      "standard": "none"
+    }
+  ]
+}

--- a/_data/chains/eip155-3141592.json
+++ b/_data/chains/eip155-3141592.json
@@ -1,0 +1,20 @@
+{
+  "name": "Filecoin — Butterfly testnet",
+  "chain": "FIL",
+  "status": "incubating",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "tFIL",
+    "symbol": "tFIL",
+    "decimals": 18
+  },
+  "infoURL": "https://filecoin.io",
+  "shortName": "filecoin",
+  "icon": "filecoin",
+  "chainId": 3141592,
+  "networkId": 3141592,
+  "explorers": [
+    
+  ]
+}

--- a/_data/chains/eip155-31415926.json
+++ b/_data/chains/eip155-31415926.json
@@ -1,0 +1,20 @@
+{
+  "name": "Filecoin — Local testnet",
+  "chain": "FIL",
+  "status": "incubating",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "tFIL",
+    "symbol": "tFIL",
+    "decimals": 18
+  },
+  "infoURL": "https://filecoin.io",
+  "shortName": "filecoin",
+  "icon": "filecoin",
+  "chainId": 31415926,
+  "networkId": 31415926,
+  "explorers": [
+    
+  ]
+}

--- a/_data/icons/filecoin.json
+++ b/_data/icons/filecoin.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmS9r9XQkMHVomWcSBNDkKkz9n87h9bH9ssabeiKZtANoU",
+    "width": 1000,
+    "height": 1000,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
The Filecoin team at Protocol Labs shipped the Filecoin Virtual Machine to mainnet in July 2022. Since then, we've been working on the first user-programmable execution runtime, called FEVM (Filecoin EVM). It will be fully compatible with Ethereum tooling. For this reason, we would like to allocate chain IDs for all Filecoin networks, including:

- Mainnet
- Buildernet
- Wallaby testnet (bleeding edge network)
- Butterfly testnet (early pre-release testing)
- Calibration testnet (mainnet-like conditions)
- Local devnets

[Full project roadmap here.](https://fvm.filecoin.io/)