### PR TITLE
Avalanche (43114): Add EIP1559 feature

### DIFF
--- a/_data/chains/eip155-43114.json
+++ b/_data/chains/eip155-43114.json
@@ -2,6 +2,7 @@
   "name": "Avalanche C-Chain",
   "chain": "AVAX",
   "rpc": ["https://api.avax.network/ext/bc/C/rpc"],
+  "features": [{ "name": "EIP1559" }],
   "faucets": ["https://free-online-app.com/faucet-for-eth-evm-chains/"],
   "nativeCurrency": {
     "name": "Avalanche",


### PR DESCRIPTION
I added the EIP1559 feature to the Avalanche chain, so that clients can correctly use type-2 transactions on Avalanche.

See also https://github.com/ethereum-lists/chains/issues/1901.