### PR TITLE
Add Ethereum Proof of Work ( #1611 )

### DIFF
--- a/_data/chains/eip155-010001.json
+++ b/_data/chains/eip155-010001.json
@@ -1,0 +1,22 @@
+{
+  "name": "ETHW-mainnet",
+  "chain": "ETHW",
+  "rpc": ["https://mainnet.ethereumpow.org/"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "EthereumPoW",
+    "symbol": "ETHW",
+    "decimals": 18
+  },
+  "infoURL": "https://ethereumpow.org/",
+  "shortName": "ETHW",
+  "chainId": 10001,
+  "networkId": 10001,
+  "explorers": [
+    {
+      "name": "ETHWScan",
+      "url": "https://mainnet.ethwscan.com",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
ETHW url source : https://twitter.com/EthereumPoW/status/1570413723969552385

it looks like that Smart bitcoin cash testnet have the same chain id with ETHW so I add 0 in the name json