### PR TITLE
Add chain ID 2777 for GM Network Mainnet

### DIFF
--- a/_data/chains/eip155-2777.json
+++ b/_data/chains/eip155-2777.json
@@ -1,0 +1,16 @@
+{
+    "name": "GM Network Mainnet",
+    "chain": "GM Network Mainnet",
+    "rpc": [],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "Ether",
+      "symbol": "ETH",
+      "decimals": 18
+    },
+    "infoURL": "https://gmnetwork.ai",
+    "shortName": "gmnetwork-mainnet",
+    "chainId": 2777,
+    "networkId": 2777,
+    "explorers": []
+  }

--- a/_data/chains/eip155-2777.json
+++ b/_data/chains/eip155-2777.json
@@ -1,17 +1,17 @@
 {
-    "name": "GM Network Mainnet",
-    "chain": "GM Network Mainnet",
-    "rpc": [],
-    "faucets": [],
-    "nativeCurrency": {
-      "name": "Ether",
-      "symbol": "ETH",
-      "decimals": 18
-    },
-    "infoURL": "https://gmnetwork.ai",
-    "shortName": "gmnetwork-mainnet",
-    "chainId": 2777,
-    "networkId": 2777,
-    "explorers": [],
-    "status": "incubating"
-  }
+  "name": "GM Network Mainnet",
+  "chain": "GM Network Mainnet",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://gmnetwork.ai",
+  "shortName": "gmnetwork-mainnet",
+  "chainId": 2777,
+  "networkId": 2777,
+  "explorers": [],
+  "status": "incubating"
+}

--- a/_data/chains/eip155-2777.json
+++ b/_data/chains/eip155-2777.json
@@ -12,5 +12,6 @@
     "shortName": "gmnetwork-mainnet",
     "chainId": 2777,
     "networkId": 2777,
-    "explorers": []
+    "explorers": [],
+    "status": "incubating"
   }


### PR DESCRIPTION
Just reserve chain ID 2777 for GM Network Mainnet. 

We are still working on RPC and Explorer (Launching Mainnet).  and we will update its value ​​later next week.