### PR TITLE
Change BKC Testnet Shortname

### DIFF
--- a/_data/chains/eip155-25925.json
+++ b/_data/chains/eip155-25925.json
@@ -13,12 +13,12 @@
     "decimals": 18
   },
   "infoURL": "https://www.bitkubchain.com/",
-  "shortName": "bkc",
+  "shortName": "bkct",
   "chainId": 25925,
   "networkId": 25925,
   "explorers": [
     {
-      "name": "bkcscan",
+      "name": "bkcscan-testnet",
       "url": "https://testnet.bkcscan.com",
       "standard": "none",
       "icon": "bkc"

--- a/_data/chains/eip155-25925.json
+++ b/_data/chains/eip155-25925.json
@@ -9,7 +9,7 @@
   "faucets": ["https://faucet.bitkubchain.com"],
   "nativeCurrency": {
     "name": "Bitkub Coin",
-    "symbol": "TKUB",
+    "symbol": "tKUB",
     "decimals": 18
   },
   "infoURL": "https://www.bitkubchain.com/",


### PR DESCRIPTION
- change it, because it's conflict with the Mainnet one
  - BKC Testnet shortName will use "bkct" instead