### PR TITLE
Update mainnet info for u2u chain

### DIFF
--- a/_data/chains/eip155-39.json
+++ b/_data/chains/eip155-39.json
@@ -1,8 +1,8 @@
 {
-  "name": "Unicorn Ultra Testnet",
+  "name": "U2U Solaris Mainnet",
   "chain": "u2u",
-  "rpc": ["https://rpc-testnet.uniultra.xyz"],
-  "faucets": ["https://faucet.uniultra.xyz"],
+  "rpc": ["https://rpc-mainnet.uniultra.xyz"],
+  "faucets": [],
   "nativeCurrency": {
     "name": "Unicorn Ultra",
     "symbol": "U2U",
@@ -17,7 +17,7 @@
     {
       "icon": "u2u",
       "name": "U2U Explorer",
-      "url": "https://testnet.uniultra.xyz",
+      "url": "https://u2uscan.xyz",
       "standard": "EIP3091"
     }
   ]


### PR DESCRIPTION
Update mainnet info for u2u chain

Network Name: U2U Solaris Mainnet
ChainID: 39
RPC: https://rpc-mainnet.uniultra.xyz/
Explorer: https://u2uscan.xyz/