### PR TITLE
rpc url for chainId 8081

### DIFF
--- a/_data/chains/eip155-8081.json
+++ b/_data/chains/eip155-8081.json
@@ -1,7 +1,7 @@
 {
   "name": "Shardeum Liberty 2.X",
   "chain": "Shardeum",
-  "rpc": [],
+  "rpc": ["https://liberty20.shardeum.org/"],
   "faucets": ["https://faucet.liberty20.shardeum.org"],
   "nativeCurrency": {
     "name": "Shardeum SHM",


### PR DESCRIPTION
Adding RPC for chainId 8081 removed from:

https://github.com/ethereum-lists/chains/commit/87417e5e6de7a3e8ea76570e7c097f2b498e5850
