### PR TITLE
Update BNB Chain brand names

### DIFF
--- a/_data/chains/eip155-56.json
+++ b/_data/chains/eip155-56.json
@@ -1,11 +1,11 @@
 {
-  "name": "Binance Smart Chain Mainnet",
+  "name": "BNB Smart Chain Mainnet",
   "chain": "BSC",
   "rpc": [
-    "https://bsc-dataseed1.binance.org",
-    "https://bsc-dataseed2.binance.org",
-    "https://bsc-dataseed3.binance.org",
-    "https://bsc-dataseed4.binance.org",
+    "https://bsc-dataseed1.bnbchain.org",
+    "https://bsc-dataseed2.bnbchain.org",
+    "https://bsc-dataseed3.bnbchain.org",
+    "https://bsc-dataseed4.bnbchain.org",
     "https://bsc-dataseed1.defibit.io",
     "https://bsc-dataseed2.defibit.io",
     "https://bsc-dataseed3.defibit.io",
@@ -19,11 +19,11 @@
   ],
   "faucets": ["https://free-online-app.com/faucet-for-eth-evm-chains/"],
   "nativeCurrency": {
-    "name": "Binance Chain Native Token",
+    "name": "BNB Chain Native Token",
     "symbol": "BNB",
     "decimals": 18
   },
-  "infoURL": "https://www.binance.org",
+  "infoURL": "https://www.bnbchain.org/en",
   "shortName": "bnb",
   "chainId": 56,
   "networkId": 56,

--- a/_data/chains/eip155-97.json
+++ b/_data/chains/eip155-97.json
@@ -1,22 +1,22 @@
 {
-  "name": "Binance Smart Chain Testnet",
+  "name": "BNB Smart Chain Testnet",
   "chain": "BSC",
   "rpc": [
-    "https://data-seed-prebsc-1-s1.binance.org:8545",
-    "https://data-seed-prebsc-2-s1.binance.org:8545",
-    "https://data-seed-prebsc-1-s2.binance.org:8545",
-    "https://data-seed-prebsc-2-s2.binance.org:8545",
-    "https://data-seed-prebsc-1-s3.binance.org:8545",
-    "https://data-seed-prebsc-2-s3.binance.org:8545",
+    "https://data-seed-prebsc-1-s1.bnbchain.org:8545",
+    "https://data-seed-prebsc-2-s1.bnbchain.org:8545",
+    "https://data-seed-prebsc-1-s2.bnbchain.org:8545",
+    "https://data-seed-prebsc-2-s2.bnbchain.org:8545",
+    "https://data-seed-prebsc-1-s3.bnbchain.org:8545",
+    "https://data-seed-prebsc-2-s3.bnbchain.org:8545",
     "https://bsc-testnet.publicnode.com"
   ],
-  "faucets": ["https://testnet.binance.org/faucet-smart"],
+  "faucets": ["https://testnet.bnbchain.org/faucet-smart"],
   "nativeCurrency": {
-    "name": "Binance Chain Native Token",
+    "name": "BNB Chain Native Token",
     "symbol": "tBNB",
     "decimals": 18
   },
-  "infoURL": "https://testnet.binance.org/",
+  "infoURL": "https://www.bnbchain.org/en",
   "shortName": "bnbt",
   "chainId": 97,
   "networkId": 97,


### PR DESCRIPTION
**Summary**
Binance Chain has been rebranded into BNB Chain. This PR is to update the brand names and RPC URLs to the correct version. Refer to the [official BNB Chain documentation](https://docs.bnbchain.org/docs/rpc#bsc-mainnet-chainid-0x38-56-in-decimal).

**Changes**
- Update all `Binance Smart Chain` to `BNB Smart Chain`
- Update all `Binance Chain` to `BNB Chain`
- Update all RPC URLs domain from `binance` to `bnbchain`
- Update info URL to https://www.bnbchain.org/en