### PR TITLE
feat: add sps mainnet, chainId 13000

### DIFF
--- a/_data/chains/eip155-13000.json
+++ b/_data/chains/eip155-13000.json
@@ -1,7 +1,7 @@
 {
   "name": "SPS",
   "chain": "SPS",
-  "rpc": ["https://marketplace.ssquad.games"],
+  "rpc": ["https://rpc.ssquad.games"],
   "faucets": [],
   "nativeCurrency": {
     "name": "ECG",
@@ -18,6 +18,5 @@
       "url": "http://spsscan.ssquad.games",
       "standard": "EIP3091"
     }
-  ],
-  "status": "incubating"
+  ]
 }


### PR DESCRIPTION
Hi team

The sps mainnet's rpc is migrated into following URI after incubation.

https://rpc.ssquad.games

Thanks
