### PR TITLE
Fix The Bifrost Testnet Shortname

### DIFF
--- a/_data/chains/eip155-49088.json
+++ b/_data/chains/eip155-49088.json
@@ -13,7 +13,7 @@
     "decimals": 18
   },
   "infoURL": "https://thebifrost.io",
-  "shortName": "bfc",
+  "shortName": "tbfc",
   "chainId": 49088,
   "networkId": 49088,
   "icon": "bifrost",


### PR DESCRIPTION
Since this is a testnet, we add `t` to the shortname.