### PR TITLE
Update Ethereum Classic RPC endpoints

### DIFF
--- a/_data/chains/eip155-61.json
+++ b/_data/chains/eip155-61.json
@@ -1,7 +1,7 @@
 {
   "name": "Ethereum Classic Mainnet",
   "chain": "ETC",
-  "rpc": ["https://www.ethercluster.com/etc"],
+  "rpc": ["https://etc.rivet.link"],
   "faucets": ["https://free-online-app.com/faucet-for-eth-evm-chains/?"],
   "nativeCurrency": {
     "name": "Ethereum Classic Ether",

--- a/_data/chains/eip155-63.json
+++ b/_data/chains/eip155-63.json
@@ -1,7 +1,7 @@
 {
   "name": "Ethereum Classic Testnet Mordor",
   "chain": "ETC",
-  "rpc": ["https://www.ethercluster.com/mordor"],
+  "rpc": ["https://rpc.mordor.etccooperative.org"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Mordor Classic Testnet Ether",


### PR DESCRIPTION
Starting from July 24th, 2023 the current endpoints will be disabled, this PR updates them with the new ones listed in the announcement.

https://etccooperative.org/posts/2023-06-24-important-announcement-migrate-the-etc-and-mordor-rpc-endpoints-by-july-24-2023-en