### PR TITLE
updated edeXa testnet RPC URLs

### DIFF
--- a/_data/chains/eip155-1995.json
+++ b/_data/chains/eip155-1995.json
@@ -2,7 +2,7 @@
   "name": "edeXa Testnet",
   "chain": "edeXa TestNetwork",
   "rpc": [
-    "https://testnet.edexa.com/rpc",
+    "https://testnet.edexa.network/rpc",
     "https://io-dataseed1.testnet.edexa.io-market.com/rpc"
   ],
   "faucets": ["https://faucet.edexa.com/"],
@@ -11,7 +11,7 @@
     "symbol": "EDX",
     "decimals": 18
   },
-  "infoURL": "https://edexa.com/",
+  "infoURL": "https://edexa.network/",
   "shortName": "edx",
   "chainId": 1995,
   "networkId": 1995,
@@ -20,7 +20,7 @@
   "explorers": [
     {
       "name": "edexa-testnet",
-      "url": "https://explorer.testnet.edexa.com",
+      "url": "https://explorer.testnet.edexa.network",
       "standard": "EIP3091"
     }
   ]


### PR DESCRIPTION
Please review the request. We have updated RPC and explorer URL for edexa.network testnet.