### PR TITLE
Updating HashScan's URLs

### DIFF
--- a/_data/chains/eip155-295.json
+++ b/_data/chains/eip155-295.json
@@ -18,8 +18,8 @@
   "explorers": [
     {
       "name": "HashScan",
-      "url": "https://hashscan.io/mainnet/dashboard",
-      "standard": "none"
+      "url": "https://hashscan.io/mainnet",
+      "standard": "EIP3091"
     },
     {
       "name": "Arkhia Explorer",

--- a/_data/chains/eip155-296.json
+++ b/_data/chains/eip155-296.json
@@ -18,8 +18,8 @@
   "explorers": [
     {
       "name": "HashScan",
-      "url": "https://hashscan.io/testnet/dashboard",
-      "standard": "none"
+      "url": "https://hashscan.io/testnet",
+      "standard": "EIP3091"
     },
     {
       "name": "Arkhia Explorer",

--- a/_data/chains/eip155-297.json
+++ b/_data/chains/eip155-297.json
@@ -18,8 +18,8 @@
   "explorers": [
     {
       "name": "HashScan",
-      "url": "https://hashscan.io/previewnet/dashboard",
-      "standard": "none"
+      "url": "https://hashscan.io/previewnet",
+      "standard": "EIP3091"
     }
   ]
 }


### PR DESCRIPTION
Now HashScan redirects URLs as requested by [@ligi's comment](https://github.com/ethereum-lists/chains/pull/2279#discussion_r1108699662) in #2279.

This PR updates the explorer's URLs accordingly and flags them as EIP3091 compliant.