### PR TITLE
Move re.al status to active

### DIFF
--- a/_data/chains/eip155-111188.json
+++ b/_data/chains/eip155-111188.json
@@ -30,6 +30,5 @@
       { "url": "https://re.al/bridge" },
       { "url": "https://bridge.gelato.network/bridge/real" }
     ]
-  },
-  "status": "incubating"
+  }
 }


### PR DESCRIPTION
Since the chain is now live, moving status to active.