### PR TITLE
chore: Beam network - gas token migration

### DIFF
--- a/_data/chains/eip155-13337.json
+++ b/_data/chains/eip155-13337.json
@@ -1,12 +1,18 @@
 {
   "name": "Beam Testnet",
   "chain": "BEAM",
-  "rpc": ["https://subnets.avax.network/beam/testnet/rpc"],
+  "rpc": [
+    "https://subnets.avax.network/beam/testnet/rpc",
+    "wss://subnets.avax.network/beam/testnet/ws"
+  ],
   "features": [{ "name": "EIP1559" }],
-  "faucets": [],
+  "faucets": [
+    "https://faucet.avax.network/?subnet=beam",
+    "https://faucet.onbeam.com"
+  ],
   "nativeCurrency": {
-    "name": "Merit Circle",
-    "symbol": "MC",
+    "name": "Beam",
+    "symbol": "BEAM",
     "decimals": 18
   },
   "infoURL": "https://www.onbeam.com",

--- a/_data/chains/eip155-4337.json
+++ b/_data/chains/eip155-4337.json
@@ -1,16 +1,19 @@
 {
   "name": "Beam",
   "chain": "BEAM",
-  "rpc": ["https://subnets.avax.network/beam/mainnet/rpc"],
+  "rpc": [
+    "https://subnets.avax.network/beam/mainnet/rpc",
+    "wss://subnets.avax.network/beam/mainnet/ws"
+  ],
   "features": [
     {
       "name": "EIP1559"
     }
   ],
-  "faucets": [],
+  "faucets": ["https://faucet.onbeam.com"],
   "nativeCurrency": {
-    "name": "Merit Circle",
-    "symbol": "MC",
+    "name": "Beam",
+    "symbol": "BEAM",
     "decimals": 18
   },
   "infoURL": "https://www.onbeam.com",


### PR DESCRIPTION
updated token info for networks `13337` and `4337` (Beam test- and mainnet), the gas token has been migrated. also added faucet and rpc links