### PR TITLE
Update eip155-2014.json

### DIFF
--- a/_data/chains/eip155-2014.json
+++ b/_data/chains/eip155-2014.json
@@ -1,9 +1,9 @@
 {
-  "name": "NOW Chain",
+  "name": "NOW Chain Testnet",
   "chain": "NOW",
   "icon": "nowchain",
-  "rpc": ["https://rpc.nowscan.io"],
-  "faucets": [],
+  "rpc": ["https://rpc-testnet.nowscan.io"],
+  "faucets": ["https://faucet.nowchain.co"],
   "nativeCurrency": {
     "name": "NOW Coin",
     "symbol": "NOW",
@@ -16,7 +16,7 @@
   "explorers": [
     {
       "name": "nowscan",
-      "url": "https://nowscan.io",
+      "url": "https://testnet.nowscan.io",
       "standard": "EIP3091"
     }
   ]


### PR DESCRIPTION
Update NOW Chain Details for Testnet Transition
- Changed RPC endpoint from `https://rpc.nowscan.io` to "https://rpc-testnet.nowscan.io".
- Updated explorer URL from `https://nowscan.io` to "https://testnet.nowscan.io".
- Add NOW faucet URL : "https://faucet.nowchain.co"