### PR TITLE
update Tanssi Testnet Token name

### DIFF
--- a/_data/chains/eip155-5678.json
+++ b/_data/chains/eip155-5678.json
@@ -7,8 +7,8 @@
   ],
   "faucets": [],
   "nativeCurrency": {
-    "name": "Unit",
-    "symbol": "Unit",
+    "name": "Tango",
+    "symbol": "Tango",
     "decimals": 18
   },
   "infoURL": "https://tanssi.network",

--- a/_data/chains/eip155-5678.json
+++ b/_data/chains/eip155-5678.json
@@ -7,8 +7,8 @@
   ],
   "faucets": [],
   "nativeCurrency": {
-    "name": "Tango",
-    "symbol": "Tango",
+    "name": "TANGO",
+    "symbol": "TANGO",
     "decimals": 18
   },
   "infoURL": "https://tanssi.network",


### PR DESCRIPTION
We've changed the token symbol from `Unit` to `Tango` to avoid confusion and differentiate more clearly between token symbols on our testnet environments. Let me know if you have any questions. Thanks! 