### PR TITLE
Add Polygon Amoy Testnet 80002

### DIFF
--- a/_data/chains/eip155-80002.json
+++ b/_data/chains/eip155-80002.json
@@ -1,0 +1,27 @@
+{
+  "name": "Amoy",
+  "title": "Polygon Testnet Amoy",
+  "chain": "Polygon",
+  "icon": "polygon",
+  "rpc": [
+    "https://rpc-amoy.polygon.technology"
+  ],
+  "faucets": ["https://faucet.polygon.technology/"],
+  "nativeCurrency": {
+    "name": "MATIC",
+    "symbol": "MATIC",
+    "decimals": 18
+  },
+  "infoURL": "https://polygon.technology/",
+  "shortName": "maticamoy",
+  "chainId": 80002,
+  "networkId": 80002,
+  "slip44": 1,
+  "explorers": [
+    {
+      "name": "oklink",
+      "url": "https://www.oklink.com/amoy",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
In this PR, we are adding Polygon Amoy Testnet which will be serving as the primary testnet for Polygon-PoS network.
Reference : [Amoy Introduction Blog](https://polygon.technology/blog/introducing-the-amoy-testnet-for-polygon-pos)