### PR TITLE
Update DeFiMetaChain Testnet ("Changi")

### DIFF
--- a/_data/chains/eip155-1133.json
+++ b/_data/chains/eip155-1133.json
@@ -1,5 +1,5 @@
 {
-  "name": "DeFiMetaChain",
+  "name": "DeFiMetaChain Testnet",
   "icon": "changi",
   "chain": "DFI",
   "rpc": ["https://testnet-dmc.mydefichain.com:20551"],


### PR DESCRIPTION
Updating chain name, as "Testnet" was omitted. Original PR for adding was #3447.