### PR TITLE
Update KAIA ticker and Explorer urls

### DIFF
--- a/_data/chains/eip155-1001.json
+++ b/_data/chains/eip155-1001.json
@@ -5,7 +5,7 @@
   "faucets": ["https://faucet.kaia.io"],
   "nativeCurrency": {
     "name": "KAIA",
-    "symbol": "KLAY",
+    "symbol": "KAIA",
     "decimals": 18
   },
   "infoURL": "https://kaia.io/",
@@ -15,13 +15,13 @@
   "slip44": 1,
   "explorers": [
     {
-      "name": "Klaytnscope",
-      "url": "https://baobab.klaytnscope.com",
+      "name": "Kaiascope",
+      "url": "https://kairos.kaiascope.com",
       "standard": "EIP3091"
     },
     {
-      "name": "Klaytnfinder",
-      "url": "https://baobab.klaytnfinder.io",
+      "name": "Kaiascan",
+      "url": "https://kairos.kaiascan.io",
       "standard": "EIP3091"
     }
   ]

--- a/_data/chains/eip155-8217.json
+++ b/_data/chains/eip155-8217.json
@@ -5,7 +5,7 @@
   "faucets": [],
   "nativeCurrency": {
     "name": "KAIA",
-    "symbol": "KLAY",
+    "symbol": "KAIA",
     "decimals": 18
   },
   "infoURL": "https://kaia.io",
@@ -15,13 +15,13 @@
   "slip44": 8217,
   "explorers": [
     {
-      "name": "Klaytnscope",
-      "url": "https://scope.klaytn.com",
+      "name": "Kaiascope",
+      "url": "https://kaiascope.com",
       "standard": "EIP3091"
     },
     {
-      "name": "Klaytnfinder",
-      "url": "https://klaytnfinder.io",
+      "name": "Kaiascan",
+      "url": "https://kaiascan.io",
       "standard": "EIP3091"
     }
   ]


### PR DESCRIPTION
Updating the Ticker change from KLAY to KAIA. Please check the reference here https://www.binance.com/en/support/announcement/binance-will-support-the-kaia-klay-rebranding-to-kaia-kaia-f75f933759ee49d0af1dfbce7e32144c?hl=en .

Also updated the explorer urls for kaia network.
Thanks.