### PR TITLE
Add Form testnet

### DIFF
--- a/_data/chains/eip155-132902.json
+++ b/_data/chains/eip155-132902.json
@@ -1,0 +1,43 @@
+{
+  "name": "Form Testnet",
+  "title": "Form Testnet",
+  "chain": "formtestnet",
+  "rpc": [
+    "https://testnet-rpc.form.network/http",
+    "wss://testnet-rpc.form.network/ws"
+  ],
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
+    }
+  ],
+  "faucets": ["https://info.form.network/faucet"],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://form.network/details",
+  "shortName": "formtestnet",
+  "chainId": 132902,
+  "networkId": 132902,
+  "explorers": [
+    {
+      "name": "Form Testnet explorer",
+      "url": "https://testnet-explorer.form.network",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-11155111",
+    "bridges": [
+      {
+        "url": "https://bridge.form.network/"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR aims to add Form testnet to chainlist.

prettier ran successfully
gradlew run output:

![image](https://github.com/ethereum-lists/chains/assets/11287980/76793119-a998-4190-a7f1-0cf3cfee01af)
