### PR TITLE
Add basic entry for BTC

### DIFF
--- a/_data/chains/bip122-000000000019d6689c085ae165831e93.json
+++ b/_data/chains/bip122-000000000019d6689c085ae165831e93.json
@@ -1,0 +1,17 @@
+{
+    "name": "Bitcoin Mainnet",
+    "chain": "BTC",
+    "rpc": [],
+    "faucets": [],
+    "nativeCurrency": {
+        "name": "Bitcoin",
+        "symbol": "BTC",
+        "decimals": 8
+    },
+    "infoURL": "https://bitcoin.org",
+    "shortName": "btc",
+    "chainId": "000000000019d6689c085ae165831e93",
+    "networkId": "000000000019d6689c085ae165831e93",
+    "slip44": 0,
+    "explorers": []
+}


### PR DESCRIPTION
Add basic entry for BTC to verify how CI works for non-EIP155 CAIP-2 chains.