### PR TITLE
Add STEP (FITFI) Main and Test networks

### DIFF
--- a/_data/chains/eip155-1234.json
+++ b/_data/chains/eip155-1234.json
@@ -1,0 +1,30 @@
+{
+  "name": "Step Network",
+  "title": "Step Main Network",
+  "chain": "STEP",
+  "icon": "step",
+  "rpc": ["https://rpc.step.network"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "FITFI",
+    "symbol": "FITFI",
+    "decimals": 18
+  },
+  "infoURL": "https://step.network",
+  "shortName": "step",
+  "chainId": 1234,
+  "networkId": 1234,
+  "explorers": [
+    {
+      "name": "StepScan",
+      "url": "https://stepscan.io",
+      "icon": "step",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-43114",
+    "bridges": [{ "url": "https://bridge.step.network" }]
+  }
+}

--- a/_data/chains/eip155-12345.json
+++ b/_data/chains/eip155-12345.json
@@ -1,0 +1,29 @@
+{
+  "name": "Step Testnet",
+  "title": "Step Test Network",
+  "chain": "STEP",
+  "icon": "step",
+  "rpc": ["https://testnet.rpc.step.network"],
+  "faucets": ["https://faucet.step.network"],
+  "nativeCurrency": {
+    "name": "FITFI",
+    "symbol": "FITFI",
+    "decimals": 18
+  },
+  "infoURL": "https://step.network",
+  "shortName": "steptest",
+  "chainId": 12345,
+  "networkId": 12345,
+  "explorers": [
+    {
+      "name": "StepScan",
+      "url": "https://testnet.stepscan.io",
+      "icon": "step",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-43113"
+  }
+}

--- a/_data/icons/step.json
+++ b/_data/icons/step.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmVp9jyb3UFW71867yVtymmiRw7dPY4BTnsp3hEjr9tn8L",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Step Network is EVM chain is powered by Avalanche subnet technology. Based on the [Avalanche](https://avax.network/) node with step [subnet](https://docs.avax.network/subnets) support baked in.

- [X] Homepage: https://step.network/
- [X] Blockexplorer: https://stepscan.io/
- [X] RPC: https://rpc.step.network/
- [X] Docs: https://docs.step.network/
- [X] GitHub: https://github.com/step-app-fi
- [X] Bridge: https://bridge.step.network/

Could you please review it?
And thanks again for your amazing work guys.