### PR TITLE
Update Columbus and Camino rpc and infoURL

### DIFF
--- a/_data/chains/eip155-500.json
+++ b/_data/chains/eip155-500.json
@@ -8,7 +8,7 @@
     "symbol": "CAM",
     "decimals": 18
   },
-  "infoURL": "https://camino.foundation/",
+  "infoURL": "https://camino.network/",
   "shortName": "Camino",
   "chainId": 500,
   "networkId": 1000,

--- a/_data/chains/eip155-501.json
+++ b/_data/chains/eip155-501.json
@@ -1,14 +1,14 @@
 {
   "name": "Columbus Test Network",
   "chain": "CAM",
-  "rpc": [],
+  "rpc": ["https://columbus.camino.network/ext/bc/C/rpc"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Camino",
     "symbol": "CAM",
     "decimals": 18
   },
-  "infoURL": "https://camino.foundation/",
+  "infoURL": "https://camino.network/",
   "shortName": "Columbus",
   "chainId": 501,
   "networkId": 1001,


### PR DESCRIPTION
Updates Columbus rpc to the correct one and changes infoURL for both Camino and Columbus networks.