### PR TITLE
Tell jitpack to use openjdk 11

### DIFF
--- a/.jitpack.yml
+++ b/.jitpack.yml
@@ -1,0 +1,1 @@
+jdk: openjdk11


### PR DESCRIPTION
Otherwise klaxon 5.6 cannot be resolved