### PR TITLE
Fix Nautilus Triton testnet so it has a unique name

### DIFF
--- a/_data/chains/eip155-91002.json
+++ b/_data/chains/eip155-91002.json
@@ -1,5 +1,5 @@
 {
-  "name": "Nautilus Chain",
+  "name": "Nautilus Trition Chain",
   "title": "Nautilus Trition Testnet",
   "chain": "ETH",
   "icon": "nautilus",


### PR DESCRIPTION
Changes the ``Nautilus Trition Testnet`` name from ``Nautilus Chain`` to ``Nautilus Trition Chain`` to avoid duplicate name