### PR TITLE
Adding EIP155-667 for LAOS testnet chain

### DIFF
--- a/_data/chains/eip155-667.json
+++ b/_data/chains/eip155-667.json
@@ -1,0 +1,25 @@
+{
+  "name": "LAOS Arrakis",
+  "title": "LAOS Testnet Arrakis",
+  "chain": "LAOS",
+  "rpc": ["https://arrakis.gorengine.com/own", "wss://arrakis.gorengine.com/own"],
+  "icon": "laos",
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "LAOS",
+    "symbol": "LAOS",
+    "decimals": 18
+  },
+  "infoURL": "https://www.laosfoundation.io/",
+  "shortName": "laos",
+  "chainId": 667,
+  "networkId": 667,
+  "explorers": [
+    {
+      "name": "blockscout",
+      "url": "https://arrakis.gorengine.com",
+      "icon": "laos",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/icons/laos.json
+++ b/_data/icons/laos.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmZ4YYcvhcaeotMPaGXC5Vab7JFaVkka37V8TiTJpT7Mak",
+    "width": 586,
+    "height": 558,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
LAOS Testnet chain is live since July 2023.
Adding the chain_id, rpc endpoints, explorer, and icon.