### PR TITLE
Update Fantasia Chain infoURL

### DIFF
--- a/_data/chains/eip155-868.json
+++ b/_data/chains/eip155-868.json
@@ -12,7 +12,7 @@
     "symbol": "FST",
     "decimals": 18
   },
-  "infoURL": "https://fantasia.technology/",
+  "infoURL": "https://fantasiachain.com/",
   "shortName": "FSCMainnet",
   "chainId": 868,
   "networkId": 868,


### PR DESCRIPTION
Our official info url: https://fantasiachain.com