### PR TITLE
[Fuse] Update Fuse IPFS URL

### DIFF
--- a/_data/icons/fuse.json
+++ b/_data/icons/fuse.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "ipfs://bafkreiaplzptahvpac43flw4eplqkim4zxwurnz4nipz3zxip4wkisidxi",
+    "url": "ipfs://QmR3gooSiRfCuryT2y7Q37a3DqmdCKvV6vYp1fVpJW3VWz",
     "width": 800,
     "height": 800,
     "format": "png"


### PR DESCRIPTION
Existing Fuse icon isn't displaying on ChainList:
https://chainlist.org/chain/122

ChainList is displaying an old Fuse icon. I update the IPFS URL which might solve this issue.