### PR TITLE
add cannon chain

### DIFF
--- a/_data/chains/eip155-13370.json
+++ b/_data/chains/eip155-13370.json
@@ -1,0 +1,16 @@
+{
+  "name": "Cannon Testnet",
+  "title": "Cannon Private Testnet",
+  "chain": "ETH",
+  "rpc": ["http://127.0.0.1:8545"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Cannon Testnet Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://usecannon.com",
+  "shortName": "cannon",
+  "chainId": 13370,
+  "networkId": 13370
+}


### PR DESCRIPTION
This PR adds support for the chain ID used by [Cannon](https://usecannon.com/), used by cannon CLI when hosting a local testnet. chain with its definitions and configurations.