### PR TITLE
Add CamDL Testnet

### DIFF
--- a/_data/chains/eip155-395.json
+++ b/_data/chains/eip155-395.json
@@ -10,10 +10,10 @@
   },
   "features": [{ "name": "EIP155" }],
   "infoURL": "https://camdl.gov.kh/",
-  "shortName": "camdl",
+  "shortName": "camdl-testnet",
   "chainId": 395,
   "networkId": 395,
-  "icon": "camdl-testnet",
+  "icon": "camdl",
   "explorers": [
     {
       "name": "CamDL Testnet Explorer",

--- a/_data/chains/eip155-395.json
+++ b/_data/chains/eip155-395.json
@@ -13,7 +13,7 @@
   "shortName": "camdl",
   "chainId": 395,
   "networkId": 395,
-  "icon": "camdl",
+  "icon": "camdl-testnet",
   "explorers": [
     {
       "name": "CamDL Testnet Explorer",

--- a/_data/chains/eip155-395.json
+++ b/_data/chains/eip155-395.json
@@ -1,0 +1,25 @@
+{
+  "name": "CamDL Testnet",
+  "chain": "CADL",
+  "rpc": ["https://rpc1.testnet.camdl.gov.kh/"],
+  "faucets": ["https://faucet.testnet.camdl.gov.kh/"],
+  "nativeCurrency": {
+    "name": "CADL",
+    "symbol": "CADL",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://camdl.gov.kh/",
+  "shortName": "camdl",
+  "chainId": 395,
+  "networkId": 395,
+  "icon": "camdl",
+  "explorers": [
+    {
+      "name": "CamDL Testnet Explorer",
+      "url": "https://explorer.testnet.camdl.gov.kh/",
+      "standard": "EIP3091"
+    }
+  ],
+  "status": "active"
+}

--- a/_data/chains/eip155-395.json
+++ b/_data/chains/eip155-395.json
@@ -17,7 +17,7 @@
   "explorers": [
     {
       "name": "CamDL Testnet Explorer",
-      "url": "https://explorer.testnet.camdl.gov.kh/",
+      "url": "https://explorer.testnet.camdl.gov.kh",
       "standard": "EIP3091"
     }
   ],


### PR DESCRIPTION
CamDL is blockchain network run by Ministry of Economy of Finance in Cambodia, with the initiative to provide the public a platform to experiment or develop any Web3 application to solve everyday problems or be part of the DeFi ecosystem.