### PR TITLE
Adding InvArch Tinkernet as 2125

### DIFF
--- a/_data/chains/eip155-2125.json
+++ b/_data/chains/eip155-2125.json
@@ -1,0 +1,20 @@
+{
+  "name": "InvArch Tinkernet Parachain",
+  "chain": "TNKR",
+  "rpc": [
+    "https://tinkernet-rpc.dwellir.com",
+    "wss://tinkernet-rpc.dwellir.com"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Tinker",
+    "symbol": "TNKR",
+    "decimals": 12
+  },
+  "infoURL": "https://invarch.network/tinkernet",
+  "shortName": "tnkr",
+  "chainId": 2125,
+  "networkId": 2125,
+  "icon": "tinkernet",
+  "status": "incubating"
+}

--- a/_data/icons/tinkernet.json
+++ b/_data/icons/tinkernet.json
@@ -1,0 +1,8 @@
+[
+    {
+      "url": "ipfs://QmR197GvbZTEjhWGkjCYbF7fuLX494sKZFxr6LDuTLyTCi",
+      "width": 1080,
+      "height": 1080,
+      "format": "png"
+    }
+]


### PR DESCRIPTION
This PR adds the InvArch Tinkernet Parachain as id 2125 with the status of `incubating`, as the network is live but the Ethereum RPC APIs are still not deployed to the nodes.