### PR TITLE
Deprecate Neo X testnet T3

### DIFF
--- a/_data/chains/eip155-12227331.json
+++ b/_data/chains/eip155-12227331.json
@@ -1,7 +1,7 @@
 {
-  "name": "NeoX Testnet",
+  "name": "NeoX Testnet T3",
   "chain": "NeoX",
-  "rpc": ["https://testnet.rpc.banelabs.org/"],
+  "rpc": ["https://neoxseed1.ngd.network/"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Gas",
@@ -20,5 +20,5 @@
       "standard": "EIP3091"
     }
   ],
-  "status": "active"
+  "status": "deprecated"
 }


### PR DESCRIPTION
Just deprecating a testnet.

I will create another PR to add a new chainId.