### PR TITLE
Fix STEP Test network RPC URI

### DIFF
--- a/_data/chains/eip155-12345.json
+++ b/_data/chains/eip155-12345.json
@@ -3,7 +3,7 @@
   "title": "Step Test Network",
   "chain": "STEP",
   "icon": "step",
-  "rpc": ["https://testnet.rpc.step.network"],
+  "rpc": ["https://rpc.testnet.step.network"],
   "faucets": ["https://faucet.step.network"],
   "nativeCurrency": {
     "name": "FITFI",


### PR DESCRIPTION
There was a typo in RPC URI. The correct RPC URI is `https://rpc.testnet.step.network`