### PR TITLE
Remove "Beta" from the Cronos Chain name

### DIFF
--- a/_data/chains/eip155-25.json
+++ b/_data/chains/eip155-25.json
@@ -1,5 +1,5 @@
 {
-  "name": "Cronos Mainnet Beta",
+  "name": "Cronos Mainnet",
   "chain": "CRO",
   "rpc": ["https://evm.cronos.org", "https://cronos-evm.publicnode.com"],
   "features": [{ "name": "EIP1559" }],


### PR DESCRIPTION
Cronos has exited the beta phase, and this request is to remove "Beta" from the Cronos Chain name.  
Official announcement: https://twitter.com/cronos_chain/status/1572932534257737728