### PR TITLE
Add NeoX Testnet T4

### DIFF
--- a/_data/chains/eip155-12227332.json
+++ b/_data/chains/eip155-12227332.json
@@ -9,7 +9,7 @@
     "decimals": 18
   },
   "infoURL": "https://neo.org/",
-  "shortName": "neox",
+  "shortName": "neox-t4",
   "chainId": 12227332,
   "networkId": 12227332,
   "icon": "neox",

--- a/_data/chains/eip155-12227332.json
+++ b/_data/chains/eip155-12227332.json
@@ -1,0 +1,24 @@
+{
+  "name": "NeoX Testnet T4",
+  "chain": "NeoX",
+  "rpc": ["https://testnet.rpc.banelabs.org/"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Gas",
+    "symbol": "GAS",
+    "decimals": 18
+  },
+  "infoURL": "https://neo.org/",
+  "shortName": "neox",
+  "chainId": 12227332,
+  "networkId": 12227332,
+  "icon": "neox",
+  "explorers": [
+    {
+      "name": "neox-scan",
+      "url": "https://testnet.scan.banelabs.org",
+      "standard": "EIP3091"
+    }
+  ],
+  "status": "active"
+}


### PR DESCRIPTION
We deprecated our previous testnet T3 here: #5485 

This PR adds a new chainId/networkId for testnet T4 (which should be the last testnet before mainnet).
