### PR TITLE
Change sepolia's ether symbol

### DIFF
--- a/_data/chains/eip155-11155111.json
+++ b/_data/chains/eip155-11155111.json
@@ -6,7 +6,7 @@
   "faucets": ["http://fauceth.komputing.org?chain=11155111&address=${ADDRESS}"],
   "nativeCurrency": {
     "name": "Sepolia Ether",
-    "symbol": "SEP",
+    "symbol": "ETH",
     "decimals": 18
   },
   "infoURL": "https://sepolia.otterscan.io",


### PR DESCRIPTION
Makes it more consistent with the other testnets, such as goerli, which have ETH as symbol