### PR TITLE
Rebrand Rethereum to Hypra

### DIFF
--- a/_data/chains/eip155-622277.json
+++ b/_data/chains/eip155-622277.json
@@ -1,27 +1,28 @@
 {
-  "name": "Rethereum Mainnet",
-  "chain": "RTH",
+  "name": "Hypra Mainnet",
+  "chain": "HYP",
   "rpc": [
+    "https://rpc.hypra.network",
     "https://rpc.rethereum.org",
     "https://rethereum.rpc.restratagem.com",
     "https://rpc.rthcentral.org"
   ],
   "faucets": [],
   "nativeCurrency": {
-    "name": "Rethereum",
-    "symbol": "RTH",
+    "name": "Hypra",
+    "symbol": "HYP",
     "decimals": 18
   },
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
-  "infoURL": "https://www.rethereum.org",
-  "shortName": "rth",
+  "infoURL": "https://www.hypra.network",
+  "shortName": "hyp",
   "chainId": 622277,
   "networkId": 622277,
   "icon": "rethereum",
   "explorers": [
     {
-      "name": "rethereum",
-      "url": "https://explorer.rethereum.org",
+      "name": "hypra",
+      "url": "https://explorer.hypra.network",
       "icon": "blockscout",
       "standard": "EIP3091"
     }


### PR DESCRIPTION
Ref: https://www.hypra.network/blog/rethereum-is-changing-to-hypra.html