### PR TITLE
Rectify degen chain chainid

### DIFF
--- a/_data/chains/eip155-1234567.json
+++ b/_data/chains/eip155-1234567.json
@@ -11,8 +11,8 @@
   },
   "infoURL": "https://degen.tips",
   "shortName": "degen-chain",
-  "chainId": 666666666,
-  "networkId": 666666666,
+  "chainId": 1234567,
+  "networkId": 1234567,
   "status": "incubating",
   "icon": "degen"
 }


### PR DESCRIPTION
Hi @ligi , 

We have made a honest mistake in adding wrong chain id for degen.tips. This PR should rectify it. 

I was the one who originally added the chain id. 


There is more context in this comment https://github.com/ethereum-lists/chains/pull/4474#issuecomment-1981732624

Thank you for all the work you have put on chainlist.org