### PR TITLE
Update darwinia chains rpc endpoint

### DIFF
--- a/_data/chains/eip155-45.json
+++ b/_data/chains/eip155-45.json
@@ -1,7 +1,7 @@
 {
   "name": "Darwinia Pangoro Testnet",
   "chain": "pangoro",
-  "rpc": ["http://pangoro-rpc.darwinia.network"],
+  "rpc": ["https://pangoro-rpc.darwinia.network"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Pangoro Network Native Token”",

--- a/_data/chains/eip155-46.json
+++ b/_data/chains/eip155-46.json
@@ -1,7 +1,7 @@
 {
   "name": "Darwinia Network",
   "chain": "darwinia",
-  "rpc": ["https://darwinia-rpc.darwinia.network"],
+  "rpc": ["https://rpc.darwinia.network"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Darwinia Network Native Token",


### PR DESCRIPTION
Some part of the RPC info has been out-of-date. This pr fix that.