### PR TITLE
changed native currency of swan chain

### DIFF
--- a/_data/chains/eip155-254.json
+++ b/_data/chains/eip155-254.json
@@ -4,8 +4,8 @@
   "rpc": ["https://mainnet-rpc01.swanchain.io"],
   "faucets": [],
   "nativeCurrency": {
-    "name": "SWANETH",
-    "symbol": "sETH",
+    "name": "Ether",
+    "symbol": "ETH",
     "decimals": 18
   },
   "infoURL": "https://swanchain.io/",


### PR DESCRIPTION
changed native currency of swan chain from sETH to ETH to correctly reflect swan mainnet's native currency