### PR TITLE
Revert "Add wagmi compatible chain listings (#1696)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ There are also aggregated json files with all chains automatically assembled:
  * [chainlist.in](https://www.chainlist.in)
  * [chainz.me](https://chainz.me)
  * [Chainlink docs](https://docs.chain.link/)
- * [Wagmi compatible chain configurations](https://spenhouet.com/chains)
 
 ### Other
  * [FaucETH](https://github.com/komputing/FaucETH)


### PR DESCRIPTION
This reverts commit 31b93d98adbe6310242b290e1e8fa034e5ce5077.