### PR TITLE
Shardeum chainId 8080 and 8081 generic version numbers

### DIFF
--- a/_data/chains/eip155-8080.json
+++ b/_data/chains/eip155-8080.json
@@ -1,5 +1,5 @@
 {
-  "name": "Shardeum Liberty 1.6",
+  "name": "Shardeum Liberty 1.X",
   "chain": "Shardeum",
   "rpc": ["https://liberty10.shardeum.org/"],
   "faucets": ["https://faucet.liberty10.shardeum.org"],

--- a/_data/chains/eip155-8081.json
+++ b/_data/chains/eip155-8081.json
@@ -1,5 +1,5 @@
 {
-  "name": "Shardeum Liberty 2.0",
+  "name": "Shardeum Liberty 2.X",
   "chain": "Shardeum",
   "rpc": [],
   "faucets": ["https://faucet.liberty20.shardeum.org"],


### PR DESCRIPTION
Liberty 2.0 is moving to Liberty 2.1.

This PR will make Liberty versions:

    1.6 => 1.X
    2.0 => 2.X

to avoid new PRs for Liberty version changes as requested here: 
https://github.com/ethereum-lists/chains/pull/1857#pullrequestreview-1179751038