### PR TITLE
add mantlescan to mantle

### DIFF
--- a/_data/chains/eip155-5000.json
+++ b/_data/chains/eip155-5000.json
@@ -19,6 +19,11 @@
   "networkId": 5000,
   "explorers": [
     {
+      "name": "mantlescan",
+      "url": "https://mantlescan.xyz/",
+      "standard": "EIP3091"
+    },
+    {
       "name": "Mantle Explorer",
       "url": "https://explorer.mantle.xyz",
       "standard": "EIP3091"


### PR DESCRIPTION
Mantle now has a new official explorer powered by Etherscan, this PR goal is to update chainlist.org details on this.

https://mantlescan.xyz/
 