### PR TITLE
Renamed metaplayerone dubai test network so has a different name to mainnet

### DIFF
--- a/_data/chains/eip155-2124.json
+++ b/_data/chains/eip155-2124.json
@@ -1,5 +1,5 @@
 {
-  "name": "Metaplayerone Network",
+  "name": "Metaplayerone Dubai Testnet",
   "chain": "MP1 Dubai-Testnet",
   "icon": "meu",
   "rpc": ["https://rpc-dubai.mp1network.com/"],


### PR DESCRIPTION
Changed the metaplayerone dubai test network so it has a different name to the metaplayerone mainnet