### PR TITLE
Added JIBCHAIN L1 - Testnet (eip155-88991.json).

### DIFF
--- a/_data/chains/eip155-88991.json
+++ b/_data/chains/eip155-88991.json
@@ -1,0 +1,24 @@
+{
+  "name": "JIBCHAIN L1 - Testnet",
+  "chain": "JBC",
+  "rpc": ["https://rpc.testnet.jibchain.net"],
+  "faucets": [],
+  "icon": "jbc-new",
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "nativeCurrency": {
+    "name": "JIBCOIN",
+    "symbol": "tJBC",
+    "decimals": 18
+  },
+  "infoURL": "https://jibchain.net",
+  "shortName": "jbc",
+  "chainId": 88991,
+  "networkId": 88991,
+  "explorers": [
+    {
+      "name": "JIBCHAIN-Testnet Explorer",
+      "url": "https://exp.testnet.jibchain.net",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/icons/jbc-new.json
+++ b/_data/icons/jbc-new.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmfADsCczEKNaSgCV9skWigcW8zNvobWAtZtAa8SeP8sut",
+    "width": 200,
+    "height": 200,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Added JIBCHAIN L1 - Testnet (eip155-88991.json).

name: `JIBCHAIN L1 - Testnet`
icon: `jbc-new`
rpc: https://rpc.testnet.jibchain.net
explorers: https://exp.testnet.jibchain.net
