### PR TITLE
fix: shardeum 1.3 is down and now replaced with shardeum 1.4

### DIFF
--- a/_data/chains/eip155-8080.json
+++ b/_data/chains/eip155-8080.json
@@ -1,5 +1,5 @@
 {
-  "name": "Shardeum Liberty 1.4",
+  "name": "Shardeum Liberty",
   "chain": "Shardeum",
   "rpc": ["https://liberty10.shardeum.org/"],
   "faucets": ["https://faucet.liberty10.shardeum.org"],

--- a/_data/chains/eip155-8080.json
+++ b/_data/chains/eip155-8080.json
@@ -1,5 +1,5 @@
 {
-  "name": "Shardeum Liberty 1.3",
+  "name": "Shardeum Liberty 1.4",
   "chain": "Shardeum",
   "rpc": ["https://liberty10.shardeum.org/"],
   "faucets": ["https://faucet.liberty10.shardeum.org"],


### PR DESCRIPTION
Shardeum 1.3 is down and shardeum 1.4 is now replaced on it with the same rpc, explorer urls and chainID.