### PR TITLE
chainId fix for Boba BNB Mainnet

### DIFF
--- a/_data/chains/eip155-56288.json
+++ b/_data/chains/eip155-56288.json
@@ -1,7 +1,12 @@
 {
   "name": "Boba BNB Mainnet",
   "chain": "Boba BNB Mainnet",
-  "rpc": [],
+  "rpc": [
+    "https://bnb.boba.network",
+    "wss://wss.bnb.boba.network",
+    "https://replica.bnb.boba.network",
+    "wss://replica-wss.bnb.boba.network"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Boba Token",
@@ -10,8 +15,8 @@
   },
   "infoURL": "https://boba.network",
   "shortName": "BobaBnb",
-  "chainId": 97288,
-  "networkId": 97288,
+  "chainId": 56288,
+  "networkId": 56288,
   "explorers": [
     {
       "name": "Boba BNB block explorer",

--- a/_data/chains/eip155-97288.json
+++ b/_data/chains/eip155-97288.json
@@ -1,0 +1,23 @@
+{
+  "name": "Boba BNB Mainnet",
+  "chain": "Boba BNB Mainnet",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Boba Token",
+    "symbol": "BOBA",
+    "decimals": 18
+  },
+  "infoURL": "https://boba.network",
+  "shortName": "BobaBnb",
+  "chainId": 97288,
+  "networkId": 97288,
+  "explorers": [
+    {
+      "name": "Boba BNB block explorer",
+      "url": "https://blockexplorer.bnb.boba.network",
+      "standard": "none"
+    }
+  ],
+  "status": "deprecated"
+}

--- a/_data/chains/eip155-97288.json
+++ b/_data/chains/eip155-97288.json
@@ -1,5 +1,5 @@
 {
-  "name": "Boba BNB Mainnet",
+  "name": "Boba BNB Mainnet Old",
   "chain": "Boba BNB Mainnet",
   "rpc": [],
   "faucets": [],

--- a/_data/chains/eip155-97288.json
+++ b/_data/chains/eip155-97288.json
@@ -9,7 +9,7 @@
     "decimals": 18
   },
   "infoURL": "https://boba.network",
-  "shortName": "BobaBnb",
+  "shortName": "BobaBnbOld",
   "chainId": 97288,
   "networkId": 97288,
   "explorers": [


### PR DESCRIPTION
eth_chainId is 0xdbe0 56288 for Boba BNB Mainnet