### PR TITLE
Update icon zenchain.json

### DIFF
--- a/_data/icons/zenchain.json
+++ b/_data/icons/zenchain.json
@@ -1,8 +1,8 @@
 [
   {
-    "url": "ipfs://QmcFfYgA4hgN5UQUP1Qc4VZKuqZDjHXc62PGSKdpf4ofTx",
-    "width": 180,
-    "height": 180,
+    "url": "ipfs://QmSnaHBAeCQEaibgsGqU1enFFyWsq5Eh3dDSMBA1Qztj91",
+    "width": 166,
+    "height": 166,
     "format": "svg"
   }
 ]


### PR DESCRIPTION
Hi, we would like to update the icon in zenchain.json, associated with the `Zenchain Testnet` and `Zenchain` networks (chain id 8408 and 8108).