### PR TITLE
Feat: Add Near chain

### DIFF
--- a/_data/chains/eip155-397.json
+++ b/_data/chains/eip155-397.json
@@ -1,0 +1,23 @@
+{
+  "name": "Near Mainnet",
+  "chain": "NEAR",
+  "rpc": [],
+  "icon": "near",
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "NEAR",
+    "symbol": "NEAR",
+    "decimals": 18
+  },
+  "infoURL": "https://near.org/",
+  "shortName": "near",
+  "chainId": 397,
+  "networkId": 397,
+  "explorers": [
+    {
+      "name": "Near Blocks",
+      "url": "https://nearblocks.io/",
+      "standard": "none"
+    }
+  ]
+}

--- a/_data/chains/eip155-397.json
+++ b/_data/chains/eip155-397.json
@@ -16,7 +16,7 @@
   "explorers": [
     {
       "name": "Near Blocks",
-      "url": "https://nearblocks.io/",
+      "url": "https://nearblocks.io",
       "standard": "none"
     }
   ]

--- a/_data/chains/eip155-398.json
+++ b/_data/chains/eip155-398.json
@@ -16,7 +16,7 @@
   "explorers": [
     {
       "name": "Near blocks",
-      "url": "https://testnet.nearblocks.io/",
+      "url": "https://testnet.nearblocks.io",
       "standard": "none"
     }
   ]

--- a/_data/chains/eip155-398.json
+++ b/_data/chains/eip155-398.json
@@ -1,0 +1,23 @@
+{
+  "name": "Near Testnet",
+  "chain": "NEAR",
+  "rpc": [],
+  "icon": "near",
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Testnet NEAR",
+    "symbol": "NEAR",
+    "decimals": 18
+  },
+  "infoURL": "https://aurora.dev",
+  "shortName": "near-testnet",
+  "chainId": 398,
+  "networkId": 398,
+  "explorers": [
+    {
+      "name": "Near blocks",
+      "url": "https://testnet.nearblocks.io/",
+      "standard": "none"
+    }
+  ]
+}

--- a/_data/icons/near.json
+++ b/_data/icons/near.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreiayxzdbu3e5ahri3ooieg6k6pjxrwkrkc2x5cnyadqeu5zbmaummq",
+    "width": 639,
+    "height": 639,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Near is working on [a protocol change](https://github.com/near/NEPs/issues/518) to enable anyone with an Ethereum-compatible wallet to interact with Near-native dapps. To this end, Near requires its own chain ID separate from [Aurora](https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-1313161554.json).