### PR TITLE
Update `Rootstock` Network

### DIFF
--- a/_data/chains/eip155-30.json
+++ b/_data/chains/eip155-30.json
@@ -1,14 +1,15 @@
 {
-  "name": "RSK Mainnet",
-  "chain": "RSK",
+  "name": "Rootstock Mainnet",
+  "chain": "Rootstock",
   "rpc": ["https://public-node.rsk.co", "https://mycrypto.rsk.co"],
   "faucets": [],
+  "icon": "rootstock",
   "nativeCurrency": {
     "name": "Smart Bitcoin",
     "symbol": "RBTC",
     "decimals": 18
   },
-  "infoURL": "https://rsk.co",
+  "infoURL": "https://rootstock.io",
   "shortName": "rsk",
   "chainId": 30,
   "networkId": 30,
@@ -16,8 +17,14 @@
 
   "explorers": [
     {
-      "name": "RSK Explorer",
+      "name": "Rootstock Explorer",
       "url": "https://explorer.rsk.co",
+      "standard": "EIP3091"
+    },
+    {
+      "name": "blockscout",
+      "url": "https://rootstock.blockscout.com",
+      "icon": "blockscout",
       "standard": "EIP3091"
     }
   ]

--- a/_data/chains/eip155-31.json
+++ b/_data/chains/eip155-31.json
@@ -1,17 +1,18 @@
 {
-  "name": "RSK Testnet",
-  "chain": "RSK",
+  "name": "Rootstock Testnet",
+  "chain": "Rootstock",
   "rpc": [
     "https://public-node.testnet.rsk.co",
     "https://mycrypto.testnet.rsk.co"
   ],
   "faucets": ["https://faucet.rsk.co/"],
+  "icon": "rootstock",
   "nativeCurrency": {
     "name": "Testnet Smart Bitcoin",
     "symbol": "tRBTC",
     "decimals": 18
   },
-  "infoURL": "https://rsk.co",
+  "infoURL": "https://rootstock.io",
   "shortName": "trsk",
   "chainId": 31,
   "networkId": 31,

--- a/_data/icons/rootstock.json
+++ b/_data/icons/rootstock.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreigidzbf22dnpmmlfxv6u7oifq6ln33j4n57ox4ipiproalufrheym",
+    "width": 3000,
+    "height": 3325,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
## Description
This pull request updates  [RSK](https://rootstock.io/) chain as its rebranded to [Rootstock](https://rootstock.io/). 

Reference: https://rootstock.io/

## Checklist 
- Added blockscout url for Rootstock as it adheres to EIP3091
- Added rootstock ipfs icon and validated CIDs
- Specified icon size as per maintainer checklist

 