### PR TITLE
Update Base mainnet RPC

### DIFF
--- a/_data/chains/eip155-8453.json
+++ b/_data/chains/eip155-8453.json
@@ -1,7 +1,7 @@
 {
   "name": "Base",
   "chain": "ETH",
-  "rpc": ["https://developer-access-mainnet.base.org/"],
+  "rpc": ["https://mainnet.base.org/"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",


### PR DESCRIPTION
Hello, this updates the Base mainnet RPC to be mainnet.base.org.

Related: #2318, #2320, #3165