### PR TITLE
Filecoin updates - new mainnet RPC, Filmine rebrand, Calibration testnet explorer update

### DIFF
--- a/_data/chains/eip155-314.json
+++ b/_data/chains/eip155-314.json
@@ -35,7 +35,7 @@
     },
     {
       "name": "Dev.storage",
-      "url": "https://dev.storage/",
+      "url": "https://dev.storage",
       "standard": "none"
     },
     {

--- a/_data/chains/eip155-314.json
+++ b/_data/chains/eip155-314.json
@@ -2,7 +2,10 @@
   "name": "Filecoin - Mainnet",
   "chain": "FIL",
   "icon": "filecoin",
-  "rpc": ["https://api.node.glif.io/", "https://rpc.ankr.com/filecoin"],
+  "rpc": [
+    "https://api.node.glif.io/",
+    "https://rpc.ankr.com/filecoin, https://filecoin-mainnet.chainstacklabs.com/rpc/v1"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "filecoin",
@@ -31,8 +34,8 @@
       "standard": "EIP3091"
     },
     {
-      "name": "Filmine",
-      "url": "https://explorer.filmine.io",
+      "name": "Dev.storage",
+      "url": "https://dev.storage/",
       "standard": "none"
     },
     {

--- a/_data/chains/eip155-3141.json
+++ b/_data/chains/eip155-3141.json
@@ -36,7 +36,7 @@
     },
     {
       "name": "Dev.storage",
-      "url": "https://dev.storage/",
+      "url": "https://dev.storage",
       "standard": "none"
     },
     {

--- a/_data/chains/eip155-3141.json
+++ b/_data/chains/eip155-3141.json
@@ -35,8 +35,8 @@
       "standard": "none"
     },
     {
-      "name": "Filmine",
-      "url": "https://explorer.filmine.io",
+      "name": "Dev.storage",
+      "url": "https://dev.storage/",
       "standard": "none"
     },
     {

--- a/_data/chains/eip155-314159.json
+++ b/_data/chains/eip155-314159.json
@@ -24,6 +24,11 @@
       "name": "Filscout - Calibration",
       "url": "https://calibration.filscout.com/en",
       "standard": "none"
+    },
+    {
+      "name": "Filfox - Calibration",
+      "url": "https://calibration.filfox.info",
+      "standard": "none"
     }
   ]
 }


### PR DESCRIPTION
Changes:
- new Chainstack mainnet RPC added
- Filmine is rebranding to Dev.storage with new URL
- Filfox Calibration testnet explorer added at end of list per request of `ethereum-lists/chains` maintainers

https://github.com/ethereum-lists/chains/pull/2347 can also be closed in favor of this update.