### PR TITLE
Update eip155-360.json

### DIFF
--- a/_data/chains/eip155-360.json
+++ b/_data/chains/eip155-360.json
@@ -1,16 +1,22 @@
 {
-  "name": "Shape",
-  "chain": "ETH",
-  "rpc": [],
+  "name": "Molten Mainnet",
+  "chain": "Molten",
+  "rpc": ["https://molten.calderachain.xyz/http", "wss://molten.calderachain.xyz/ws"],
   "faucets": [],
   "nativeCurrency": {
-    "name": "Ether",
-    "symbol": "ETH",
+    "name": "Molten",
+    "symbol": "MOLTEN",
     "decimals": 18
   },
-  "infoURL": "https://shape.us",
-  "shortName": "shape",
+  "infoURL": "https://www.moltennetwork.com/",
+  "shortName": "molten",
   "chainId": 360,
   "networkId": 360,
-  "status": "incubating"
+  "explorers": [
+    {
+      "name": "Molten Explorer",
+      "url": "https://molten.calderaexplorer.xyz/",
+      "standard": "EIP3091"
+    }
+  ]
 }


### PR DESCRIPTION
the existing config for chain 360 does not exist nor is it live. The site leads to a deadlink and its project is in testnet only on chainid  11011. 

Molten Network has been live and operating (with daily usage) with 360 as its chainid for multiple months long before chain 360 was added to this list.

This is not a case of "our chain is better and the other isnt", rather the existing details for eip155-360 are just filler material for when it does go live. ChainID 360 is already live, taken, and has network usage from users on its mainnet. This PR means to replace the existing config with a network that is currently live with users for eip155-360 rather than one that is going to potentially launch sometime in the distant future.