### PR TITLE
Changed native currency name and symbol to Ether and ETH from KRK

### DIFF
--- a/_data/chains/eip155-2410.json
+++ b/_data/chains/eip155-2410.json
@@ -5,8 +5,8 @@
   "rpc": ["https://rpc.karak.network"],
   "faucets": [],
   "nativeCurrency": {
-    "name": "Karak",
-    "symbol": "KRK",
+    "name": "Ether",
+    "symbol": "ETH",
     "decimals": 18
   },
   "infoURL": "https://karak.network",


### PR DESCRIPTION
Should be `Ether` and `ETH` since it's a eth L2