### PR TITLE
Add eip155-96.json (Bitkub chain)

### DIFF
--- a/_data/chains/eip155-96.json
+++ b/_data/chains/eip155-96.json
@@ -1,0 +1,26 @@
+{
+  "name": "Bitkub Chain",
+  "chain": "BKC",
+  "icon": "bkc",
+  "rpc": [
+    "https://rpc.bitkubchain.io",
+    "wss://wss.bitkubchain.io"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "KUB",
+    "symbol": "KUB",
+    "decimals": 18
+  },
+  "infoURL": "https://www.bitkubchain.com/",
+  "shortName": "BKC",
+  "chainId": 96,
+  "networkId": 96,
+  "explorers": [
+    {
+      "name": "bkcscan",
+      "url": "https://www.bkcscan.com",
+      "standard": "none"
+    }
+  ]
+}


### PR DESCRIPTION
I have added "Bitkub chain" to the list. Please consider adding it to the mainstream.

Bitkub chain is an EVM-compatible chain operated by the biggest crypto currency exchange platform in Thailand. It has potential to grow blockchain adoption in South East Asia.

Getting listed on Chainlist.org dramatically helps in user adoption.