### PR TITLE
fix canto testnet explorer url (http -> https)

### DIFF
--- a/_data/chains/eip155-740.json
+++ b/_data/chains/eip155-740.json
@@ -15,7 +15,7 @@
   "explorers": [
     {
       "name": "Canto Tesnet Explorer (Neobase)",
-      "url": "http://testnet-explorer.canto.neobase.one",
+      "url": "https://testnet-explorer.canto.neobase.one",
       "standard": "none"
     }
   ]


### PR DESCRIPTION
it *is* https: https://testnet-explorer.canto.neobase.one

not having the `https` does not let users add this network to their metamask (for example)