### PR TITLE
Update Crab network explorer link

### DIFF
--- a/_data/chains/eip155-44.json
+++ b/_data/chains/eip155-44.json
@@ -17,8 +17,8 @@
   "networkId": 44,
   "explorers": [
     {
-      "name": "subscan",
-      "url": "https://crab.subscan.io",
+      "name": "blockscout",
+      "url": "https://crab-scan.darwinia.network",
       "standard": "EIP3091"
     }
   ]


### PR DESCRIPTION
The original explorer will be replaced with a new one, update the link here.