### PR TITLE
Correct mis-allocation of 1337 from Ganache CLI to defunct network

### DIFF
--- a/_data/chains/eip155-1337.json
+++ b/_data/chains/eip155-1337.json
@@ -1,16 +1,21 @@
 {
-  "name": "CENNZnet old",
-  "chain": "CENNZnet",
-  "rpc": [],
-  "faucets": [],
-  "nativeCurrency": {
-    "name": "CPAY",
-    "symbol": "CPAY",
-    "decimals": 18
-  },
-  "infoURL": "https://cennz.net",
-  "shortName": "cennz-old",
-  "chainId": 1337,
-  "networkId": 1337,
-  "status": "deprecated"
+  {
+    "name": "Ganache",
+    "title": "Ganache CLI Ethereum Testnet",
+    "chain": "ETH",
+    "icon": "ganache",
+    "rpc": ["https://127.0.0.1:8545"],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "Ganache Test Ether",
+      "symbol": "ETH",
+      "decimals": 18
+    },
+    "infoURL": "https://trufflesuite.com/ganache/",
+    "shortName": "gcli",
+    "chainId": 1337,
+    "networkId": 1337,
+    "explorers": [
+    ]
+  }
 }

--- a/_data/icons/ganache.json
+++ b/_data/icons/ganache.json
@@ -1,0 +1,9 @@
+[
+    {
+        "url": "ipfs://Qmc9N7V8CiLB4r7FEcG7GojqfiGGsRCZqcFWCahwMohbDW",
+        "width": 267,
+        "height": 300,
+        "format": "png"
+    }
+]
+  


### PR DESCRIPTION
Another case of a network claiming a common development configuration raising all kinds of grief for ETH developers

Reverting 1337 to ganache CLI default