### PR TITLE
Prefer cached icon copies over ipfs

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -23,6 +23,13 @@ jobs:
       with:
         files: _data/icons/*.json
         base_sha: ${{ steps.last_successful_commit_push.outputs.base }}
+    
+    - name: Get changed icon blobs
+      id: changed-icon-blobs
+      uses: tj-actions/changed-files@v35
+      with:
+        files: _data/iconsDownload/*
+        base_sha: ${{ steps.last_successful_commit_push.outputs.base }}
 
     - run: sudo apt-get -y install jq curl exiftool
 
@@ -33,13 +40,23 @@ jobs:
 
         BAD=0
 
+        CHANGED_ICON_BLOBS=(${{ steps.changed-icon-blobs.outputs.all_changed_files }})
+
         for CHANGED_FILE in ${{ steps.changed-icons.outputs.all_changed_files }}; do
           echo "Checking icon $CHANGED_FILE"
           URL=$(cat "$CHANGED_FILE" | jq '.[0].url' -r)
           if [[ "$URL" =~ ^ipfs://([A-Za-z0-9]+)$ ]]; then
-            echo "Trying to download the image..."
-            curl -Lo icon "https://cloudflare-ipfs.com/ipfs/${BASH_REMATCH[1]}" 2>/dev/null
-            METADATA=$(exiftool icon -json)
+            IPFS_HASH=${BASH_REMATCH[1]}
+
+            if [[ "${CHANGED_ICON_BLOBS[*]} " =~ "_data/iconsDownload/$IPFS_HASH " ]]; then
+              TARGET_FILE="_data/iconsDownload/$IPFS_HASH"
+            else
+              echo "Trying to download the image..."
+              TARGET_FILE=icon
+              curl -Lo icon "https://cloudflare-ipfs.com/ipfs/$IPFS_HASH" 2>/dev/null
+            fi
+
+            METADATA=$(exiftool $TARGET_FILE -json)
             
             SCHEMA_WIDTH=$(cat "$CHANGED_FILE" | jq '.[0].width' -r)
             SCHEMA_HEIGHT=$(cat "$CHANGED_FILE" | jq '.[0].height' -r)


### PR DESCRIPTION
This will prefer the cached copies of the icons if they are present in the PR. The remaining checks (dimensions and format) will still run.

Demo PR failure: https://github.com/farcaller/chains/actions/runs/4478054036/jobs/7870343997?pr=4

PS: I really need to rewrite this in js at this point. The amount of shell lines is getting a wee uncomfortable for human consumption 😄 