### PR TITLE
Added Chiliz Chain 2.0 Mainnet

### DIFF
--- a/_data/chains/eip155-88888.json
+++ b/_data/chains/eip155-88888.json
@@ -1,22 +1,22 @@
 {
-  "name": "IVAR Chain Mainnet",
-  "chain": "IVAR",
-  "icon": "ivar",
-  "rpc": ["https://mainnet-rpc.ivarex.com"],
-  "faucets": ["https://faucet.ivarex.com/"],
+  "name": "Chiliz Chain 2.0 Mainnet",
+  "chain": "CC2",
+  "icon": "cc2",
+  "rpc": ["https://rpc.chiliz.com"],
+  "faucets": [],
   "nativeCurrency": {
-    "name": "Ivar",
-    "symbol": "IVAR",
+    "name": "Chiliz",
+    "symbol": "CHZ",
     "decimals": 18
   },
-  "infoURL": "https://ivarex.com",
-  "shortName": "ivar",
+  "infoURL": "https://chiliz.com/chiliz-chain-2-0/",
+  "shortName": "cc2",
   "chainId": 88888,
   "networkId": 88888,
   "explorers": [
     {
-      "name": "ivarscan",
-      "url": "https://ivarscan.com",
+      "name": "cc2scan",
+      "url": "https://scan.chiliz.com",
       "standard": "EIP3091"
     }
   ]

--- a/_data/icons/cc2.json
+++ b/_data/icons/cc2.json
@@ -1,0 +1,9 @@
+[
+    {
+      "url": "ipfs://QmTGYofJ8VLkeNY4J69AvXi8e126kmbHmf34wLFoJ1FKAK",
+      "width": 400,
+      "height": 400,
+      "format": "png"
+    }
+  ]
+  


### PR DESCRIPTION
Hello, I know I'm trying to replace an existing chain but it looks like IVAR chain is deprecated. 
We tried to contact them but no response. 
I am representing Chiliz here, we are a very reputable company, we have millions of users and we already launched our mainnet (not public yet) with that chain ID.

Can we do something about this ? 
thanks a lot in advance ! 