### PR TITLE
Update oho.json

### DIFF
--- a/_data/icons/oho.json
+++ b/_data/icons/oho.json
@@ -1,8 +1,8 @@
 [
   {
-    "url": "ipfs://QmZt75xixnEtFzqHTrJa8kJkV4cTXmUZqeMeHM8BcvomQc",
-    "width": 512,
-    "height": 512,
-    "format": "png"
+    "url": "ipfs://Qmdwo3McZTNMB21V19fpA11Uq8RMa9iAPSGjnC1JbdNXoJ",
+    "width": 32,
+    "height": 32,
+    "format": "svg"
   }
 ]


### PR DESCRIPTION
Logo doesn't show on chainlist.org, so try changing to SVG format.