### PR TITLE
Updating Liberty 2.X and Sphinx 1.X Details

### DIFF
--- a/_data/chains/eip155-8081.json
+++ b/_data/chains/eip155-8081.json
@@ -1,22 +1,22 @@
 {
-  "name": "Shardeum Liberty 2.X",
+  "name": "Shardeum Sphinx DApp 1.X",
   "chain": "Shardeum",
   "icon": "shardeum",
-  "rpc": ["https://liberty20.shardeum.org/"],
-  "faucets": ["https://faucet.liberty20.shardeum.org"],
+  "rpc": ["https://dapps.shardeum.org/"],
+  "faucets": ["https://faucet-dapps.shardeum.org/"],
   "nativeCurrency": {
     "name": "Shardeum SHM",
     "symbol": "SHM",
     "decimals": 18
   },
   "infoURL": "https://docs.shardeum.org/",
-  "shortName": "Liberty20",
+  "shortName": "shmDapp",
   "chainId": 8081,
   "networkId": 8081,
   "explorers": [
     {
       "name": "Shardeum Scan",
-      "url": "https://explorer-liberty20.shardeum.org",
+      "url": "https://explorer-dapps.shardeum.org/",
       "standard": "EIP3091"
     }
   ],

--- a/_data/chains/eip155-8082.json
+++ b/_data/chains/eip155-8082.json
@@ -1,5 +1,5 @@
 {
-  "name": "Shardeum Sphinx 1.X",
+  "name": "Shardeum Sphinx Validator 1.X",
   "chain": "Shardeum",
   "icon": "shardeum",
   "rpc": ["https://sphinx.shardeum.org/"],
@@ -10,7 +10,7 @@
     "decimals": 18
   },
   "infoURL": "https://docs.shardeum.org/",
-  "shortName": "Sphinx10",
+  "shortName": "shmVali",
   "chainId": 8082,
   "networkId": 8082,
   "explorers": [


### PR DESCRIPTION
Shardeum Liberty 2.X  and SPhinx 1.X Testnet is updated with its new details. 

Moving forward we are making those two testnets more standardized - Liberty 2.X(now renamed as Sphinx Dapp 1.X) now becomes specifically for developers and acts as a devnet, while  Sphinx 1.X is renamed( to Sphinx Validator 1.X) to denote it is the primary testnet for Shardeum Validators.