### PR TITLE
Update Q token symbol

### DIFF
--- a/_data/chains/eip155-35441.json
+++ b/_data/chains/eip155-35441.json
@@ -4,8 +4,8 @@
   "rpc": ["https://rpc.q.org"],
   "faucets": [],
   "nativeCurrency": {
-    "name": "Q token",
-    "symbol": "Q",
+    "name": "QGOV",
+    "symbol": "QGOV",
     "decimals": 18
   },
   "infoURL": "https://q.org",


### PR DESCRIPTION
According to https://q.org the token symbol for Q mainnet (35441) is changed from "Q" to "QGOV"

<img width="1385" alt="image" src="https://github.com/ethereum-lists/chains/assets/17788043/62bac252-3e6c-4e35-a5c1-b37399d43f8b">
<img width="1388" alt="image" src="https://github.com/ethereum-lists/chains/assets/17788043/acd6f44f-1a23-4910-9769-acace493fa13">
