### PR TITLE
Add Chips Network to Chainlist

### DIFF
--- a/_data/chains/eip155-2882.json
+++ b/_data/chains/eip155-2882.json
@@ -1,0 +1,17 @@
+{
+  "name": "Chips Network",
+  "chain": "CHIPS",
+  "rpc": [
+    "https://node.chips.chat/wasp/api/v1/chains/iota1pqd4jhzzsv5pxn68mczpdxma55h8heqp6lyn3d734h8p79uvjehewc9zq0d/evm"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "IOTA",
+    "symbol": "IOTA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.chips.chat",
+  "shortName": "chips",
+  "chainId": 2882,
+  "networkId": 2882
+}


### PR DESCRIPTION
This pull request adds the Chips Network to the Chainlist.

- Name: Chips Network
- Chain: CHIPS
- RPC: https://node.chips.chat/wasp/api/v1/chains/iota1pqd4jhzzsv5pxn68mczpdxma55h8heqp6lyn3d734h8p79uvjehewc9zq0d/evm
- Native Currency: IOTA (symbol: IOTA, decimals: 18)
- Info URL: https://www.chips.chat
- Short Name: chips
- Chain ID: 2882
- Network ID: 2882