### PR TITLE
Add Althea-L1 testnet and mainnet

### DIFF
--- a/_data/chains/eip155-417834.json
+++ b/_data/chains/eip155-417834.json
@@ -1,0 +1,17 @@
+{
+  "name": "Althea L1",
+  "chain": "Althea L1",
+  "rpc": ["https://althea.zone:8545"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Althea",
+    "symbol": "ALTHEA",
+    "decimals": 18
+  },
+  "infoURL": "https://althea.net",
+  "shortName": "althea-L1",
+  "chainId": 417834,
+  "networkId": 417834,
+  "icon": "althea",
+  "explorers": []
+}

--- a/_data/chains/eip155-7357.json
+++ b/_data/chains/eip155-7357.json
@@ -1,0 +1,24 @@
+{
+  "name": "Althea L1 Testnet",
+  "chain": "Althea L1",
+  "rpc": ["https://testnet.althea.zone:8545"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Althea",
+    "symbol": "ALTHEA",
+    "decimals": 18
+  },
+  "infoURL": "https://althea.net",
+  "shortName": "althea-L1-testnet",
+  "chainId": 7357,
+  "networkId": 7357,
+  "icon": "althea",
+  "explorers": [
+    {
+      "name": "Althea Cosmos Explorer",
+      "url": "https://explorer.stavr.tech/althea-testnet",
+      "standard": "none",
+      "icon": "althea"
+    }
+  ]
+}

--- a/_data/icons/althea.json
+++ b/_data/icons/althea.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmVcAbJyP9dTjpjFauYZV9gqe1LB92hXwZM4Dkvj4qas8M",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Hello, this PR is meant to register Althea L1 as an EVM chain. Althea L1 is a Cosmos-SDK chain with an EVM compatibility layer based off of the technology powering Evmos, so these files should somewhat resemble the eip155-9000.json and eip155-9001.json files. You can find out more here if interested: https://www.althea.net/

Althea L1 is currently in testnet and will be deploying mainnet after our July hackathon concludes. We are registering 7357 as the testnet chain id and 417834 as the mainnet chain id.

This passes tests locally:
```
BUILD SUCCESSFUL in 16s
6 actionable tasks: 1 executed, 5 up-to-date
```