### PR TITLE
Update WAGMI subnet name as per Avalanche branding guidelines

### DIFF
--- a/_data/chains/eip155-11111.json
+++ b/_data/chains/eip155-11111.json
@@ -1,5 +1,5 @@
 {
-  "name": "WAGMI",
+  "name": "WAGMI Subnet Testnet",
   "chain": "WAGMI",
   "icon": "wagmi",
   "rpc": ["https://subnets.avax.network/wagmi/wagmi-chain-testnet/rpc"],


### PR DESCRIPTION
I'm with the Ava Labs team and submitting this PR to update WAGMI to match our branding guidelines.