### PR TITLE
Create new Neo X testnet (t4) and set deprecated to old Neo X testnet

### DIFF
--- a/_data/chains/eip155-12227331.json
+++ b/_data/chains/eip155-12227331.json
@@ -1,5 +1,5 @@
 {
-  "name": "NeoX Testnet",
+  "name": "NeoX Testnet T3",
   "chain": "NeoX",
   "rpc": ["https://testnet.rpc.banelabs.org/"],
   "faucets": [],
@@ -20,5 +20,5 @@
       "standard": "EIP3091"
     }
   ],
-  "status": "active"
+  "status": "deprecated"
 }

--- a/_data/chains/eip155-12227331.json
+++ b/_data/chains/eip155-12227331.json
@@ -10,8 +10,8 @@
   },
   "infoURL": "https://neo.org/",
   "shortName": "neox",
-  "chainId": 12227332,
-  "networkId": 12227332,
+  "chainId": 12227331,
+  "networkId": 12227331,
   "icon": "neox",
   "explorers": [
     {

--- a/_data/chains/eip155-12227331.json
+++ b/_data/chains/eip155-12227331.json
@@ -1,7 +1,7 @@
 {
   "name": "NeoX Testnet T3",
   "chain": "NeoX",
-  "rpc": ["https://testnet.rpc.banelabs.org/"],
+  "rpc": ["https://neoxseed1.ngd.network/"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Gas",

--- a/_data/chains/eip155-12227332.json
+++ b/_data/chains/eip155-12227332.json
@@ -1,0 +1,24 @@
+{
+"name": "NeoX Testnet T4",
+"chain": "NeoX",
+"rpc": ["https://testnet.rpc.banelabs.org/"],
+"faucets": [],
+"nativeCurrency": {
+  "name": "Gas",
+  "symbol": "GAS",
+  "decimals": 18
+},
+"infoURL": "https://neo.org/",
+"shortName": "neox",
+"chainId": 12227332,
+"networkId": 12227332,
+"icon": "neox",
+"explorers": [
+  {
+    "name": "neox-scan",
+    "url": "https://testnet.scan.banelabs.org",
+    "standard": "EIP3091"
+  }
+],
+"status": "active"
+}

--- a/_data/chains/eip155-12227332.json
+++ b/_data/chains/eip155-12227332.json
@@ -10,8 +10,8 @@
   },
   "infoURL": "https://neo.org/",
   "shortName": "neox",
-  "chainId": 12227331,
-  "networkId": 12227331,
+  "chainId": 12227332,
+  "networkId": 12227332,
   "icon": "neox",
   "explorers": [
     {


### PR DESCRIPTION
This is hopefully the last hardfork the Neo X Testnet will have before mainnet. That's why I'm changing the network/chain Id.