### PR TITLE
Add Redstone and Garnet Holesky, deprecate Redstone Holesky testnet

### DIFF
--- a/_data/chains/eip155-17001.json
+++ b/_data/chains/eip155-17001.json
@@ -1,9 +1,7 @@
 {
   "name": "Redstone Holesky Testnet",
   "chain": "ETH",
-  "rpc": [
-    "https://rpc.holesky.redstone.xyz"
-  ],
+  "rpc": ["https://rpc.holesky.redstone.xyz"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Redstone Testnet Ether",

--- a/_data/chains/eip155-17001.json
+++ b/_data/chains/eip155-17001.json
@@ -1,7 +1,9 @@
 {
   "name": "Redstone Holesky Testnet",
   "chain": "ETH",
-  "rpc": ["https://rpc.holesky.redstone.xyz"],
+  "rpc": [
+    "https://rpc.holesky.redstone.xyz"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Redstone Testnet Ether",
@@ -21,5 +23,6 @@
       "icon": "ethereum",
       "standard": "EIP3091"
     }
-  ]
+  ],
+  "status": "deprecated"
 }

--- a/_data/chains/eip155-17001.json
+++ b/_data/chains/eip155-17001.json
@@ -9,7 +9,7 @@
     "decimals": 18
   },
   "infoURL": "https://redstone.xyz/docs/network-info",
-  "shortName": "redstone",
+  "shortName": "redstone-holesky",
   "chainId": 17001,
   "networkId": 17001,
   "slip44": 1,

--- a/_data/chains/eip155-17069.json
+++ b/_data/chains/eip155-17069.json
@@ -1,7 +1,10 @@
 {
   "name": "Garnet Holesky",
   "chain": "ETH",
-  "rpc": ["https://rpc.garnetchain.com", "wss://rpc.garnetchain.com"],
+  "rpc": [
+    "https://rpc.garnetchain.com",
+    "wss://rpc.garnetchain.com"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
@@ -23,6 +26,11 @@
   ],
   "parent": {
     "type": "L2",
-    "chain": "eip155-17000"
+    "chain": "eip155-17000",
+    "bridges": [
+      {
+        "url": "https://garnetchain.com/deposit"
+      }
+    ]
   }
 }

--- a/_data/chains/eip155-17069.json
+++ b/_data/chains/eip155-17069.json
@@ -1,10 +1,7 @@
 {
   "name": "Garnet Holesky",
   "chain": "ETH",
-  "rpc": [
-    "https://rpc.garnetchain.com",
-    "wss://rpc.garnetchain.com"
-  ],
+  "rpc": ["https://rpc.garnetchain.com", "wss://rpc.garnetchain.com"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
@@ -15,7 +12,7 @@
   "shortName": "garnet",
   "chainId": 17069,
   "networkId": 17069,
-  "icon": "redstone",
+  "icon": "garnet",
   "explorers": [
     {
       "name": "blockscout",

--- a/_data/chains/eip155-17069.json
+++ b/_data/chains/eip155-17069.json
@@ -1,0 +1,28 @@
+{
+  "name": "Redstone Garnet",
+  "chain": "ETH",
+  "rpc": ["https://rpc.garnetchain.com", "wss://rpc.garnetchain.com"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://redstone.xyz",
+  "shortName": "garnet",
+  "chainId": 17069,
+  "networkId": 17069,
+  "icon": "redstone",
+  "explorers": [
+    {
+      "name": "blockscout",
+      "url": "https://explorer.garnetchain.com",
+      "icon": "blockscout",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-17000"
+  }
+}

--- a/_data/chains/eip155-17069.json
+++ b/_data/chains/eip155-17069.json
@@ -1,5 +1,5 @@
 {
-  "name": "Redstone Garnet",
+  "name": "Garnet Holesky",
   "chain": "ETH",
   "rpc": ["https://rpc.garnetchain.com", "wss://rpc.garnetchain.com"],
   "faucets": [],

--- a/_data/chains/eip155-690.json
+++ b/_data/chains/eip155-690.json
@@ -1,10 +1,7 @@
 {
   "name": "Redstone",
   "chain": "ETH",
-  "rpc": [
-    "https://rpc.redstonechain.com",
-    "wss://rpc.redstonechain.com"
-  ],
+  "rpc": ["https://rpc.redstonechain.com", "wss://rpc.redstonechain.com"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",

--- a/_data/chains/eip155-690.json
+++ b/_data/chains/eip155-690.json
@@ -1,0 +1,36 @@
+{
+  "name": "Redstone",
+  "chain": "ETH",
+  "rpc": [
+    "https://rpc.redstonechain.com",
+    "wss://rpc.redstonechain.com"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://redstone.xyz",
+  "shortName": "redstone",
+  "chainId": 690,
+  "networkId": 690,
+  "icon": "redstone",
+  "explorers": [
+    {
+      "name": "blockscout",
+      "url": "https://explorer.redstone.xyz",
+      "icon": "blockscout",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-1",
+    "bridges": [
+      {
+        "url": "https://redstone.xyz/deposit"
+      }
+    ]
+  }
+}

--- a/_data/icons/garnet.json
+++ b/_data/icons/garnet.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmY3ny6nsAQMK3BzQjHtVaTkgHdZTzt3qGfbg3LEgQfXun",
+    "width": 600,
+    "height": 600,
+    "format": "png"
+  }
+]

--- a/_data/icons/garnet.json
+++ b/_data/icons/garnet.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "ipfs://QmY3ny6nsAQMK3BzQjHtVaTkgHdZTzt3qGfbg3LEgQfXun",
+    "url": "ipfs://QmWhHvjbjTiNNsHKpbEz9rxSt4CCL2Q5xVZjk8eQkp82B9",
     "width": 600,
     "height": 600,
     "format": "png"


### PR DESCRIPTION
Adds Redstone (ID 690) and the Garnet Holesky testnet (ID 17069). 

Also deprecates the old Redstone Holesky testnet and changes it's `shortname`.