### PR TITLE
Add IRISHub Testnet

### DIFF
--- a/_data/chains/eip155-16688.json
+++ b/_data/chains/eip155-16688.json
@@ -1,9 +1,7 @@
 {
   "name": "IRIShub Testnet",
   "chain": "IRIShub",
-  "rpc": [
-    "http://34.80.202.172:8545"
-  ],
+  "rpc": ["http://34.80.202.172:8545"],
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "faucets": [],
   "nativeCurrency": {
@@ -15,14 +13,8 @@
   "shortName": "nyancat",
   "chainId": 16688,
   "networkId": 16688,
-  "icon":"nyancat",
+  "icon": "nyancat",
   "explorers": [
-    {
-      "name": "IRISHub Testnet EVM Explorer",
-      "url": "",
-      "standard": "none",
-      "icon": "nyancat",
-    },
     {
       "name": "IRISHub Testnet Cosmos Explorer (IOBScan)",
       "url": "https://nyancat.iobscan.io",

--- a/_data/icons/nyancat.json
+++ b/_data/icons/nyancat.json
@@ -1,8 +1,8 @@
 [
   {
-    "url": "",
-    "width": 0,
-    "height": 0,
-    "format": ""
+    "url": "ipfs://QmRaSx7AX1VDgcqjwLgSDP4WZmKBHPdHhbjkcEEXPA2Fnc",
+    "width": 1062,
+    "height": 822,
+    "format": "png"
   }
 ]


### PR DESCRIPTION
IRISHub Testnet, also known as Nyancat, now supports EVM. 

We haven't prepared our Ethereum explorer and the icon to IPFS yet.