### PR TITLE
Add exSat mainnet 

### DIFF
--- a/_data/chains/eip155-7200.json
+++ b/_data/chains/eip155-7200.json
@@ -1,0 +1,30 @@
+{
+  "name": "exSat Network",
+  "chain": "exSat",
+  "icon": "exsat",
+  "rpc": ["https://evm.exsat.network"],
+  "faucets": ["https://faucet.exsat.network"],
+  "nativeCurrency": {
+    "name": "BTC",
+    "symbol": "BTC",
+    "decimals": 18
+  },
+  "infoURL": "https://exsat.network/",
+  "shortName": "xsat",
+  "chainId": 7200,
+  "networkId": 7200,
+  "explorers": [
+    {
+      "name": "exSat Explorer",
+      "url": "https://scan.exsat.network",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-1",
+    "bridges": [
+      { "url": "TBD" }
+    ]
+  }
+}

--- a/_data/chains/eip155-7200.json
+++ b/_data/chains/eip155-7200.json
@@ -23,8 +23,6 @@
   "parent": {
     "type": "L2",
     "chain": "eip155-1",
-    "bridges": [
-      { "url": "TBD" }
-    ]
+    "bridges": [{ "url": "https://bridge.exsat.network" }]
   }
 }

--- a/_data/icons/exsat.json
+++ b/_data/icons/exsat.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmYZ1FjYCByj89pNiZfae2a9uTm7pJMKrzdQ1V1UKwhwNs",
+    "width": 1024,
+    "height": 1024,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
The exSat is a Docking Layer for the Scalability of BTC. We combine the top rank BTC mining Pools & famous orgs to build this network. As a validator joining this network requires at least 100 BTC.

The exSat network is testing and will launch in late September. Our testnet has been launched, but our testnet ChainID has a Collision with another chain, so we only apply the chainID of the exSat mainnet.

Our mainnet RPC & explorer are not ready but they are the same as those on testnet. Please refer to our docs for more information:

https://docs.exsat.network/user-guide-for-testnet-hayek