### PR TITLE
Add a slightly better linter check

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -88,3 +88,37 @@ jobs:
           fi
         done
         exit $BAD
+
+  validate_formatting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - uses: nrwl/nx-set-shas@v3
+      id: last_successful_commit_push
+      with:
+        main-branch-name: master
+        workflow-id: 'pr_checks.yml'
+
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v35
+      with:
+        files: _data/*/*.json
+        base_sha: ${{ steps.last_successful_commit_push.outputs.base }}
+
+    - run: sudo npm i -g prettier
+
+    - name: Verify the changed icons
+      if: steps.changed-files.outputs.any_changed == 'true'
+      run: |
+        set -euo pipefail
+
+        BAD=0
+
+        for CHANGED_FILE in ${{ steps.changed-files.outputs.all_changed_files }}; do
+          echo "Checking $CHANGED_FILE"
+          diff -u "$CHANGED_FILE" <(prettier "$CHANGED_FILE")
+        done

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -24,15 +24,6 @@ jobs:
         files: _data/icons/*.json
         base_sha: ${{ steps.last_successful_commit_push.outputs.base }}
 
-    - name: Configure npm Caching
-      uses: actions/cache@v2
-      if: steps.changed-icons.outputs.any_changed == 'true'
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-npm-${{ hashFiles('**/workflows/validate_json.yml') }}
-        restore-keys: |
-          ${{ runner.os }}-npm-
-
     - run: sudo apt-get -y install jq curl exiftool
 
     - name: Verify the changed icons

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -2,7 +2,6 @@ name: Run prettier
 
 on:
   push:
-  pull_request:
 
 jobs:
   prettier:


### PR DESCRIPTION
Reports the diff with changes instead of asking the user to run the tool: [example failure](https://github.com/farcaller/chains/actions/runs/4456330928/jobs/7826703319?pr=3).

It will also run on only the changed files since the previous check run.

Updated the original check to run only on the commits to master.