### PR TITLE
update bttc testnet

### DIFF
--- a/_data/chains/eip155-1028.json
+++ b/_data/chains/eip155-1028.json
@@ -1,21 +1,26 @@
 {
   "name": "BitTorrent Chain Testnet",
   "chain": "BTTC",
-  "rpc": ["https://testrpc.bittorrentchain.io/"],
-  "faucets": [],
+  "rpc": ["https://pre-rpc.bt.io/"],
+  "faucets": ["https://testfaucet.bt.io"],
   "nativeCurrency": {
     "name": "BitTorrent",
     "symbol": "BTT",
     "decimals": 18
   },
-  "infoURL": "https://bittorrentchain.io/",
+  "infoURL": "https://bt.io/",
   "shortName": "tbtt",
-  "chainId": 1028,
-  "networkId": 1028,
+  "chainId": 1029,
+  "networkId": 1029,
   "explorers": [
     {
-      "name": "testbttcscan",
-      "url": "https://testscan.bittorrentchain.io",
+      "name": "Bttc Scan Testnet",
+      "url": "https://testnet.bttcscan.com/",
+      "standard": "EIP3091"
+    },
+    {
+      "name": "Bttc Scan Donau Testnet",
+      "url": "https://testscan.bt.io/",
       "standard": "none"
     }
   ]


### PR DESCRIPTION
update bttc testnet chain info.includes:chainid,rpc url, faucets