### PR TITLE
feat: zora network icon

### DIFF
--- a/_data/chains/eip155-7777777.json
+++ b/_data/chains/eip155-7777777.json
@@ -8,6 +8,7 @@
     "symbol": "ETH",
     "decimals": 18
   },
+  "icon": "zora",
   "infoURL": "https://zora.co",
   "shortName": "zora",
   "chainId": 7777777,

--- a/_data/chains/eip155-7777777.json
+++ b/_data/chains/eip155-7777777.json
@@ -1,7 +1,7 @@
 {
   "name": "Zora",
   "chain": "ETH",
-  "rpc": ["https://rpc.zora.co/"],
+  "rpc": ["https://rpc.zora.energy/"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
@@ -9,14 +9,14 @@
     "decimals": 18
   },
   "icon": "zora",
-  "infoURL": "https://zora.co",
+  "infoURL": "https://zora.energy",
   "shortName": "zora",
   "chainId": 7777777,
   "networkId": 7777777,
   "explorers": [
     {
       "name": "Zora Network Explorer",
-      "url": "https://explorer.zora.co",
+      "url": "https://explorer.zora.energy",
       "standard": "EIP3091"
     }
   ]

--- a/_data/icons/zora.json
+++ b/_data/icons/zora.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmYQf9VKTzPwQiU5xQMNbJKKGasLDVoXs2S86Ay77MStp7",
+    "width": 2390,
+    "height": 2390,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
This PR adds the icon for Zora's network, an optimistic rollup chain for zora.co.

More information is available at [zora.energy](https://zora.energy/).