### PR TITLE
Camino and columbus networks

### DIFF
--- a/_data/chains/eip155-500.json
+++ b/_data/chains/eip155-500.json
@@ -12,6 +12,7 @@
   "shortName": "Camino",
   "chainId": 500,
   "networkId": 1000,
+  "icon": "camino",
   "explorers": [
     {
       "name": "caminoscan",

--- a/_data/chains/eip155-500.json
+++ b/_data/chains/eip155-500.json
@@ -16,8 +16,8 @@
   "explorers": [
     {
       "name": "blockexplorer",
-      "url": "https://explorer.camino.foundation",
-      "standard": "EIP3091"
+      "url": "https://explorer.camino.foundation/mainnet",
+      "standard": "none"
     }
   ]
 }

--- a/_data/chains/eip155-500.json
+++ b/_data/chains/eip155-500.json
@@ -1,0 +1,22 @@
+{
+  "name": "Camino C-Chain",
+  "chain": "CAM",
+  "rpc": ["https://mainnet.camino.foundation/ext/bc/C/rpc"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Camino",
+    "symbol": "CAM",
+    "decimals": 18
+  },
+  "infoURL": "https://camino.foundation/",
+  "shortName": "Camino",
+  "chainId": 500,
+  "networkId": 1000,
+  "explorers": [
+    {
+      "name": "caminoscan",
+      "url": "https://explorer.camino.foundation",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-500.json
+++ b/_data/chains/eip155-500.json
@@ -15,7 +15,7 @@
   "icon": "camino",
   "explorers": [
     {
-      "name": "caminoscan",
+      "name": "blockexplorer",
       "url": "https://explorer.camino.foundation",
       "standard": "EIP3091"
     }

--- a/_data/chains/eip155-501.json
+++ b/_data/chains/eip155-501.json
@@ -15,7 +15,7 @@
   "icon": "camino",
   "explorers": [
     {
-      "name": "columbusscan",
+      "name": "blockexplorer",
       "url": "https://explorer.camino.foundation/columbus",
       "standard": "EIP3091"
     }

--- a/_data/chains/eip155-501.json
+++ b/_data/chains/eip155-501.json
@@ -15,7 +15,7 @@
   "explorers": [
     {
       "name": "columbusscan",
-      "url": "https://explorer.camino.foundation",
+      "url": "https://explorer.camino.foundation/columbus",
       "standard": "EIP3091"
     }
   ]

--- a/_data/chains/eip155-501.json
+++ b/_data/chains/eip155-501.json
@@ -12,6 +12,7 @@
   "shortName": "Columbus",
   "chainId": 501,
   "networkId": 1001,
+  "icon": "camino",
   "explorers": [
     {
       "name": "columbusscan",

--- a/_data/chains/eip155-501.json
+++ b/_data/chains/eip155-501.json
@@ -10,7 +10,7 @@
   },
   "infoURL": "https://camino.foundation/",
   "shortName": "Columbus",
-  "chainId": 502,
+  "chainId": 501,
   "networkId": 1001,
   "explorers": [
     {

--- a/_data/chains/eip155-501.json
+++ b/_data/chains/eip155-501.json
@@ -16,8 +16,8 @@
   "explorers": [
     {
       "name": "blockexplorer",
-      "url": "https://explorer.camino.foundation/columbus",
-      "standard": "EIP3091"
+      "url": "https://explorer.camino.foundation",
+      "standard": "none"
     }
   ]
 }

--- a/_data/chains/eip155-502.json
+++ b/_data/chains/eip155-502.json
@@ -1,0 +1,22 @@
+{
+  "name": "Columbus Test Network",
+  "chain": "CAM",
+  "rpc": ["https://columbus.camino.foundation/ext/bc/C/rpc"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Camino",
+    "symbol": "CAM",
+    "decimals": 18
+  },
+  "infoURL": "https://camino.foundation/",
+  "shortName": "Columbus",
+  "chainId": 502,
+  "networkId": 1001,
+  "explorers": [
+    {
+      "name": "columbusscan",
+      "url": "https://explorer.camino.foundation",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/icons/camino.json
+++ b/_data/icons/camino.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmSEoUonisawfCvT3osysuZzbqUEHugtgNraePKWL8PKYa",
+    "width": 768,
+    "height": 768,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
This PR adds both Camino (chainId 500, networkId 1000) and Columbus  (chainId 501, networkId 1001) networks. It also adds Camino logo.