### PR TITLE
change .ml TLD to .dev

### DIFF
--- a/_data/chains/eip155-75000.json
+++ b/_data/chains/eip155-75000.json
@@ -1,21 +1,21 @@
 {
   "name": "ResinCoin Mainnet",
   "chain": "RESIN",
-  "rpc": ["https://mainnet.resincoin.ml"],
+  "rpc": ["https://mainnet.resincoin.dev"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
     "symbol": "RESIN",
     "decimals": 18
   },
-  "infoURL": "https://resincoin.ml",
+  "infoURL": "https://resincoin.dev",
   "shortName": "resin",
   "chainId": 75000,
   "networkId": 75000,
   "explorers": [
     {
       "name": "ResinScan",
-      "url": "https://explorer.resincoin.ml",
+      "url": "https://explorer.resincoin.dev",
       "standard": "none"
     }
   ]


### PR DESCRIPTION
the old .ml is legacy and is not working already. i need to change it to dev