### PR TITLE
Update Cronos Explorer Link in eip155-25.json

### DIFF
--- a/_data/chains/eip155-25.json
+++ b/_data/chains/eip155-25.json
@@ -20,7 +20,7 @@
   "explorers": [
     {
       "name": "Cronos Explorer",
-      "url": "https://cronoscan.com",
+      "url": "https://explorer.cronos.org/",
       "standard": "none"
     }
   ]


### PR DESCRIPTION
Cronos mainnet new explorer has just been launched ([official announcement](https://blog.cronos.org/p/introducing-the-new-cronos-explorer-7ee)), updating the Cronos explorer link from Cronoscan to the new explorer: https://explorer.cronos.org/.