### PR TITLE
Add Markr Go Network

### DIFF
--- a/_data/chains/eip155-431140.json
+++ b/_data/chains/eip155-431140.json
@@ -1,0 +1,19 @@
+{
+  "name": "Markr Go",
+  "chain": "Unified",
+  "icon": "markrgo",
+  "rpc": [
+    "https://rpc.markr.io/ext/"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Avalanche",
+    "symbol": "AVAX",
+    "decimals": 18
+  },
+  "infoURL": "https://www.markr.io/",
+  "shortName": "markr-go",
+  "chainId": 431140,
+  "networkId": 431140,
+  "explorers": []
+}

--- a/_data/chains/eip155-431140.json
+++ b/_data/chains/eip155-431140.json
@@ -2,9 +2,7 @@
   "name": "Markr Go",
   "chain": "Unified",
   "icon": "markrgo",
-  "rpc": [
-    "https://rpc.markr.io/ext/"
-  ],
+  "rpc": ["https://rpc.markr.io/ext/"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Avalanche",
@@ -15,5 +13,6 @@
   "shortName": "markr-go",
   "chainId": 431140,
   "networkId": 431140,
-  "explorers": []
+  "explorers": [],
+  "status": "incubating"
 }

--- a/_data/icons/markrgo.json
+++ b/_data/icons/markrgo.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmVMBTZVPawyLBD2B5VbG68dfWLfZ1CnB8V59xduBe2kwh",
+    "width": 84,
+    "height": 84,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Hey,

Markr Go functions as a network abstraction platform that provides users with a seamless web3 experience, although it is not a blockchain in itself. 

As we described, our native currency currently is AVAX but subject to change.

Please note that: It's a launch preperation before we go live. When it's successfully merged, we are going to push the product.

Regards,
