### PR TITLE
Callisto Network data update

### DIFF
--- a/_data/chains/eip155-820.json
+++ b/_data/chains/eip155-820.json
@@ -1,16 +1,25 @@
 {
   "name": "Callisto Mainnet",
   "chain": "CLO",
-  "rpc": ["https://rpc.callisto.network/"],
-  "faucets": [],
+  "icon": "callistonetwork",
+  "rpc": ["https://rpc.callistodao.org"],
+  "faucets": ["https://faucet.callistodao.org"],
   "nativeCurrency": {
     "name": "Callisto",
     "symbol": "CLO",
     "decimals": 18
   },
-  "infoURL": "https://callisto.network",
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://callistodao.org",
   "shortName": "clo",
   "chainId": 820,
   "networkId": 1,
-  "slip44": 820
+  "slip44": 820,
+  "explorers": [
+    {
+      "name": "blockscout-callisto-network",
+      "url": "https://explorer.callistodao.org",
+      "standard": "EIP3091"
+    }
+  ]
 }

--- a/_data/icons/callistonetwork.json
+++ b/_data/icons/callistonetwork.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmQbn4Jr6PLSsgFo1eALKQ7eMfndJJJ4B15a9yj5G5vMLC",
+    "width": 256,
+    "height": 256,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
-removed deprecated CE urls as they no longer support chain: https://github.com/CallistoEnterprise/PoWServers
-added Callisto DAO managed servers
-added icon