### PR TITLE
Updated Zircuit testnet RPC

### DIFF
--- a/_data/chains/eip155-48899.json
+++ b/_data/chains/eip155-48899.json
@@ -2,7 +2,7 @@
   "name": "Zircuit Testnet",
   "chain": "Zircuit Testnet",
   "icon": "zircuit",
-  "rpc": ["http://zircuit1-testnet.p2pify.com/"],
+  "rpc": ["https://zircuit1-testnet.p2pify.com/"],
   "faucets": [],
   "nativeCurrency": {
     "name": "ETH",


### PR DESCRIPTION
Updated Zircuit testnet RPC to use `https://`