### PR TITLE
Add RPC endpoint for Neo X Mainnet

### DIFF
--- a/_data/chains/eip155-47763.json
+++ b/_data/chains/eip155-47763.json
@@ -1,7 +1,10 @@
 {
   "name": "Neo X Mainnet",
   "chain": "Neo X",
-  "rpc": ["https://mainnet-1.rpc.banelabs.org"],
+  "rpc": [
+    "https://mainnet-1.rpc.banelabs.org",
+    "https://mainnet-2.rpc.banelabs.org"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Gas",


### PR DESCRIPTION
Adding a second RPC endpoint to the `Neo X Mainnet` chain data that has initially been added in #5560.