### PR TITLE
Change websocket endpoint for Titan chain mainnet

### DIFF
--- a/_data/chains/eip155-55004.json
+++ b/_data/chains/eip155-55004.json
@@ -3,7 +3,7 @@
   "chain": "ETH",
   "rpc": [
     "https://rpc.titan.tokamak.network",
-    "wss://rpc.titan.tokamak.network/ws"
+    "wss://rpc.titan.tokamak.network"
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
This PR changes websocket endpoint for Titan's network, an optimistic rollup chain.

More information is available at [tokamak.network](https://tokamak.network/)

Thank you!