### PR TITLE
Add Aleph Zero EVM Mainnet

### DIFF
--- a/_data/chains/eip155-41455.json
+++ b/_data/chains/eip155-41455.json
@@ -1,0 +1,27 @@
+{
+  "name": "Aleph Zero EVM",
+  "chain": "Aleph Zero EVM",
+  "icon": "aleph-zero",
+  "rpc": [
+    "https://rpc.alephzero.raas.gelato.cloud",
+    "wss://ws.alephzero.raas.gelato.cloud"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Aleph Zero",
+    "symbol": "AZERO",
+    "decimals": 18
+  },
+  "infoURL": "https://alephzero.org/",
+  "shortName": "aleph-zero",
+  "chainId": 41455,
+  "networkId": 41455,
+  "explorers": [
+    {
+      "name": "Aleph Zero EVM Mainnet Explorer",
+      "url": "https://evm-explorer.alephzero.org",
+      "icon": "aleph-zero",
+      "standard": "none"
+    }
+  ]
+}

--- a/_data/icons/aleph-zero.json
+++ b/_data/icons/aleph-zero.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmUmw7yJDdkTV6SNp5PDfMLe5LWMfUo6vyQbh7fdhTfGDH",
+    "width": 200,
+    "height": 200,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
This PR adds the Aleph Zero EVM Mainnet to the Chainlist.

- Name: Aleph Zero EVM
- RPC: https://rpc.alephzero.raas.gelato.cloud
- Chain ID: 41455
- Currency symbol: AZERO
- Explorer: https://evm-explorer.alephzero.org

Please let me know if any changes are needed. Thank you!