### PR TITLE
add cuckoo chain mainnet

### DIFF
--- a/_data/chains/eip155-1200.json
+++ b/_data/chains/eip155-1200.json
@@ -1,0 +1,27 @@
+{
+  "name": "Cuckoo Chain",
+  "title": "Cuckoo Chain",
+  "chain": "CuckooAI",
+  "icon": "cuckoo-ai",
+  "rpc": [
+    "https://mainnet-rpc.cuckoo.network",
+    "wss://mainnet-rpc.cuckoo.network"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "CuckooAI",
+    "symbol": "CAI",
+    "decimals": 18
+  },
+  "infoURL": "https://cuckoo.network",
+  "shortName": "cai",
+  "chainId": 1200,
+  "networkId": 1200,
+  "explorers": [
+    {
+      "name": "Cuckoo Chain Explorer",
+      "url": "https://mainnet-scan.cuckoo.network",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

This pull request adds the [Cuckoo Network](https://cuckoo.network/)'s mainnet to the chains registration. The explorer is available at [mainnet-scan.cuckoo.network](https://mainnet-scan.cuckoo.network/) and is EIP3091-compliant with blockscout.

## Additional Notes

Please review the changes and let me know if any adjustments are needed. Your feedback is highly appreciated.

Thank you for considering this pull request. I look forward to your positive response!

Best regards,
Lark