### PR TITLE
Remove deprecated RPCs for Polygon Mumbai

### DIFF
--- a/_data/chains/eip155-80001.json
+++ b/_data/chains/eip155-80001.json
@@ -4,9 +4,7 @@
   "chain": "Polygon",
   "icon": "polygon",
   "rpc": [
-    "https://matic-mumbai.chainstacklabs.com",
     "https://rpc-mumbai.maticvigil.com",
-    "https://matic-testnet-archive-rpc.bwarelabs.com",
     "https://polygon-mumbai-bor.publicnode.com",
     "https://polygon-mumbai.gateway.tenderly.co",
     "wss://polygon-mumbai.gateway.tenderly.co"


### PR DESCRIPTION
https://matic-mumbai.chainstacklabs.com - Has been discontinued and no longer works

https://twitter.com/ChainstackHQ/status/1682027531917234179

---

https://matic-testnet-archive-rpc.bwarelabs.com - DNS entries no longer exist

ubuntu@ip-10-128-59-167:~/efs_gsn# ping matic-testnet-archive-rpc.bwarelabs.com
ping: matic-testnet-archive-rpc.bwarelabs.com: No address associated with hostname