### PR TITLE
Remove public ANKR RPC from Rollux mainnet.

### DIFF
--- a/_data/chains/eip155-570.json
+++ b/_data/chains/eip155-570.json
@@ -1,10 +1,7 @@
 {
   "name": "Rollux Mainnet",
   "chain": "SYS",
-  "rpc": [
-    "https://rpc.rollux.com",
-    "wss://rpc.rollux.com/wss"
-  ],
+  "rpc": ["https://rpc.rollux.com", "wss://rpc.rollux.com/wss"],
   "faucets": ["https://rollux.id/faucetapp"],
   "nativeCurrency": {
     "name": "Syscoin",

--- a/_data/chains/eip155-570.json
+++ b/_data/chains/eip155-570.json
@@ -3,7 +3,6 @@
   "chain": "SYS",
   "rpc": [
     "https://rpc.rollux.com",
-    "https://rollux.public-rpc.com",
     "wss://rpc.rollux.com/wss"
   ],
   "faucets": ["https://rollux.id/faucetapp"],


### PR DESCRIPTION
As reported by the Syscoin Foundation https://github.com/DefiLlama/chainlist/commit/44bfcceedcbf288262139add171546038f57d7de, this RPC should be removed temporarily.

Note that ANKR provides both rpc.ankr.com/rollux and rollux.public-rpc.com

For reference: https://github.com/ethereum-lists/chains/pull/3787