### PR TITLE
Rename Optimism (10) to OP Mainnet

### DIFF
--- a/_data/chains/eip155-10.json
+++ b/_data/chains/eip155-10.json
@@ -1,5 +1,5 @@
 {
-  "name": "Optimism",
+  "name": "OP Mainnet",
   "chain": "ETH",
   "rpc": ["https://mainnet.optimism.io/"],
   "faucets": [],


### PR DESCRIPTION
Renaming "Optimism" (Chain id: 10) to "OP Mainnet"

Official comms from Optimism FND: https://twitter.com/optimismFND/status/1672281032962478080

Optimism = Broader Ecosystem
OP Mainnet = Chain ID 10 Network