### PR TITLE
Update Polygon zkEVM testnet (1442)

### DIFF
--- a/_data/chains/eip155-1422.json
+++ b/_data/chains/eip155-1422.json
@@ -2,7 +2,7 @@
   "name": "Polygon zkEVM Testnet Pre Audit-Upgraded",
   "title": "Polygon zkEVM Testnet Pre Audit-Upgraded",
   "chain": "Polygon",
-  "rpc": ["https://rpc.public.zkevm-test.net"],
+  "rpc": [],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",

--- a/_data/chains/eip155-1442.json
+++ b/_data/chains/eip155-1442.json
@@ -1,6 +1,6 @@
 {
-  "name": "Polygon zkEVM Testnet Pre Audit-Upgraded",
-  "title": "Polygon zkEVM Testnet Pre Audit-Upgraded",
+  "name": "Polygon zkEVM Testnet",
+  "title": "Polygon zkEVM Testnet",
   "chain": "Polygon",
   "rpc": ["https://rpc.public.zkevm-test.net"],
   "faucets": [],
@@ -10,15 +10,14 @@
     "decimals": 18
   },
   "infoURL": "https://polygon.technology/solutions/polygon-zkevm/",
-  "shortName": "testnet-zkEVM-mango-pre-audit-upgraded",
-  "chainId": 1422,
-  "networkId": 1422,
+  "shortName": "testnet-zkEVM-mango",
+  "chainId": 1442,
+  "networkId": 1442,
   "explorers": [
     {
       "name": "Polygon zkEVM explorer",
       "url": "https://explorer.public.zkevm-test.net",
       "standard": "EIP3091"
     }
-  ],
-  "status": "deprecated"
+  ]
 }


### PR DESCRIPTION
Updates Polygon zkEVM Testnet according to [official docs](https://wiki.polygon.technology/docs/zkEVM/develop):

- Chain ID: 1442

Deprecated `1422` and added `1442`