### PR TITLE
Add Milkomeda A1 configs

### DIFF
--- a/_data/chains/eip155-2002.json
+++ b/_data/chains/eip155-2002.json
@@ -9,7 +9,7 @@
   "faucets": [],
   "nativeCurrency": {
     "name": "milkALGO",
-    "symbol": "milkALGO",
+    "symbol": "mALGO",
     "decimals": 18
   },
   "infoURL": "https://milkomeda.com",

--- a/_data/chains/eip155-2002.json
+++ b/_data/chains/eip155-2002.json
@@ -1,0 +1,26 @@
+{
+  "name": "Milkomeda A1 Mainnet",
+  "chain": "milkALGO",
+  "icon": "milkomeda",
+  "rpc": [
+    "https://rpc-mainnet-algorand-rollup.a1.milkomeda.com",
+    "wss://rpc-mainnet-algorand-rollup.a1.milkomeda.com/ws"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "milkALGO",
+    "symbol": "milkALGO",
+    "decimals": 18
+  },
+  "infoURL": "https://milkomeda.com",
+  "shortName": "milkALGO",
+  "chainId": 2002,
+  "networkId": 2002,
+  "explorers": [
+    {
+      "name": "Blockscout",
+      "url": "https://explorer-mainnet-algorand-rollup.a1.milkomeda.com",
+      "standard": "none"
+    }
+  ]
+}


### PR DESCRIPTION
This adds the mainnet config for the Milkomeda A1 deployment (testnet configs were previously merged [here](https://github.com/ethereum-lists/chains/pull/1429))