### PR TITLE
Remove Harmony Mainnet endpoint of Onfinality

### DIFF
--- a/_data/chains/eip155-1666600000.json
+++ b/_data/chains/eip155-1666600000.json
@@ -7,7 +7,6 @@
     "https://api.s0.t.hmny.io",
     "https://rpc.ankr.com/harmony",
 
-    "https://harmony.api.onfinality.io/public",
     "https://1rpc.io/one",
     "https://harmony-0.drpc.org",
     "wss://harmony-0.drpc.org"


### PR DESCRIPTION
OnFinality has removed Harmony's RPC, so this endpoint is no longer valid:
 `https://harmony.api.onfinality.io/public`