### PR TITLE
adding quicknode RPC & faucet urls

### DIFF
--- a/_data/chains/eip155-1.json
+++ b/_data/chains/eip155-1.json
@@ -19,7 +19,9 @@
     "https://rpc.mevblocker.io/noreverts",
     "https://rpc.mevblocker.io/fullprivacy",
     "https://eth.drpc.org",
-    "wss://eth.drpc.org"
+    "wss://eth.drpc.org",
+    "https://${QN_ENDPT_NAME}.quiknode.pro/${QN_API_KEY}",
+    "wss://${QN_ENDPT_NAME}.quiknode.pro/${QN_API_KEY}"
   ],
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "faucets": [],

--- a/_data/chains/eip155-10.json
+++ b/_data/chains/eip155-10.json
@@ -8,7 +8,9 @@
     "https://optimism.gateway.tenderly.co",
     "wss://optimism.gateway.tenderly.co",
     "https://optimism.drpc.org",
-    "wss://optimism.drpc.org"
+    "wss://optimism.drpc.org",
+    "https://${QN_ENDPT_NAME}.optimism.quiknode.pro/${QN_API_KEY}",
+    "wss://${QN_ENDPT_NAME}.optimism.quiknode.pro/${QN_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-100.json
+++ b/_data/chains/eip155-100.json
@@ -14,7 +14,9 @@
     "https://gnosis.oat.farm",
     "wss://rpc.gnosischain.com/wss",
     "https://gnosis-rpc.publicnode.com",
-    "wss://gnosis-rpc.publicnode.com"
+    "wss://gnosis-rpc.publicnode.com",
+    "https://${QN_ENDPT_NAME}.xdai.quiknode.pro/${QN_API_KEY}",
+    "wss://${QN_ENDPT_NAME}.xdai.quiknode.pro/${QN_API_KEY}"
   ],
   "faucets": [
     "https://gnosisfaucet.com",

--- a/_data/chains/eip155-1101.json
+++ b/_data/chains/eip155-1101.json
@@ -5,7 +5,9 @@
   "rpc": [
     "https://zkevm-rpc.com",
     "https://polygon-zkevm.drpc.org",
-    "wss://polygon-zkevm.drpc.org"
+    "wss://polygon-zkevm.drpc.org",
+    "https://${QN_ENDPT_NAME}.zkevm-mainnet.quiknode.pro/${QN_API_KEY}",
+    "wss://${QN_ENDPT_NAME}.zkevm-mainnet.quiknode.pro/${QN_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-11155111.json
+++ b/_data/chains/eip155-11155111.json
@@ -17,7 +17,10 @@
     "wss://sepolia.drpc.org",
     "https://rpc-sepolia.rockx.com"
   ],
-  "faucets": ["http://fauceth.komputing.org?chain=11155111&address=${ADDRESS}"],
+  "faucets": [
+    "http://fauceth.komputing.org?chain=11155111&address=${ADDRESS}",
+    "https://faucet.quicknode.com/ethereum/sepolia"
+  ],
   "nativeCurrency": {
     "name": "Sepolia Ether",
     "symbol": "ETH",

--- a/_data/chains/eip155-1329.json
+++ b/_data/chains/eip155-1329.json
@@ -1,7 +1,12 @@
 {
   "name": "Sei Network",
   "chain": "Sei",
-  "rpc": ["https://evm-rpc.sei-apis.com", "wss://evm-ws.sei-apis.com"],
+  "rpc": [
+    "https://evm-rpc.sei-apis.com",
+    "wss://evm-ws.sei-apis.com",
+    "https://${QN_ENDPT_NAME}.sei-pacific.quiknode.pro/${QN_API_KEY}",
+    "wss://${QN_ENDPT_NAME}.sei-pacific.quiknode.pro/${QN_API_KEY}"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Sei",

--- a/_data/chains/eip155-13371.json
+++ b/_data/chains/eip155-13371.json
@@ -4,7 +4,9 @@
   "rpc": [
     "https://rpc.immutable.com",
     "https://immutable-zkevm.drpc.org",
-    "wss://immutable-zkevm.drpc.org"
+    "wss://immutable-zkevm.drpc.org",
+    "https://${QN_ENDPT_NAME}.imx.quiknode.pro/${QN_API_KEY}",
+    "wss://${QN_ENDPT_NAME}.imx.quiknode.pro/${QN_API_KEY}"
   ],
   "faucets": ["https://docs.immutable.com/docs/zkEVM/guides/faucet"],
   "nativeCurrency": {

--- a/_data/chains/eip155-137.json
+++ b/_data/chains/eip155-137.json
@@ -14,7 +14,9 @@
     "https://polygon.gateway.tenderly.co",
     "wss://polygon.gateway.tenderly.co",
     "https://polygon.drpc.org",
-    "wss://polygon.drpc.org"
+    "wss://polygon.drpc.org",
+    "https://${QN_ENDPT_NAME}.matic.quiknode.pro/${QN_API_KEY}",
+    "wss://${QN_ENDPT_NAME}.matic.quiknode.pro/${QN_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-1442.json
+++ b/_data/chains/eip155-1442.json
@@ -7,7 +7,7 @@
     "https://polygon-zkevm-testnet.drpc.org",
     "wss://polygon-zkevm-testnet.drpc.org"
   ],
-  "faucets": [],
+  "faucets": ["https://faucet.quicknode.com/polygon/zkevm-goerli"],
   "nativeCurrency": {
     "name": "Ether",
     "symbol": "ETH",

--- a/_data/chains/eip155-17000.json
+++ b/_data/chains/eip155-17000.json
@@ -12,7 +12,8 @@
   ],
   "faucets": [
     "https://faucet.holesky.ethpandaops.io",
-    "https://holesky-faucet.pk910.de"
+    "https://holesky-faucet.pk910.de",
+    "https://faucet.quicknode.com/ethereum/holesky"
   ],
   "nativeCurrency": {
     "name": "Testnet ETH",

--- a/_data/chains/eip155-238.json
+++ b/_data/chains/eip155-238.json
@@ -2,7 +2,11 @@
   "name": "Blast Mainnet",
   "chain": "ETH",
   "icon": "blastIcon",
-  "rpc": ["https://rpc.blastblockchain.com"],
+  "rpc": [
+    "https://rpc.blastblockchain.com",
+    "https://${QN_ENDPT_NAME}.blast-mainnet.quiknode.pro/${QN_API_KEY}",
+    "wss://${QN_ENDPT_NAME}.blast-mainnet.quiknode.pro/${QN_API_KEY}"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",

--- a/_data/chains/eip155-250.json
+++ b/_data/chains/eip155-250.json
@@ -6,7 +6,9 @@
     "https://fantom-rpc.publicnode.com",
     "wss://fantom-rpc.publicnode.com",
     "https://fantom.drpc.org",
-    "wss://fantom.drpc.org"
+    "wss://fantom.drpc.org",
+    "https://${QN_ENDPT_NAME}.fantom.quiknode.pro/${QN_API_KEY}",
+    "wss://${QN_ENDPT_NAME}.fantom.quiknode.pro/${QN_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-280.json
+++ b/_data/chains/eip155-280.json
@@ -3,7 +3,7 @@
   "status": "deprecated",
   "chain": "ETH",
   "rpc": ["https://testnet.era.zksync.dev"],
-  "faucets": [],
+  "faucets": ["https://faucet.quicknode.com/zksync/goerli"],
   "nativeCurrency": {
     "name": "Ether",
     "symbol": "ETH",

--- a/_data/chains/eip155-300.json
+++ b/_data/chains/eip155-300.json
@@ -6,7 +6,7 @@
     "https://zksync-sepolia.drpc.org",
     "wss://zksync-sepolia.drpc.org"
   ],
-  "faucets": [],
+  "faucets": ["https://faucet.quicknode.com/zksync/sepolia"],
   "nativeCurrency": {
     "name": "Ether",
     "symbol": "ETH",

--- a/_data/chains/eip155-324.json
+++ b/_data/chains/eip155-324.json
@@ -4,7 +4,9 @@
   "rpc": [
     "https://mainnet.era.zksync.io",
     "https://zksync.drpc.org",
-    "wss://zksync.drpc.org"
+    "wss://zksync.drpc.org",
+    "https://${QN_ENDPT_NAME}.zksync-mainnet.quiknode.pro/${QN_API_KEY}",
+    "wss://${QN_ENDPT_NAME}.zksync-mainnet.quiknode.pro/${QN_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-37714555429.json
+++ b/_data/chains/eip155-37714555429.json
@@ -10,7 +10,7 @@
     "decimals": 18
   },
   "rpc": ["https://testnet-v2.xai-chain.net/rpc"],
-  "faucets": [],
+  "faucets": ["https://faucet.quicknode.com/xai/sepolia"],
   "explorers": [
     {
       "name": "Blockscout",

--- a/_data/chains/eip155-397.json
+++ b/_data/chains/eip155-397.json
@@ -1,7 +1,10 @@
 {
   "name": "Near Mainnet",
   "chain": "NEAR",
-  "rpc": [],
+  "rpc": [
+    "https://${QN_ENDPT_NAME}.near-mainnet.quiknode.pro/${QN_API_KEY}",
+    "wss://${QN_ENDPT_NAME}.near-mainnet.quiknode.pro/${QN_API_KEY}"
+  ],
   "icon": "near",
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-420.json
+++ b/_data/chains/eip155-420.json
@@ -10,7 +10,7 @@
     "https://optimism-testnet.drpc.org",
     "wss://optimism-testnet.drpc.org"
   ],
-  "faucets": [],
+  "faucets": ["https://faucet.quicknode.com/optimism"],
   "nativeCurrency": {
     "name": "Goerli Ether",
     "symbol": "ETH",

--- a/_data/chains/eip155-42161.json
+++ b/_data/chains/eip155-42161.json
@@ -14,7 +14,9 @@
     "https://arb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}",
     "https://arb1.arbitrum.io/rpc",
     "https://arbitrum-one.publicnode.com",
-    "wss://arbitrum-one.publicnode.com"
+    "wss://arbitrum-one.publicnode.com",
+    "https://${QN_ENDPT_NAME}.arbitrum-mainnet.quiknode.pro/${QN_API_KEY}",
+    "wss://${QN_ENDPT_NAME}.arbitrum-mainnet.quiknode.pro/${QN_API_KEY}"
   ],
   "faucets": [],
   "explorers": [

--- a/_data/chains/eip155-421613.json
+++ b/_data/chains/eip155-421613.json
@@ -16,7 +16,7 @@
     "https://arbitrum-goerli.publicnode.com",
     "wss://arbitrum-goerli.publicnode.com"
   ],
-  "faucets": [],
+  "faucets": ["https://faucet.quicknode.com/arbitrum"],
   "infoURL": "https://arbitrum.io/",
   "explorers": [
     {

--- a/_data/chains/eip155-42170.json
+++ b/_data/chains/eip155-42170.json
@@ -12,7 +12,9 @@
   "rpc": [
     "https://nova.arbitrum.io/rpc",
     "https://arbitrum-nova.publicnode.com",
-    "wss://arbitrum-nova.publicnode.com"
+    "wss://arbitrum-nova.publicnode.com",
+    "https://${QN_ENDPT_NAME}.nova-mainnet.quiknode.pro/${QN_API_KEY}",
+    "wss://${QN_ENDPT_NAME}.nova-mainnet.quiknode.pro/${QN_API_KEY}"
   ],
   "faucets": [],
   "explorers": [

--- a/_data/chains/eip155-42220.json
+++ b/_data/chains/eip155-42220.json
@@ -9,7 +9,12 @@
     "symbol": "CELO",
     "decimals": 18
   },
-  "rpc": ["https://forno.celo.org", "wss://forno.celo.org/ws"],
+  "rpc": [
+    "https://forno.celo.org",
+    "wss://forno.celo.org/ws",
+    "https://${QN_ENDPT_NAME}.celo-mainnet.quiknode.pro/${QN_API_KEY}",
+    "wss://${QN_ENDPT_NAME}.celo-mainnet.quiknode.pro/${QN_API_KEY}"
+  ],
   "faucets": [],
   "infoURL": "https://docs.celo.org/",
   "explorers": [

--- a/_data/chains/eip155-43113.json
+++ b/_data/chains/eip155-43113.json
@@ -7,7 +7,10 @@
     "https://avalanche-fuji-c-chain-rpc.publicnode.com",
     "wss://avalanche-fuji-c-chain-rpc.publicnode.com"
   ],
-  "faucets": ["https://faucet.avax-test.network/"],
+  "faucets": [
+    "https://faucet.avax-test.network/",
+    "https://faucet.quicknode.com/avalanche/fuji"
+  ],
   "nativeCurrency": {
     "name": "Avalanche",
     "symbol": "AVAX",

--- a/_data/chains/eip155-43114.json
+++ b/_data/chains/eip155-43114.json
@@ -5,7 +5,9 @@
   "rpc": [
     "https://api.avax.network/ext/bc/C/rpc",
     "https://avalanche-c-chain-rpc.publicnode.com",
-    "wss://avalanche-c-chain-rpc.publicnode.com"
+    "wss://avalanche-c-chain-rpc.publicnode.com",
+    "https://${QN_ENDPT_NAME}.avalanche-mainnet.quiknode.pro/${QN_API_KEY}/ext/bc/C/rpc/",
+    "wss://${QN_ENDPT_NAME}.avalanche-mainnet.quiknode.pro/${QN_API_KEY}/ext/bc/C/rpc/"
   ],
   "features": [{ "name": "EIP1559" }],
   "faucets": [],

--- a/_data/chains/eip155-5.json
+++ b/_data/chains/eip155-5.json
@@ -14,7 +14,8 @@
   "faucets": [
     "http://fauceth.komputing.org?chain=5&address=${ADDRESS}",
     "https://goerli-faucet.slock.it?address=${ADDRESS}",
-    "https://faucet.goerli.mudit.blog"
+    "https://faucet.goerli.mudit.blog",
+    "https://faucet.quicknode.com/ethereum/goerli"
   ],
   "nativeCurrency": {
     "name": "Goerli Ether",

--- a/_data/chains/eip155-5000.json
+++ b/_data/chains/eip155-5000.json
@@ -5,7 +5,9 @@
   "rpc": [
     "https://rpc.mantle.xyz",
     "https://mantle-rpc.publicnode.com",
-    "wss://mantle-rpc.publicnode.com"
+    "wss://mantle-rpc.publicnode.com",
+    "https://${QN_ENDPT_NAME}.mantle-mainnet.quiknode.pro/${QN_API_KEY}",
+    "wss://${QN_ENDPT_NAME}.mantle-mainnet.quiknode.pro/${QN_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-534351.json
+++ b/_data/chains/eip155-534351.json
@@ -8,7 +8,7 @@
     "https://scroll-sepolia.chainstacklabs.com",
     "https://scroll-testnet-public.unifra.io"
   ],
-  "faucets": [],
+  "faucets": ["https://faucet.quicknode.com/scroll/sepolia"],
   "nativeCurrency": {
     "name": "Ether",
     "symbol": "ETH",

--- a/_data/chains/eip155-534352.json
+++ b/_data/chains/eip155-534352.json
@@ -5,7 +5,9 @@
   "rpc": [
     "https://rpc.scroll.io",
     "https://rpc.ankr.com/scroll",
-    "https://scroll-mainnet.chainstacklabs.com"
+    "https://scroll-mainnet.chainstacklabs.com",
+    "https://${QN_ENDPT_NAME}.scroll-mainnet.quiknode.pro/${QN_API_KEY}",
+    "wss://${QN_ENDPT_NAME}.scroll-mainnet.quiknode.pro/${QN_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-56.json
+++ b/_data/chains/eip155-56.json
@@ -16,7 +16,9 @@
     "https://bsc-dataseed4.ninicoin.io",
     "https://bsc-rpc.publicnode.com",
     "wss://bsc-rpc.publicnode.com",
-    "wss://bsc-ws-node.nariox.org"
+    "wss://bsc-ws-node.nariox.org",
+    "https://${QN_ENDPT_NAME}.bsc.quiknode.pro/${QN_API_KEY}",
+    "wss://${QN_ENDPT_NAME}.bsc.quiknode.pro/${QN_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-660279.json
+++ b/_data/chains/eip155-660279.json
@@ -9,7 +9,11 @@
     "symbol": "XAI",
     "decimals": 18
   },
-  "rpc": ["https://xai-chain.net/rpc"],
+  "rpc": [
+    "https://xai-chain.net/rpc",
+    "https://${QN_ENDPT_NAME}.xai-mainnet.quiknode.pro/${QN_API_KEY}",
+    "wss://${QN_ENDPT_NAME}.xai-mainnet.quiknode.pro/${QN_API_KEY}"
+  ],
   "faucets": [],
   "explorers": [
     {

--- a/_data/chains/eip155-747.json
+++ b/_data/chains/eip155-747.json
@@ -1,7 +1,11 @@
 {
   "name": "Mainnet",
   "chain": "Flow",
-  "rpc": ["https://mainnet.evm.nodes.onflow.org"],
+  "rpc": [
+    "https://mainnet.evm.nodes.onflow.org",
+    "https://${QN_ENDPT_NAME}.flow-mainnet.quiknode.pro/${QN_API_KEY}",
+    "wss://${QN_ENDPT_NAME}.flow-mainnet.quiknode.pro/${QN_API_KEY}"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "FLOW",

--- a/_data/chains/eip155-7560.json
+++ b/_data/chains/eip155-7560.json
@@ -5,7 +5,9 @@
     "https://cyber.alt.technology/",
     "wss://cyber-ws.alt.technology/",
     "https://rpc.cyber.co/",
-    "wss://rpc.cyber.co/"
+    "wss://rpc.cyber.co/",
+    "https://${QN_ENDPT_NAME}.cyber-mainnet.quiknode.pro/${QN_API_KEY}",
+    "wss://${QN_ENDPT_NAME}.cyber-mainnet.quiknode.pro/${QN_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-80001.json
+++ b/_data/chains/eip155-80001.json
@@ -10,7 +10,10 @@
     "https://polygon-mumbai.gateway.tenderly.co",
     "wss://polygon-mumbai.gateway.tenderly.co"
   ],
-  "faucets": ["https://faucet.polygon.technology/"],
+  "faucets": [
+    "https://faucet.polygon.technology/",
+    "https://faucet.quicknode.com/polygon/mumbai"
+  ],
   "nativeCurrency": {
     "name": "MATIC",
     "symbol": "MATIC",

--- a/_data/chains/eip155-80002.json
+++ b/_data/chains/eip155-80002.json
@@ -8,7 +8,10 @@
     "https://polygon-amoy-bor-rpc.publicnode.com",
     "wss://polygon-amoy-bor-rpc.publicnode.com"
   ],
-  "faucets": ["https://faucet.polygon.technology/"],
+  "faucets": [
+    "https://faucet.polygon.technology/",
+    "https://faucet.quicknode.com/polygon/amoy"
+  ],
   "nativeCurrency": {
     "name": "MATIC",
     "symbol": "MATIC",

--- a/_data/chains/eip155-80085.json
+++ b/_data/chains/eip155-80085.json
@@ -5,7 +5,10 @@
     "https://artio.rpc.berachain.com",
     "https://rpc.ankr.com/berachain_testnet"
   ],
-  "faucets": ["https://artio.faucet.berachain.com"],
+  "faucets": [
+    "https://artio.faucet.berachain.com",
+    "https://faucet.quicknode.com/berachain/artio"
+  ],
   "nativeCurrency": {
     "name": "BERA Token",
     "symbol": "BERA",

--- a/_data/chains/eip155-8453.json
+++ b/_data/chains/eip155-8453.json
@@ -7,7 +7,9 @@
     "https://base.gateway.tenderly.co",
     "wss://base.gateway.tenderly.co",
     "https://base-rpc.publicnode.com",
-    "wss://base-rpc.publicnode.com"
+    "wss://base-rpc.publicnode.com",
+    "https://${QN_ENDPT_NAME}.base-mainnet.quiknode.pro/${QN_API_KEY}",
+    "wss://${QN_ENDPT_NAME}.base-mainnet.quiknode.pro/${QN_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-84531.json
+++ b/_data/chains/eip155-84531.json
@@ -8,7 +8,10 @@
     "https://base-goerli-rpc.publicnode.com",
     "wss://base-goerli-rpc.publicnode.com"
   ],
-  "faucets": ["https://www.coinbase.com/faucets/base-ethereum-goerli-faucet"],
+  "faucets": [
+    "https://www.coinbase.com/faucets/base-ethereum-goerli-faucet",
+    "https://faucet.quicknode.com/base/goerli"
+  ],
   "nativeCurrency": {
     "name": "Goerli Ether",
     "symbol": "ETH",

--- a/_data/chains/eip155-84532.json
+++ b/_data/chains/eip155-84532.json
@@ -6,7 +6,7 @@
     "https://base-sepolia-rpc.publicnode.com",
     "wss://base-sepolia-rpc.publicnode.com"
   ],
-  "faucets": [],
+  "faucets": ["https://faucet.quicknode.com/base/sepolia"],
   "nativeCurrency": {
     "name": "Sepolia Ether",
     "symbol": "ETH",

--- a/_data/chains/eip155-97.json
+++ b/_data/chains/eip155-97.json
@@ -11,7 +11,10 @@
     "https://bsc-testnet-rpc.publicnode.com",
     "wss://bsc-testnet-rpc.publicnode.com"
   ],
-  "faucets": ["https://testnet.bnbchain.org/faucet-smart"],
+  "faucets": [
+    "https://testnet.bnbchain.org/faucet-smart",
+    "https://faucet.quicknode.com/binance-smart-chain/bnb-testnet"
+  ],
   "nativeCurrency": {
     "name": "BNB Chain Native Token",
     "symbol": "tBNB",


### PR DESCRIPTION
Adding RPC URLs for all mainnet chains supported via QuickNode RPC as well as faucet URLs for the chains supported via QuickNode faucet.