### PR TITLE
Shardeum Explorer EIP-3091 standard support now

### DIFF
--- a/_data/chains/eip155-8080.json
+++ b/_data/chains/eip155-8080.json
@@ -17,7 +17,7 @@
     {
       "name": "Shardeum Scan",
       "url": "https://explorer-liberty10.shardeum.org",
-      "standard": "none"
+      "standard": "EIP3091"
     }
   ],
   "redFlags": ["reusedChainId"]

--- a/_data/chains/eip155-8081.json
+++ b/_data/chains/eip155-8081.json
@@ -17,7 +17,7 @@
     {
       "name": "Shardeum Scan",
       "url": "https://explorer-liberty20.shardeum.org",
-      "standard": "none"
+      "standard": "EIP3091"
     }
   ],
   "redFlags": ["reusedChainId"]

--- a/_data/chains/eip155-8082.json
+++ b/_data/chains/eip155-8082.json
@@ -17,7 +17,7 @@
     {
       "name": "Shardeum Scan",
       "url": "https://explorer-sphinx.shardeum.org",
-      "standard": "none"
+      "standard": "EIP3091"
     }
   ],
   "redFlags": ["reusedChainId"]


### PR DESCRIPTION
Shardeum Explorer follows EIP-3091 URL routing now:

https://github.com/Shardeum/shardeum-bug-reporting/issues/40