### PR TITLE
Add Sorian Testnet chain details

### DIFF
--- a/_data/chains/eip155-210210.json
+++ b/_data/chains/eip155-210210.json
@@ -22,12 +22,5 @@
   "shortName": "sorianTestnet",
   "chainId": 210210,
   "networkId": 210210,
-  "explorers": [
-    {
-      "name": "sorianTestnet",
-      "url": "https://testnet-scan.sorian.io",
-      "icon": "sorianTestnet",
-      "standard": "EIP3091"
-    }
-  ]
+  "explorers": []
 }

--- a/_data/chains/eip155-210210.json
+++ b/_data/chains/eip155-210210.json
@@ -1,0 +1,33 @@
+{
+  "name": "Sorian Testnet",
+  "chain": "tSOR",
+  "rpc": ["https://testnet-rpc.sorian.io", "https://testnet.rpc.sorian.io"],
+  "faucets": [],
+  "icon": "sorianTestnet",
+  "nativeCurrency": {
+    "name": "Sorian Testnet",
+    "symbol": "tSOR",
+    "decimals": 18
+  },
+
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
+    }
+  ],
+  "infoURL": "https://mint.sorian.io",
+  "shortName": "sorianTestnet",
+  "chainId": 210210,
+  "networkId": 210210,
+  "explorers": [
+    {
+      "name": "sorianTestnet",
+      "url": "https://testnet-scan.sorian.io",
+      "icon": "sorianTestnet",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/icons/sorianTestnet.json
+++ b/_data/icons/sorianTestnet.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmZmrcLYFtPZb36MZ1DyQpR7Lw8CWPP7x3Bx2anCjVWfMR",
+    "width": 500,
+    "height": 500,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
This pull request adds the Sorian Testnet chain to the Chainlist repository. The details of the chain are as follows:

Network Name: Sorian Testnet Network
Chain Name: Sorian Testnet Chain
Coin Name: Sorian Testnet
Symbol: tSOR
Decimals: 18
RPC URLs:
https://testnet-rpc.sorian.io/
https://testnet.rpc.sorian.io/
Chain ID: 210209
Explorer URL: https://testnet-scan.sorian.io
Info URL: https://mint.sorian.io/
Token Logo: ipfs://QmZmrcLYFtPZb36MZ1DyQpR7Lw8CWPP7x3Bx2anCjVWfMR