### PR TITLE
Add Humans.ai Testnet chain 

### DIFF
--- a/_data/chains/eip155-3000-1.json
+++ b/_data/chains/eip155-3000-1.json
@@ -1,0 +1,32 @@
+{
+  "name": "Humans.ai Testnet",
+  "chain": "Humans",
+  "rpc": ["https://evm-rpc.friction.humans.zone"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "HEART",
+    "symbol": "HEART",
+    "decimals": 18
+  },
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
+    }
+  ],
+  "infoURL": "https://humans.ai",
+  "shortName": "humans",
+  "chainId": 3000,
+  "networkId": 3000,
+  "icon": "humans",
+  "explorers": [
+    {
+      "name": "friction.humans.zone",
+      "url": "https://evm-explorer.friction.humans.zone",
+      "icon": "humans",
+      "standard": "none"
+    }
+  ]
+}

--- a/_data/icons/humans.json
+++ b/_data/icons/humans.json
@@ -1,8 +1,8 @@
 [
   {
-    "url": "ipfs://QmU83haX3TNifDDjBx6RP6ByqES1Kg9VqeJC87X9ipKyCS",
-    "width": 386,
-    "height": 397,
+    "url": "ipfs://QmX6XuoQDTTjYqAmdNJiieLDZSwHHyUx44yQb4E3tmHmEA",
+    "width": 400,
+    "height": 400,
     "format": "png"
   }
 ]


### PR DESCRIPTION
This PR is to add Humans.ai Testnet and update the IPFS logo

Please note that file eip155-3000.json was already present in the _data/chains folder, I was not sure how to name the JSON to correctly follow the naming convention (couldn't find other duplicates to figure out how it was resolved, please advise).

I have named the Humans Testnet JSON: 

_data/chains/eip155-3000-1.json