### PR TITLE
mark to be deprecated the old testnet, and add a new Kroma Sepolia network

### DIFF
--- a/_data/chains/eip155-2357.json
+++ b/_data/chains/eip155-2357.json
@@ -2,7 +2,7 @@
   "name": "(deprecated) Kroma Sepolia",
   "title": "(deprecated) Kroma Testnet Sepolia",
   "chainId": 2357,
-  "shortName": "kroma-sepolia",
+  "shortName": "deprecated-kroma-sepolia",
   "chain": "ETH",
   "networkId": 2357,
   "nativeCurrency": {
@@ -26,5 +26,6 @@
     "type": "L2",
     "chain": "eip155-11155111",
     "bridges": [{ "url": "https://kroma.network/bridge" }]
-  }
+  },
+  "status": "deprecated"
 }

--- a/_data/chains/eip155-2358.json
+++ b/_data/chains/eip155-2358.json
@@ -1,23 +1,23 @@
 {
-  "name": "(deprecated) Kroma Sepolia",
-  "title": "(deprecated) Kroma Testnet Sepolia",
-  "chainId": 2357,
+  "name": "Kroma Sepolia",
+  "title": "Kroma Testnet Sepolia",
+  "chainId": 2358,
   "shortName": "kroma-sepolia",
   "chain": "ETH",
-  "networkId": 2357,
+  "networkId": 2358,
   "nativeCurrency": {
     "name": "Sepolia Ether",
     "symbol": "ETH",
     "decimals": 18
   },
-  "rpc": ["https://api.sepolia-deprecated.kroma.network"],
+  "rpc": ["https://api.sepolia.kroma.network"],
   "faucets": [],
   "infoURL": "https://kroma.network",
   "icon": "kroma",
   "explorers": [
     {
       "name": "blockscout",
-      "url": "https://blockscout.sepolia-deprecated.kroma.network",
+      "url": "https://blockscout.sepolia.kroma.network",
       "icon": "kroma",
       "standard": "EIP3091"
     }


### PR DESCRIPTION
A new Kroma Sepolia testnet is launched, so marked the existing one deprecated and added a new one.

This is our announcement link: https://medium.com/@kroma-network/kroma-second-testnet-is-live-e4b759ea65ca