### PR TITLE
Update eip155-2043.json - Rename OriginTrail Parachain (OTP) to NeuroWeb (NEURO)

### DIFF
--- a/_data/chains/eip155-2043.json
+++ b/_data/chains/eip155-2043.json
@@ -1,18 +1,18 @@
 {
-  "name": "OriginTrail Parachain",
-  "chain": "OTP",
+  "name": "NeuroWeb",
+  "chain": "NEUROWEB",
   "rpc": [
     "https://astrosat.origintrail.network",
     "wss://parachain-rpc.origin-trail.network"
   ],
   "faucets": [],
   "nativeCurrency": {
-    "name": "OriginTrail Parachain Token",
-    "symbol": "OTP",
+    "name": "NeuroWeb Token",
+    "symbol": "NEURO",
     "decimals": 12
   },
-  "infoURL": "https://parachain.origintrail.io",
-  "shortName": "otp",
+  "infoURL": "https://neuroweb.ai",
+  "shortName": "NEURO",
   "chainId": 2043,
   "networkId": 2043
 }


### PR DESCRIPTION
OriginTrail Parachain is transformed into NeuroWeb after [a community Governance vote](https://neuroweb.subscan.io/referenda/5?tab=preimage) on OriginTrail Parachain in December 2023. Token name is changed from OTP to NEURO. Only names are changed, all technical details are same.