### PR TITLE
Add BOSagora mainnet eip155-2151

### DIFF
--- a/_data/chains/eip155-2151.json
+++ b/_data/chains/eip155-2151.json
@@ -1,0 +1,25 @@
+{
+  "name": "BOSagora Mainnet",
+  "chain": "ETH",
+  "network": "mainnet",
+  "rpc": ["https://mainnet.bosagora.org", "https://rpc.bosagora.org"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "BOSAGORA",
+    "symbol": "BOA",
+    "decimals": 18
+  },
+  "infoURL": "https://docs.bosagora.org",
+  "shortName": "boa",
+  "chainId": 2151,
+  "networkId": 2151,
+  "icon": "agora",
+  "explorers": [
+    {
+      "name": "BOASCAN",
+      "url": "https://boascan.io",
+      "icon": "agora",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-2151.json
+++ b/_data/chains/eip155-2151.json
@@ -1,7 +1,6 @@
 {
   "name": "BOSagora Mainnet",
   "chain": "ETH",
-  "network": "mainnet",
   "rpc": ["https://mainnet.bosagora.org", "https://rpc.bosagora.org"],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/icons/agora.json
+++ b/_data/icons/agora.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmW3CT4SHmso5dRJdsjR8GL1qmt79HkdAebCn2uNaWXFYh",
+    "width": 256,
+    "height": 257,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
We are public a new BOSagora mainnet in November.

Homepage: [https://bosagora.io](https://bosagora.io)
Blockexplorer : [https://boascan.io](https://boascan.io)
RPC: [https://mainnet.bosagora.org](https://mainnet.bosagora.org)
Docs: [https://docs.bosagora.org](https://docs.bosagora.org)

Could you please review it?