### PR TITLE
Update ShimmerEVM name

### DIFF
--- a/_data/chains/eip155-148.json
+++ b/_data/chains/eip155-148.json
@@ -1,6 +1,6 @@
 {
-  "name": "ShimmerEVM Mainnet",
-  "title": "ShimmerEVM Mainnet",
+  "name": "ShimmerEVM",
+  "title": "ShimmerEVM",
   "chain": "ShimmerEVM",
   "rpc": ["https://json-rpc.evm.shimmer.network"],
   "faucets": [],
@@ -10,7 +10,7 @@
     "decimals": 18
   },
   "infoURL": "https://shimmer.network",
-  "shortName": "shimmerevm-mainnet",
+  "shortName": "shimmerevm",
   "chainId": 148,
   "networkId": 148,
   "icon": "shimmerevm",


### PR DESCRIPTION
I updated the ShimmerEVM name as it is called ShimmerEVM everywhere else which leads to problems like in the Metamask check for example