### PR TITLE
Update Cronos Testnet Explorer URL

### DIFF
--- a/_data/chains/eip155-338.json
+++ b/_data/chains/eip155-338.json
@@ -15,7 +15,7 @@
   "explorers": [
     {
       "name": "Cronos Testnet Explorer",
-      "url": "https://testnet.cronoscan.com",
+      "url": "https://explorer.cronos.org/testnet",
       "standard": "none"
     }
   ]


### PR DESCRIPTION
The Cronos Testnet block explorer URL has been changed to https://explorer.cronos.org/testnet. Update new this explorer URL in Chainlist.