### PR TITLE
Add new zilliqa 2 proto-testnet network

### DIFF
--- a/_data/chains/eip155-33102.json
+++ b/_data/chains/eip155-33102.json
@@ -1,0 +1,23 @@
+{
+  "name": "Zilliqa 2 EVM proto-testnet",
+  "chain": "ZIL",
+  "rpc": ["https://api.zq2-prototestnet.zilliqa.com"],
+  "faucets": ["https://faucet.zq2-prototestnet.zilliqa.com"],
+  "nativeCurrency": {
+    "name": "Zilliqa",
+    "symbol": "ZIL",
+    "decimals": 18
+  },
+  "infoURL": "https://www.zilliqa.com/",
+  "shortName": "zq2-proto-testnet",
+  "chainId": 33102,
+  "networkId": 33102,
+  "icon": "zilliqa",
+  "explorers": [
+    {
+      "name": "Zilliqa 2 EVM proto-testnet explorer",
+      "url": "https://explorer.zq2-prototestnet.zilliqa.com",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-33103.json
+++ b/_data/chains/eip155-33103.json
@@ -10,8 +10,8 @@
   },
   "infoURL": "https://www.zilliqa.com/",
   "shortName": "zq2-proto-testnet",
-  "chainId": 33102,
-  "networkId": 33102,
+  "chainId": 33103,
+  "networkId": 33103,
   "icon": "zilliqa",
   "explorers": [
     {


### PR DESCRIPTION
The PR adds a new Zilliqa 2 proto-testnet network to chainlist.