### PR TITLE
Deprecate eip155-444.json

### DIFF
--- a/_data/chains/eip155-444.json
+++ b/_data/chains/eip155-444.json
@@ -1,5 +1,6 @@
 {
   "name": "Frenchain Testnet",
+  "status": "deprecated",
   "chain": "tfren",
   "rpc": ["https://rpc-01tn.frenchain.app"],
   "faucets": [],


### PR DESCRIPTION
Deprecates Frenchain Testnet, currently using Chain ID 444, in preparation of a new PR for an unrelated testnet to use chain ID 444. 

RPC is fully down. 
```
cast block latest --rpc-url https://rpc-01tn.frenchain.app
Error:
error sending request for url (https://rpc-01tn.frenchain.app/): error trying to connect: dns error: failed to lookup address information: nodename nor servname provided, or not known
```

https://chainlist.org/chain/444

Explorer no longer exists (https://testnet.frenscan.io/), and redirects to https://app.tryethernal.com. 

Twitter account has been deleted: https://twitter.com/fren_chain, which is linked from the official site provided in the chain information: https://frenchain.app/

No tweets mention the Frenchain Testnet since November 2022. 