### PR TITLE
Add Scroll Sepolia (534351) & update other Scroll chains statuses

### DIFF
--- a/_data/chains/eip155-534351.json
+++ b/_data/chains/eip155-534351.json
@@ -1,5 +1,5 @@
 {
-  "name": "Scroll",
+  "name": "Scroll Sepolia Testnet",
   "chain": "ETH",
   "status": "incubating",
   "rpc": [],
@@ -10,13 +10,13 @@
     "decimals": 18
   },
   "infoURL": "https://scroll.io",
-  "shortName": "scr",
-  "chainId": 534352,
-  "networkId": 534352,
+  "shortName": "scr-sepolia",
+  "chainId": 534351,
+  "networkId": 534351,
   "explorers": [],
   "parent": {
     "type": "L2",
-    "chain": "eip155-1",
+    "chain": "eip155-11155111",
     "bridges": []
   }
 }

--- a/_data/chains/eip155-534353.json
+++ b/_data/chains/eip155-534353.json
@@ -1,7 +1,7 @@
 {
   "name": "Scroll Alpha Testnet",
   "chain": "ETH",
-  "status": "incubating",
+  "status": "active",
   "rpc": ["https://alpha-rpc.scroll.io/l2"],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-534354.json
+++ b/_data/chains/eip155-534354.json
@@ -1,6 +1,7 @@
 {
   "name": "Scroll Pre-Alpha Testnet",
   "chain": "ETH",
+  "status": "deprecated",
   "rpc": ["https://prealpha-rpc.scroll.io/l2"],
   "faucets": ["https://prealpha.scroll.io/faucet"],
   "nativeCurrency": {


### PR DESCRIPTION
Established ChainId for in-development Scroll testnet on Sepolia.

Additionally, updates statuses to show that Scroll Alpha Testnet on Goerli is our only active network. PreAlpha has been deprecated, and mainnet is not yet active.