### PR TITLE
Adding Base mainnet (for builders)

### DIFF
--- a/_data/chains/eip155-8453.json
+++ b/_data/chains/eip155-8453.json
@@ -1,7 +1,7 @@
 {
   "name": "Base",
   "chain": "ETH",
-  "rpc": [],
+  "rpc": ["https://developer-access-mainnet.base.org/"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
@@ -12,5 +12,18 @@
   "shortName": "base",
   "chainId": 8453,
   "networkId": 8453,
-  "status": "incubating"
+  "icon": "base",
+  "explorers": [
+    {
+      "name": "basescan",
+      "url": "http://basescan.org",
+      "standard": "none"
+    },
+    {
+      "name": "basescout",
+      "url": "http://base.blockscout.com",
+      "standard": "none"
+    }
+  ],
+  "status": "active"
 }

--- a/_data/chains/eip155-8453.json
+++ b/_data/chains/eip155-8453.json
@@ -16,12 +16,12 @@
   "explorers": [
     {
       "name": "basescan",
-      "url": "http://basescan.org",
+      "url": "https://basescan.org",
       "standard": "none"
     },
     {
       "name": "basescout",
-      "url": "http://base.blockscout.com",
+      "url": "https://base.blockscout.com",
       "standard": "none"
     }
   ],

--- a/_data/chains/eip155-84531.json
+++ b/_data/chains/eip155-84531.json
@@ -12,6 +12,7 @@
   "shortName": "basegor",
   "chainId": 84531,
   "networkId": 84531,
+  "icon": "baseTestnet",
   "explorers": [
     {
       "name": "basescan",

--- a/_data/icons/base.json
+++ b/_data/icons/base.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmaxRoHpxZd8PqccAynherrMznMufG6sdmHZLihkECXmZv",
+    "width": 1200,
+    "height": 1200,
+    "format": "png"
+  }
+]

--- a/_data/icons/baseTestnet.json
+++ b/_data/icons/baseTestnet.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmaxRoHpxZd8PqccAynherrMznMufG6sdmHZLihkECXmZv",
+    "width": 1200,
+    "height": 1200,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Following up on [the testnet chain addition from @barmstrong](https://github.com/ethereum-lists/chains/pull/2318), we're excited to now add developer access for mainnet!

🔵 

--

> We’re excited to add Base, an Ethereum Layer 2 (L2) network offering a secure, low-cost, builder-friendly way for anyone, anywhere, to build decentralized apps onchain. Our goal with Base is to make onchain the next online and onboard 1B+ users into the cryptoeconomy. In pursuit of this goal, Base will serve as both a home for Coinbase’s onchain products, as well as an open ecosystem where anyone can build.