### PR TITLE
Update for new Autonity Bakerloo Testnet

### DIFF
--- a/_data/chains/eip155-65010001.json
+++ b/_data/chains/eip155-65010001.json
@@ -1,5 +1,5 @@
 {
-  "name": "Autonity Bakerloo (Thames) Testnet",
+  "name": "Autonity Bakerloo (Barada) Testnet",
   "chain": "AUT",
   "rpc": [
     "https://rpc1.bakerloo.autonity.org/",
@@ -12,9 +12,9 @@
     "decimals": 18
   },
   "infoURL": "https://autonity.org/",
-  "shortName": "bakerloo-0",
-  "chainId": 65010000,
-  "networkId": 65010000,
+  "shortName": "bakerloo-01",
+  "chainId": 65010001,
+  "networkId": 65010001,
   "icon": "autonity",
   "explorers": [
     {

--- a/eip155-65010000.json
+++ b/eip155-65010000.json
@@ -1,0 +1,27 @@
+{
+  "name": "Autonity Bakerloo (Thames) Testnet",
+  "status": "deprecated",
+  "chain": "AUT",
+  "rpc": [
+    "https://rpc1.bakerloo.autonity.org/",
+    "wss://rpc1.bakerloo.autonity.org/ws/"
+  ],
+  "faucets": ["https://faucet.autonity.org/"],
+  "nativeCurrency": {
+    "name": "Bakerloo Auton",
+    "symbol": "ATN",
+    "decimals": 18
+  },
+  "infoURL": "https://autonity.org/",
+  "shortName": "bakerloo-0",
+  "chainId": 65010000,
+  "networkId": 65010000,
+  "icon": "autonity",
+  "explorers": [
+    {
+      "name": "autonity-blockscout",
+      "url": "https://bakerloo.autonity.org",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Adds 65010001 and deprecates 65010000