### PR TITLE
Remove un-supported endpoint for the Darwinia Chain

### DIFF
--- a/_data/chains/eip155-46.json
+++ b/_data/chains/eip155-46.json
@@ -4,7 +4,6 @@
   "rpc": [
     "https://rpc.darwinia.network",
     "https://darwinia-rpc.darwiniacommunitydao.xyz",
-    "https://darwinia2.api.onfinality.io/public-ws",
     "https://darwinia-rpc.dwellir.com"
   ],
   "faucets": [],


### PR DESCRIPTION
This endpoint is no longer supported, so remove it from the RPC list. 

![image](https://github.com/ethereum-lists/chains/assets/11801722/fa5df7e6-86ca-411d-9ea9-e68bf49fe1f6)
