### PR TITLE
chore: update evmos config

### DIFF
--- a/_data/chains/eip155-9000.json
+++ b/_data/chains/eip155-9000.json
@@ -15,14 +15,8 @@
   "icon": "evmos",
   "explorers": [
     {
-      "name": "Evmos EVM Explorer",
-      "url": "https://evm.evmos.dev",
-      "standard": "EIP3091",
-      "icon": "evmos"
-    },
-    {
-      "name": "Evmos Cosmos Explorer",
-      "url": "https://explorer.evmos.dev",
+      "name": "Evmos Explorer (Escan)",
+      "url": "https://testnet.escan.live",
       "standard": "none",
       "icon": "evmos"
     }

--- a/_data/chains/eip155-9001.json
+++ b/_data/chains/eip155-9001.json
@@ -1,7 +1,7 @@
 {
   "name": "Evmos",
   "chain": "Evmos",
-  "rpc": ["https://eth.bd.evmos.org:8545", "https://evmos-evm.publicnode.com"],
+  "rpc": ["https://evmos-evm.publicnode.com"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Evmos",
@@ -15,14 +15,8 @@
   "icon": "evmos",
   "explorers": [
     {
-      "name": "Evmos EVM Explorer (Escan)",
+      "name": "Evmos Explorer (Escan)",
       "url": "https://escan.live",
-      "standard": "none",
-      "icon": "evmos"
-    },
-    {
-      "name": "Evmos Cosmos Explorer (Mintscan)",
-      "url": "https://www.mintscan.io/evmos",
       "standard": "none",
       "icon": "evmos"
     }


### PR DESCRIPTION
Update Evmos config for mainnet and testnet:
- Block explorer link
- RPC provider