### PR TITLE
Update 71401 (Godwoken Testnet v1)

### DIFF
--- a/_data/chains/eip155-71401.json
+++ b/_data/chains/eip155-71401.json
@@ -1,7 +1,10 @@
 {
-  "name": "Godwoken Testnet (V1.1)",
+  "name": "Godwoken Testnet v1",
   "chain": "GWT",
-  "rpc": ["https://godwoken-testnet-v1.ckbapp.dev"],
+  "rpc": [
+    "https://godwoken-testnet-v1.ckbapp.dev",
+    "https://v1.testnet.godwoken.io/rpc"
+  ],
   "faucets": ["https://testnet.bridge.godwoken.io"],
   "nativeCurrency": {
     "name": "pCKB",


### PR DESCRIPTION
As the Godwoken Testnet continues to evolve, we like to update a few info in the `eip155-71401.json` file:
1. Update the name of the chain to "Godwoken Testnet v1"
2. Add a new RPC URL "https://v1.testnet.godwoken.io/rpc"

To cross-check the new RPC URL and the name of the chain, please visit: 
- [README.md - godwoken-info](https://github.com/godwokenrises/godwoken-info/tree/main/testnet_v1_1#godwoken-web3-rpc)
- [Godwoken Public Networks - Godwoken Docs](https://docs.godwoken.io/connectionInfo#godwoken-testnet-v1)