### PR TITLE
fix icon not displayed

### DIFF
--- a/_data/chains/eip155-4337.json
+++ b/_data/chains/eip155-4337.json
@@ -18,7 +18,6 @@
   },
   "infoURL": "https://www.onbeam.com",
   "shortName": "beam",
-  "icon": "beam",
   "chainId": 4337,
   "networkId": 4337,
   "explorers": [


### PR DESCRIPTION
Icon isn't displayed on the website, other chains with the same issue using the key "icon" too. Removed it for Beam to fix. The beam.json with the IPFS logo is already created.


`./gradlew run`
BUILD SUCCESSFUL in 1m 30s
8 actionable tasks: 8 executed
