### PR TITLE
Add rpc's to Sepolia

### DIFF
--- a/_data/chains/eip155-11155111.json
+++ b/_data/chains/eip155-11155111.json
@@ -5,7 +5,10 @@
   "rpc": [
     "https://rpc.sepolia.org",
     "https://rpc2.sepolia.org",
-    "https://rpc-sepolia.rockx.com"
+    "https://rpc-sepolia.rockx.com",
+    "https://rpc.sepolia.ethpandaops.io",
+    "https://sepolia.infura.io/v3/${INFURA_API_KEY}",
+    "wss://sepolia.infura.io/v3/${INFURA_API_KEY}"
   ],
   "faucets": ["http://fauceth.komputing.org?chain=11155111&address=${ADDRESS}"],
   "nativeCurrency": {


### PR DESCRIPTION
Adding `ethpandaops` and Infura RPCs (similar to Goerli) to Sepolia `rpc`s as `*.sepolia.org` RPCs have been down, as well as others in https://sepolia.dev/. 

It is difficult to find a working RPC as of writing and this can be discouraging to migrate to Sepolia for devs. Open to discuss what could be a better way.