### PR TITLE
Adding Cronos zkEVM mainnet

### DIFF
--- a/_data/eip155-388.json
+++ b/_data/eip155-388.json
@@ -1,0 +1,22 @@
+{
+  "name": "Cronos zkEVM Mainnet",
+  "chain": "CronosZkEVMMainnet",
+  "rpc": ["https://mainnet.zkevm.cronos.org"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Cronos zkEVM CRO",
+    "symbol": "zkCRO",
+    "decimals": 18
+  },
+  "infoURL": "https://cronos.org/zkevm",
+  "shortName": "zkCRO",
+  "chainId": 388,
+  "networkId": 388,
+  "explorers": [
+    {
+      "name": "Cronos zkEVM (Mainnet) Chain Explorer",
+      "url": "https://explorer.zkevm.cronos.org",
+      "standard": "none"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds Cronos zkEVM mainnet (chain ID `388`) ahead of the mainnet deployment.
RPCs and explorers will be functional after the mainnet is live.

Details about Cronos zkEVM:
- [Documentation](https://docs-zkevm.cronos.org/)
- [GitHub Repo](https://github.com/cronos-labs/cronos-zkevm)