### PR TITLE
Update rpc endpoint - Shiden (Evm) 

### DIFF
--- a/_data/chains/eip155-336.json
+++ b/_data/chains/eip155-336.json
@@ -2,8 +2,12 @@
   "name": "Shiden",
   "chain": "SDN",
   "rpc": [
+    "https://shiden.api.onfinality.io/public",
+    "https://shiden-rpc.dwellir.com",
     "https://shiden.public.blastapi.io",
-    "wss://shiden.api.onfinality.io/public-ws"
+    "wss://shiden.api.onfinality.io/public-ws",
+    "wss://shiden.public.blastapi.io",
+    "wss://shiden-rpc.dwellir.com"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-336.json
+++ b/_data/chains/eip155-336.json
@@ -2,7 +2,7 @@
   "name": "Shiden",
   "chain": "SDN",
   "rpc": [
-    "https://rpc.shiden.astar.network:8545",
+    "https://shiden.public.blastapi.io",
     "wss://shiden.api.onfinality.io/public-ws"
   ],
   "faucets": [],


### PR DESCRIPTION
Specified _https_ endpoint for Shiden network is not available and seems to be replaced. 

That PR reflects those changes, and update public RPC endpoints to correspond to those described on their web page (https://docs.astar.network/docs/quickstart/endpoints)