### PR TITLE
update canto rpc

### DIFF
--- a/_data/chains/eip155-7700.json
+++ b/_data/chains/eip155-7700.json
@@ -1,7 +1,7 @@
 {
   "name": "Canto",
   "chain": "Canto",
-  "rpc": ["https://canto.evm.chandrastation.com"],
+  "rpc": ["https://canto.slingshot.finance"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Canto",


### PR DESCRIPTION
Change CANTO (chainId 7700) RPC from `https://canto.evm.chandrastation.com` to `https://canto.slingshot.finance` as the previous one only contains a partial state of the chain.

This is causing downstream errors in sourcify smart contract verification


Block queries below done using cast from foundry (https://github.com/foundry-rs/foundry):

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/42722188/193944349-9f2dc3c6-9616-4c1e-b888-9bdad383c3cd.png">
