### PR TITLE
Add ZORA chain mainnet

### DIFF
--- a/_data/chains/eip155-7777777.json
+++ b/_data/chains/eip155-7777777.json
@@ -1,0 +1,22 @@
+{
+  "name": "Zora",
+  "chain": "ETH",
+  "rpc": ["https://rpc.zora.co/"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://zora.co",
+  "shortName": "zora",
+  "chainId": 7777777,
+  "networkId": 7777777,
+  "explorers": [
+    {
+      "name": "Zora Network Explorer",
+      "url": "https://explorer.zora.co",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds network information for Zora's network, an optimistic rollup chain for zora.co.

More information is available at [zora.energy](https://zora.energy/).