### PR TITLE
Add linea mainnet

### DIFF
--- a/_data/chains/eip155-59140.json
+++ b/_data/chains/eip155-59140.json
@@ -6,7 +6,7 @@
     "https://rpc.goerli.linea.build",
     "wss://rpc.goerli.linea.build",
     "https://linea-goerli.infura.io/v3/${INFURA_API_KEY}",
-    "wss://linea-goerli.infura.io/v3/${INFURA_API_KEY}"
+    "wss://linea-goerli.infura.io/ws/v3/${INFURA_API_KEY}"
   ],
   "faucets": ["https://faucetlink.to/goerli"],
   "nativeCurrency": {

--- a/_data/chains/eip155-59140.json
+++ b/_data/chains/eip155-59140.json
@@ -31,7 +31,7 @@
   "explorers": [
     {
       "name": "Etherscan",
-      "url": "https://goerli.lineascan.io",
+      "url": "https://goerli.lineascan.build",
       "standard": "EIP3091",
       "icon": "linea"
     },

--- a/_data/chains/eip155-59140.json
+++ b/_data/chains/eip155-59140.json
@@ -30,7 +30,13 @@
   },
   "explorers": [
     {
-      "name": "blockscout",
+      "name": "Etherscan",
+      "url": "https://goerli.lineascan.io",
+      "standard": "EIP3091",
+      "icon": "linea"
+    },
+    {
+      "name": "Blockscout",
       "url": "https://explorer.goerli.linea.build",
       "standard": "EIP3091",
       "icon": "linea"

--- a/_data/chains/eip155-59144.json
+++ b/_data/chains/eip155-59144.json
@@ -31,7 +31,7 @@
   "explorers": [
     {
       "name": "Etherscan",
-      "url": "https://lineascan.io",
+      "url": "https://lineascan.build",
       "standard": "EIP3091",
       "icon": "linea"
     },

--- a/_data/chains/eip155-59144.json
+++ b/_data/chains/eip155-59144.json
@@ -6,7 +6,7 @@
     "https://rpc.linea.build",
     "wss://rpc.linea.build",
     "https://linea-mainnet.infura.io/v3/${INFURA_API_KEY}",
-    "wss://linea-mainnet.infura.io/v3/${INFURA_API_KEY}"
+    "wss://linea-mainnet.infura.io/ws/v3/${INFURA_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-59144.json
+++ b/_data/chains/eip155-59144.json
@@ -31,7 +31,13 @@
   "explorers": [
     {
       "name": "Etherscan",
-      "url": "https://lineascan.build",
+      "url": "https://lineascan.io",
+      "standard": "EIP3091",
+      "icon": "linea"
+    },
+    {
+      "name": "Blockscout",
+      "url": "https://explorer.linea.build",
       "standard": "EIP3091",
       "icon": "linea"
     }

--- a/_data/chains/eip155-59144.json
+++ b/_data/chains/eip155-59144.json
@@ -1,0 +1,40 @@
+{
+  "name": "Linea",
+  "title": "Linea Mainnet",
+  "chain": "ETH",
+  "rpc": [
+    "https://rpc.linea.build",
+    "wss://rpc.linea.build",
+    "https://linea-mainnet.infura.io/v3/${INFURA_API_KEY}",
+    "wss://linea-mainnet.infura.io/v3/${INFURA_API_KEY}"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Linea Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://linea.build",
+  "shortName": "linea",
+  "chainId": 59144,
+  "networkId": 59144,
+  "icon": "linea",
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-1",
+    "bridges": [
+      {
+        "url": "https://bridge.linea.build"
+      }
+    ]
+  },
+  "explorers": [
+    {
+      "name": "Etherscan",
+      "url": "https://lineascan.build",
+      "standard": "EIP3091",
+      "icon": "linea"
+    }
+  ],
+  "status": "active"
+}


### PR DESCRIPTION
Hi! Following the PRs opened for Linea testnet a few weeks and months ago, we now would like to add support for **Linea mainnet**.
Please keep in mind that RPC endpoints, bridge and block explorer will be available in the upcoming weeks (hence the draft status).

Many thanks for support 🙂 