### PR TITLE
Updating Filecoin RPC endpoint versions and direct faucet URLs

### DIFF
--- a/_data/chains/eip155-3141.json
+++ b/_data/chains/eip155-3141.json
@@ -2,8 +2,9 @@
   "name": "Filecoin - Hyperspace testnet",
   "chain": "FIL",
   "icon": "filecoin",
-  "rpc": ["https://api.hyperspace.node.glif.io/rpc/v0"],
-  "faucets": ["https://hyperspace.filtest.network/#faucet"],
+  "rpc": ["https://api.hyperspace.node.glif.io/rpc/v1",
+    "https://filecoin-hyperspace.chainstacklabs.com/rpc/v1"],
+  "faucets": ["https://hyperspace.yoga/#faucet"],
   "nativeCurrency": {
     "name": "testnet filecoin",
     "symbol": "tFIL",

--- a/_data/chains/eip155-3141.json
+++ b/_data/chains/eip155-3141.json
@@ -2,8 +2,10 @@
   "name": "Filecoin - Hyperspace testnet",
   "chain": "FIL",
   "icon": "filecoin",
-  "rpc": ["https://api.hyperspace.node.glif.io/rpc/v1",
-    "https://filecoin-hyperspace.chainstacklabs.com/rpc/v1"],
+  "rpc": [
+    "https://api.hyperspace.node.glif.io/rpc/v1",
+    "https://filecoin-hyperspace.chainstacklabs.com/rpc/v1"
+  ],
   "faucets": ["https://hyperspace.yoga/#faucet"],
   "nativeCurrency": {
     "name": "testnet filecoin",

--- a/_data/chains/eip155-31415.json
+++ b/_data/chains/eip155-31415.json
@@ -2,8 +2,8 @@
   "name": "Filecoin - Wallaby testnet",
   "chain": "FIL",
   "icon": "filecoin",
-  "rpc": ["https://wallaby.node.glif.io/rpc/v0"],
-  "faucets": ["https://wallaby.network/#faucet"],
+  "rpc": ["https://wallaby.node.glif.io/rpc/v1"],
+  "faucets": ["https://wallaby.yoga/#faucet"],
   "nativeCurrency": {
     "name": "testnet filecoin",
     "symbol": "tFIL",

--- a/_data/chains/eip155-314159.json
+++ b/_data/chains/eip155-314159.json
@@ -2,7 +2,7 @@
   "name": "Filecoin - Calibration testnet",
   "chain": "FIL",
   "icon": "filecoin",
-  "rpc": ["https://api.calibration.node.glif.io/rpc/v0"],
+  "rpc": ["https://api.calibration.node.glif.io/rpc/v1"],
   "faucets": ["https://faucet.calibration.fildev.network/"],
   "nativeCurrency": {
     "name": "testnet filecoin",


### PR DESCRIPTION
EVM JSON RPC is only supported by the v1 Filecoin RPC, so we need to update the endpoint versions from v0

Also revising with direct links to faucet pages