### PR TITLE
Ethereum Classic networks clean up

### DIFF
--- a/_data/chains/eip155-6.json
+++ b/_data/chains/eip155-6.json
@@ -1,5 +1,6 @@
 {
   "name": "Ethereum Classic Testnet Kotti",
+  "status": "deprecated",
   "chain": "ETC",
   "rpc": ["https://www.ethercluster.com/kotti"],
   "faucets": [],

--- a/_data/chains/eip155-61.json
+++ b/_data/chains/eip155-61.json
@@ -2,6 +2,7 @@
   "name": "Ethereum Classic Mainnet",
   "chain": "ETC",
   "rpc": ["https://etc.rivet.link"],
+  "features": [{ "name": "EIP155" }],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ethereum Classic Ether",
@@ -13,12 +14,11 @@
   "chainId": 61,
   "networkId": 1,
   "slip44": 61,
-
   "explorers": [
     {
       "name": "blockscout",
       "url": "https://blockscout.com/etc/mainnet",
-      "standard": "none"
+      "standard": "EIP3091"
     }
   ]
 }

--- a/_data/chains/eip155-61.json
+++ b/_data/chains/eip155-61.json
@@ -2,7 +2,7 @@
   "name": "Ethereum Classic Mainnet",
   "chain": "ETC",
   "rpc": ["https://etc.rivet.link"],
-  "faucets": ["https://free-online-app.com/faucet-for-eth-evm-chains/?"],
+  "faucets": [],
   "nativeCurrency": {
     "name": "Ethereum Classic Ether",
     "symbol": "ETC",

--- a/_data/chains/eip155-63.json
+++ b/_data/chains/eip155-63.json
@@ -14,5 +14,12 @@
   "infoURL": "https://github.com/eth-classic/mordor/",
   "shortName": "metc",
   "chainId": 63,
-  "networkId": 7
+  "networkId": 7,
+  "explorers": [
+    {
+      "name": "blockscout",
+      "url": "https://blockscout.com/etc/mordor",
+      "standard": "EIP3091"
+    }
+  ]
 }

--- a/_data/chains/eip155-63.json
+++ b/_data/chains/eip155-63.json
@@ -2,7 +2,10 @@
   "name": "Ethereum Classic Testnet Mordor",
   "chain": "ETC",
   "rpc": ["https://rpc.mordor.etccooperative.org"],
-  "faucets": [],
+  "faucets": [
+    "https://mordor.canhaz.net/",
+    "https://easy.hebeswap.com/#/faucet"
+  ],
   "nativeCurrency": {
     "name": "Mordor Classic Testnet Ether",
     "symbol": "METC",

--- a/_data/chains/eip155-63.json
+++ b/_data/chains/eip155-63.json
@@ -2,6 +2,7 @@
   "name": "Ethereum Classic Testnet Mordor",
   "chain": "ETC",
   "rpc": ["https://rpc.mordor.etccooperative.org"],
+  "features": [{ "name": "EIP155" }],
   "faucets": [
     "https://mordor.canhaz.net/",
     "https://easy.hebeswap.com/#/faucet"
@@ -15,6 +16,7 @@
   "shortName": "metc",
   "chainId": 63,
   "networkId": 7,
+  "slip44": 63,
   "explorers": [
     {
       "name": "blockscout",


### PR DESCRIPTION
This PR:
 * Deprecates Kotti ([core-geth](https://github.com/etclabscore/core-geth/pull/552) and [besu](https://github.com/hyperledger/besu/pull/5816) dropped support, its explorer was taken down and none validator stayed online)
 * Removes faucets from ETC mainnet
 * Adds faucets and aditional information for Mordor ETC testnet