### PR TITLE
Add Japan Open Chain Testnet

### DIFF
--- a/_data/chains/eip155-10081.json
+++ b/_data/chains/eip155-10081.json
@@ -1,0 +1,25 @@
+{
+  "name": "Japan Open Chain Testnet",
+  "chain": "JOCT",
+  "rpc": [
+    "https://rpc-1.testnet.japanopenchain.org:8545",
+    "https://rpc-2.testnet.japanopenchain.org:8545"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Japan Open Chain Testnet Token",
+    "symbol": "JOCT",
+    "decimals": 18
+  },
+  "infoURL": "https://www.japanopenchain.org/",
+  "shortName": "joct",
+  "chainId": 10081,
+  "networkId": 10081,
+  "explorers": [
+    {
+      "name": "Testnet Block Explorer",
+      "url": "https://explorer.testnet.japanopenchain.org",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Hello,

Japan Open Chain Mainnet was merged 2 weeks ago. https://github.com/ethereum-lists/chains/pull/3222 
I propose to add Japan Open Chain Testnet in this PR.

Thank you for taking a look