### PR TITLE
Add Titan chain mainnet

### DIFF
--- a/_data/chains/eip155-55004.json
+++ b/_data/chains/eip155-55004.json
@@ -1,0 +1,25 @@
+{
+  "name": "Titan",
+  "chain": "ETH",
+  "rpc": [
+    "https://rpc.titan.tokamak.network",
+    "wss://rpc.titan.tokamak.network/ws"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://tokamak.network",
+  "shortName": "teth",
+  "chainId": 55004,
+  "networkId": 55004,
+  "explorers": [
+    {
+      "name": "blockscout",
+      "url": "https://explorer.titan.tokamak.network",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds network information for Titan's network, an optimistic rollup chain.

More information is available at [tokamak.network](https://tokamak.network)

Thank you!