### PR TITLE
add RPC to Neon Mainnet

### DIFF
--- a/_data/chains/eip155-245022934.json
+++ b/_data/chains/eip155-245022934.json
@@ -1,7 +1,7 @@
 {
   "name": "Neon EVM Mainnet",
   "chain": "Solana",
-  "rpc": [],
+  "rpc": ["https://neon-proxy-mainnet.solana.p2p.org"],
   "faucets": [],
   "icon": "neon",
   "nativeCurrency": {


### PR DESCRIPTION
Neon EVM Mainnet was missing RPC link, added it now.