### PR TITLE
Remove broken RPCs and update info - Rollux Mainnet

### DIFF
--- a/_data/chains/eip155-570.json
+++ b/_data/chains/eip155-570.json
@@ -4,11 +4,9 @@
   "rpc": [
     "https://rpc.rollux.com",
     "wss://rpc.rollux.com/wss",
-    "https://rpc.ankr.com/rollux",
-    "https://rollux.rpc.syscoin.org",
-    "wss://rollux.rpc.syscoin.org/wss"
+    "https://rpc.ankr.com/rollux"
   ],
-  "faucets": ["https://rollux.id/faucetapp"],
+  "faucets": ["https://rollux.id/faucet"],
   "nativeCurrency": {
     "name": "Syscoin",
     "symbol": "SYS",
@@ -20,7 +18,7 @@
   "networkId": 570,
   "explorers": [
     {
-      "name": "Rollux Explorer",
+      "name": "Rollux Mainnet Explorer",
       "url": "https://explorer.rollux.com",
       "standard": "EIP3091"
     }


### PR DESCRIPTION
Update includes the faucet link and explorer name.