### PR TITLE
Updated KLAY Ticker

### DIFF
--- a/_data/chains/eip155-1001.json
+++ b/_data/chains/eip155-1001.json
@@ -5,7 +5,7 @@
   "faucets": ["https://faucet.kaia.io"],
   "nativeCurrency": {
     "name": "KAIA",
-    "symbol": "KAIA",
+    "symbol": "KLAY",
     "decimals": 18
   },
   "infoURL": "https://kaia.io/",

--- a/_data/chains/eip155-8217.json
+++ b/_data/chains/eip155-8217.json
@@ -1,7 +1,7 @@
 {
   "name": "Kaia Mainnet",
   "chain": "KAIA",
-  "rpc": ["https://public-en-cypress.klaytn.net"],
+  "rpc": ["https://public-en.node.kaia.io"],
   "faucets": [],
   "nativeCurrency": {
     "name": "KAIA",

--- a/_data/chains/eip155-8217.json
+++ b/_data/chains/eip155-8217.json
@@ -5,7 +5,7 @@
   "faucets": [],
   "nativeCurrency": {
     "name": "KAIA",
-    "symbol": "KAIA",
+    "symbol": "KLAY",
     "decimals": 18
   },
   "infoURL": "https://kaia.io",


### PR DESCRIPTION
Updated Kaia symbol back to KLAY as the ticker is going to remain for a while until all exchanges updates.
Also updated the rpc endpoint according to https://docs.kaia.io/references/public-en/#public-json-rpc-endpoints-1

This is the previous PR https://github.com/ethereum-lists/chains/pull/5411 i created for updating the Ticker. But as per the discussion with the team, its decided to wait for a while for Ticker update.

Reference:
https://kaia.io