### PR TITLE
Add support for re.al chain

### DIFF
--- a/_data/chains/eip155-111188.json
+++ b/_data/chains/eip155-111188.json
@@ -2,7 +2,7 @@
   "name": "re.al",
   "title": "re.al Real-World Assets network",
   "chain": "re.al",
-  "rpc": ["https://public-rpc.re.al", "wss://public-rpc.re.al"],
+  "rpc": ["https://real.drpc.org", "wss://real.drpc.org"],
   "nativeCurrency": {
     "name": "re.al Ether",
     "symbol": "reETH",

--- a/_data/chains/eip155-111188.json
+++ b/_data/chains/eip155-111188.json
@@ -1,0 +1,35 @@
+{
+  "name": "re.al",
+  "title": "re.al Real-World Assets network",
+  "chain": "re.al",
+  "rpc": ["https://public-rpc.re.al", "wss://public-rpc.re.al"],
+  "nativeCurrency": {
+    "name": "re.al Ether",
+    "symbol": "reETH",
+    "decimals": 18
+  },
+  "infoURL": "https://re.al",
+  "faucets": [],
+  "shortName": "re-al",
+  "chainId": 111188,
+  "networkId": 111188,
+  "slip44": 60,
+  "icon": "real",
+  "explorers": [
+    {
+      "name": "blockscout",
+      "url": "https://explorer.re.al",
+      "icon": "real",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-1",
+    "bridges": [
+      { "url": "https://re.al/bridge" },
+      { "url": "https://bridge.gelato.network/bridge/real" }
+    ]
+  },
+  "status": "incubating"
+}

--- a/_data/chains/eip155-18231.json
+++ b/_data/chains/eip155-18231.json
@@ -1,0 +1,35 @@
+{
+  "name": "unreal-old",
+  "title": "unreal testnet for re.al",
+  "chain": "unreal",
+  "rpc": [
+    "https://rpc.unreal.gelato.digital",
+    "wss://ws.unreal.gelato.digital"
+  ],
+  "nativeCurrency": {
+    "name": "unreal Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://raas.gelato.network/rollups/details/public/unreal",
+  "faucets": [],
+  "shortName": "unreal-old",
+  "chainId": 18231,
+  "networkId": 18231,
+  "slip44": 60,
+  "icon": "unreal",
+  "explorers": [
+    {
+      "name": "blockscout",
+      "url": "https://unreal.blockscout.com",
+      "icon": "unreal",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-11155111",
+    "bridges": []
+  },
+  "status": "deprecated"
+}

--- a/_data/chains/eip155-18233.json
+++ b/_data/chains/eip155-18233.json
@@ -3,19 +3,19 @@
   "title": "unreal testnet for re.al",
   "chain": "unreal",
   "rpc": [
-    "https://rpc.unreal.gelato.digital",
-    "wss://ws.unreal.gelato.digital"
+    "https://rpc.unreal-orbit.gelato.digital",
+    "wss://ws.unreal-orbit.gelato.digital"
   ],
   "nativeCurrency": {
     "name": "unreal Ether",
-    "symbol": "ETH",
+    "symbol": "reETH",
     "decimals": 18
   },
   "infoURL": "https://raas.gelato.network/rollups/details/public/unreal",
   "faucets": [],
   "shortName": "unreal",
-  "chainId": 18231,
-  "networkId": 18231,
+  "chainId": 18233,
+  "networkId": 18233,
   "slip44": 60,
   "icon": "unreal",
   "explorers": [
@@ -28,7 +28,7 @@
   ],
   "parent": {
     "type": "L2",
-    "chain": "eip155-11155111",
-    "bridges": [{ "url": "https://bridge.unreal.gelato.digital" }]
+    "chain": "eip155-17000",
+    "bridges": [{ "url": "https://bridge.gelato.network/bridge/unreal" }]
   }
 }

--- a/_data/icons/real.json
+++ b/_data/icons/real.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmNUmWC7jNEBcTs6ZqkrQ5vMAQG8qjq7n3FcZnXvJZLoQ9",
+    "width": 301,
+    "height": 302,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Update data for Unreal testnet because
chainId changed. We had to move away from zkEVM Polygon CDK because it wasn't production ready, and we spinned up unreal with Arbitrum CDK.
