### PR TITLE
Update Asset Chain testnet

### DIFF
--- a/_data/chains/eip155-42421.json
+++ b/_data/chains/eip155-42421.json
@@ -1,6 +1,6 @@
 {
-  "name": "AssetChain Testnet",
-  "chain": "RWA",
+  "name": "Asset Chain Testnet",
+  "chain": "Asset Chain",
   "rpc": ["https://enugu-rpc.assetchain.org"],
   "faucets": ["https://faucet.assetchain.org"],
   "nativeCurrency": {


### PR DESCRIPTION
Asset Chain's network name isnt showing correctly in Trustwallet.
This change corrects that.
Thanks