### PR TITLE
Rename fraxchain to fraxtal

### DIFF
--- a/_data/chains/eip155-252.json
+++ b/_data/chains/eip155-252.json
@@ -1,5 +1,5 @@
 {
-  "name": "Fraxchain Mainnet",
+  "name": "Fraxtal Mainnet",
   "chain": "FRAX",
   "rpc": [],
   "faucets": [],
@@ -9,7 +9,7 @@
     "decimals": 18
   },
   "infoURL": "https://mainnet.frax.com",
-  "shortName": "fraxchain",
+  "shortName": "fraxtal",
   "chainId": 252,
   "networkId": 252,
   "explorers": [],

--- a/_data/chains/eip155-2522.json
+++ b/_data/chains/eip155-2522.json
@@ -1,5 +1,5 @@
 {
-  "name": "Fraxchain Testnet",
+  "name": "Fraxtal Testnet",
   "chain": "FRAX",
   "rpc": ["https://rpc.testnet.frax.com"],
   "faucets": [],
@@ -9,7 +9,7 @@
     "decimals": 18
   },
   "infoURL": "https://testnet.frax.com",
-  "shortName": "fraxchain-testnet",
+  "shortName": "fraxtal-testnet",
   "chainId": 2522,
   "networkId": 2522,
   "slip44": 1,


### PR DESCRIPTION
We're renaming our chain to [Fraxtal](https://twitter.com/fraxfinance)