### PR TITLE
Add Astra testnet

### DIFF
--- a/_data/chains/eip155-19777.json
+++ b/_data/chains/eip155-19777.json
@@ -1,0 +1,24 @@
+{
+    "name": "Astra Testnet",
+    "chain": "ATX",
+    "icon": "astra",
+    "rpc": ["https://rpc-astra-9on2f72wzn.t.conduit.xyz"],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "Astra",
+      "symbol": "ATX",
+      "decimals": 18
+    },
+    "infoURL": "",
+    "shortName": "astra-testnet",
+    "chainId": 19777,
+    "networkId": 19777,
+    "slip44": 1,
+    "explorers": [
+      {
+        "name": "Astra Testnet Explorer",
+        "url": "https://explorer-astra-9on2f72wzn.t.conduit.xyz",
+        "standard": "EIP3091"
+      }
+    ]
+}

--- a/_data/icons/astratoken.json
+++ b/_data/icons/astratoken.json
@@ -1,0 +1,4 @@
+"url": "ipfs://bafybeidfrtx346zufwtxb6kjep2qrgor7zvslznz67e62ragkfylaoalcu",
+    "width": 96,
+    "height": 96,
+    "format": "png"


### PR DESCRIPTION
This pull request adds the Astra Testnet chain to the Chainlist repository. The details of the chain are as follows:

Network Name: Astra Testnet Network
Chain Name: Astra Testnet Chain
Coin Name: Astra
Symbol: ATX
Decimals: 18
RPC URLs: https://rpc-astra-9on2f72wzn.t.conduit.xyz
Chain ID: 19777
Explorer URL: https://explorer-astra-9on2f72wzn.t.conduit.xyz
Info URL: ipfs://bafybeidfrtx346zufwtxb6kjep2qrgor7zvslznz67e62ragkfylaoalcu