### PR TITLE
update domains for bifrost network

### DIFF
--- a/_data/chains/eip155-3068.json
+++ b/_data/chains/eip155-3068.json
@@ -3,8 +3,8 @@
   "title": "Bifrost Network Mainnet",
   "chain": "BFC",
   "rpc": [
-    "https://public-01.mainnet.thebifrost.io/rpc",
-    "https://public-02.mainnet.thebifrost.io/rpc"
+    "https://public-01.mainnet.bifrostnetwork.com/rpc",
+    "https://public-02.mainnet.bifrostnetwork.com/rpc"
   ],
   "faucets": [],
   "nativeCurrency": {
@@ -12,7 +12,7 @@
     "symbol": "BFC",
     "decimals": 18
   },
-  "infoURL": "https://thebifrost.io",
+  "infoURL": "https://bifrostnetwork.com",
   "shortName": "bfc",
   "chainId": 3068,
   "networkId": 3068,
@@ -20,7 +20,7 @@
   "explorers": [
     {
       "name": "explorer-thebifrost",
-      "url": "https://explorer.mainnet.thebifrost.io",
+      "url": "https://explorer.mainnet.bifrostnetwork.com",
       "standard": "EIP3091"
     }
   ]

--- a/_data/chains/eip155-49088.json
+++ b/_data/chains/eip155-49088.json
@@ -3,8 +3,8 @@
   "title": "Bifrost Network Testnet",
   "chain": "BFC",
   "rpc": [
-    "https://public-01.testnet.thebifrost.io/rpc",
-    "https://public-02.testnet.thebifrost.io/rpc"
+    "https://public-01.testnet.bifrostnetwork.com/rpc",
+    "https://public-02.testnet.bifrostnetwork.com/rpc"
   ],
   "faucets": [],
   "nativeCurrency": {
@@ -12,7 +12,7 @@
     "symbol": "BFC",
     "decimals": 18
   },
-  "infoURL": "https://thebifrost.io",
+  "infoURL": "https://bifrostnetwork.com",
   "shortName": "tbfc",
   "chainId": 49088,
   "networkId": 49088,
@@ -21,7 +21,7 @@
   "explorers": [
     {
       "name": "explorer-thebifrost",
-      "url": "https://explorer.testnet.thebifrost.io",
+      "url": "https://explorer.testnet.bifrostnetwork.com",
       "standard": "EIP3091"
     }
   ]


### PR DESCRIPTION
RPC, Bifrost Homepage, and Explorer URLs have been updated.

https://github.com/ethereum-lists/chains/pull/4258

In a previous PR, redirect from the old domain to a new domain is a good pattern, so I went ahead and did it.

However, for RPC, we will be migrating slowly as Hardhat, Metamask, Web3py, etc. do not detect redirects, so the existing domain (thebifrost.io) will be discontinued with further notice.

For now, the redirects from thebifrost.io to bifrostnetwork.com have mostly gone through except for rpc.