### PR TITLE
chore: adjust Sophon chain configuration

### DIFF
--- a/_data/chains/eip155-531050104.json
+++ b/_data/chains/eip155-531050104.json
@@ -1,10 +1,13 @@
 {
   "name": "Sophon Testnet",
   "chain": "Sophon Testnet",
-  "rpc": ["https://rpc.testnet.sophon.xyz/"],
+  "rpc": [
+    "https://rpc.testnet.sophon.xyz",
+    "wss://rpc.testnet.sophon.xyz/ws"
+  ],
   "nativeCurrency": {
-    "name": "ETH",
-    "symbol": "ETH",
+    "name": "Sophon",
+    "symbol": "SOPH",
     "decimals": 18
   },
   "faucets": [],
@@ -14,7 +17,7 @@
   "networkId": 531050104,
   "explorers": [
     {
-      "name": "Sophon Testnet",
+      "name": "Sophon Block Explorer",
       "url": "https://explorer.testnet.sophon.xyz",
       "icon": "sophon-testnet",
       "standard": "none"
@@ -25,7 +28,7 @@
     "chain": "eip155-1",
     "bridges": [
       {
-        "url": "https://bridge.zksync.io/"
+        "url": "https://bridge.zksync.io"
       }
     ]
   }

--- a/_data/chains/eip155-531050104.json
+++ b/_data/chains/eip155-531050104.json
@@ -25,7 +25,7 @@
     "chain": "eip155-1",
     "bridges": [
       {
-        "url": "https://bridge.zksync.io"
+        "url": "https://portal.testnet.sophon.xyz/bridge"
       }
     ]
   }

--- a/_data/chains/eip155-531050104.json
+++ b/_data/chains/eip155-531050104.json
@@ -1,10 +1,7 @@
 {
   "name": "Sophon Testnet",
   "chain": "Sophon Testnet",
-  "rpc": [
-    "https://rpc.testnet.sophon.xyz",
-    "wss://rpc.testnet.sophon.xyz/ws"
-  ],
+  "rpc": ["https://rpc.testnet.sophon.xyz", "wss://rpc.testnet.sophon.xyz/ws"],
   "nativeCurrency": {
     "name": "Sophon",
     "symbol": "SOPH",


### PR DESCRIPTION
Hello!

We noticed a few adjustments were needed to the Sophon chain configuration, mainly to the native token (which is Sophon/SOPH, instead of ETH). Also added the missing websocket entrypoint. 