### PR TITLE
Update eip155-1648.json

### DIFF
--- a/_data/chains/eip155-1648.json
+++ b/_data/chains/eip155-1648.json
@@ -7,8 +7,8 @@
   "faucets": [],
   "shortName": "pivotal-mainnet",
   "nativeCurrency": {
-    "name": "Pivotal Plus",
-    "symbol": "PLUS",
+    "name": "Ether",
+    "symbol": "ETH",
     "decimals": 18
   },
   "infoURL": "http://thepivotal.xyz/",


### PR DESCRIPTION
No longer using a custom gas token for standard OP Stack config. Amended nativeCurrency to Ether (ETH).