### PR TITLE
Adding Blocknative’s Transaction Boost RPC Endpoint

### DIFF
--- a/_data/chains/eip155-1.json
+++ b/_data/chains/eip155-1.json
@@ -10,7 +10,8 @@
     "https://ethereum.publicnode.com",
     "wss://ethereum.publicnode.com",
     "https://mainnet.gateway.tenderly.co",
-    "wss://mainnet.gateway.tenderly.co"
+    "wss://mainnet.gateway.tenderly.co",
+    "https://rpc.blocknative.com/boost"
   ],
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "faucets": [],


### PR DESCRIPTION
Description: Blocknative’s Transaction Boost protects users from frontrunning and sandwiching attacks without sacrificing visibility.