### PR TITLE
Update ohoscan.json

### DIFF
--- a/_data/icons/ohoscan.json
+++ b/_data/icons/ohoscan.json
@@ -1,8 +1,8 @@
 [
   {
-    "url": "ipfs://QmZt75xixnEtFzqHTrJa8kJkV4cTXmUZqeMeHM8BcvomQc",
-    "width": 512,
-    "height": 512,
-    "format": "png"
+    "url": "ipfs://QmVKeZScb5YC3yEZp3FJYP1GLK9U9tdgqv1u1CRTyq6bhJ",
+    "width": 24,
+    "height": 24,
+    "format": "svg"
   }
 ]


### PR DESCRIPTION
Logo doesn't show on chainlist.org, so try changing to SVG format.