### PR TITLE
add cuckoo network / cuckoo ai testnet sepolia

### DIFF
--- a/_data/chains/eip155-1210.json
+++ b/_data/chains/eip155-1210.json
@@ -1,0 +1,27 @@
+{
+  "name": "Cuckoo Sepolia",
+  "title": "Cuckoo AI Testnet Sepolia",
+  "chain": "CuckooAI",
+  "icon": "cuckoo-ai",
+  "rpc": [
+    "https://testnet-rpc.cuckoo.network",
+    "wss://testnet-rpc.cuckoo.network"
+  ],
+  "faucets": ["https://cuckoo.network/portal/faucet/"],
+  "nativeCurrency": {
+    "name": "CuckooAI",
+    "symbol": "CAI",
+    "decimals": 18
+  },
+  "infoURL": "https://cuckoo.network",
+  "shortName": "caisepolia",
+  "chainId": 1210,
+  "networkId": 1210,
+  "explorers": [
+    {
+      "name": "Cuckoo Sepolia Explorer",
+      "url": "https://testnet-scan.cuckoo.network",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/icons/cuckoo-ai.json
+++ b/_data/icons/cuckoo-ai.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmZjVDfk56DjqkCPymaweJJaj9ASGjjgcwJ95XsFDzj9us",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
### Description

This pull request adds the [Cuckoo Network](https://cuckoo.network)'s Testnet Sepolia to the chains registration. The explorer is available at [testnet-scan.cuckoo.network](https://testnet-scan.cuckoo.network/) and is EIP3091-compliant with blockscout.

### Additional Notes

Please review the changes and let me know if any adjustments are needed. Your feedback is highly appreciated.

Thank you for considering this pull request. I look forward to your positive response!

Best regards,
Lark