### PR TITLE
Adding a icon to Qkacoin

### DIFF
--- a/_data/chains/eip155-2077.json
+++ b/_data/chains/eip155-2077.json
@@ -12,6 +12,7 @@
   "shortName": "QKA",
   "chainId": 2077,
   "networkId": 2077,
+  "icon": "qkacoin",
   "explorers": [
     {
       "name": "blockscout",

--- a/_data/icons/qkacoin.json
+++ b/_data/icons/qkacoin.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreiea5sbl37xxlmq4gxhdz36ohvpmnelug6gqobswnszwbz2gu3i7wi",
+    "width": 256,
+    "height": 256,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
the icon is pining at https://web3.storage
the ipfs linking is
[ipfs gateway for the icon of qkacoin.png](https://ipfs.io/ipfs/bafkreiea5sbl37xxlmq4gxhdz36ohvpmnelug6gqobswnszwbz2gu3i7wi )
please check out if everything is fine