### PR TITLE
Update Scroll Sepolia URLs

### DIFF
--- a/_data/chains/eip155-534351.json
+++ b/_data/chains/eip155-534351.json
@@ -21,7 +21,7 @@
   "explorers": [
     {
       "name": "Scroll Sepolia Etherscan",
-      "url": "https://sepolia.scrollscan.dev",
+      "url": "https://sepolia.scrollscan.com",
       "standard": "EIP3091"
     },
     {
@@ -33,6 +33,6 @@
   "parent": {
     "type": "L2",
     "chain": "eip155-11155111",
-    "bridges": [{ "url": "https://scroll.io/bridge" }]
+    "bridges": [{ "url": "https://sepolia.scroll.io/bridge" }]
   }
 }


### PR DESCRIPTION
After launch of Scoll mainnet, testnet URLs have changed.