### PR TITLE
remove Harmony shards 2 and 3 due to HIP30, reason - https://talk.harmony.one/t/hip30v2-update-announcement/23268

### DIFF
--- a/_data/chains/eip155-1666600002.json
+++ b/_data/chains/eip155-1666600002.json
@@ -13,6 +13,7 @@
   "shortName": "hmy-s2",
   "chainId": 1666600002,
   "networkId": 1666600002,
+  "status": "deprecated",
   "explorers": [
     {
       "name": "Harmony Block Explorer",

--- a/_data/chains/eip155-1666600003.json
+++ b/_data/chains/eip155-1666600003.json
@@ -13,6 +13,7 @@
   "shortName": "hmy-s3",
   "chainId": 1666600003,
   "networkId": 1666600003,
+  "status": "deprecated",
   "explorers": [
     {
       "name": "Harmony Block Explorer",


### PR DESCRIPTION
Hello chains maintainers,

Harmony decided to shutdown shards 2 and 3, due to this I want to remove both of them.

Source: https://talk.harmony.one/t/hip30v2-update-announcement/23268