### PR TITLE
Update rpc url in eip155-199.json

### DIFF
--- a/_data/chains/eip155-199.json
+++ b/_data/chains/eip155-199.json
@@ -1,14 +1,14 @@
 {
   "name": "BitTorrent Chain Mainnet",
   "chain": "BTTC",
-  "rpc": ["https://rpc.bittorrentchain.io/"],
+  "rpc": ["https://rpc.bt.io"],
   "faucets": [],
   "nativeCurrency": {
     "name": "BitTorrent",
     "symbol": "BTT",
     "decimals": 18
   },
-  "infoURL": "https:/bt.io",
+  "infoURL": "https://bt.io",
   "shortName": "BTT",
   "chainId": 199,
   "networkId": 199,


### PR DESCRIPTION
https://rpc.bittorrentchain.io is not available, see: https://doc.bt.io/docs/networks/network.