### PR TITLE
Deprecate Old Version of Cronos zkEVM chain

### DIFF
--- a/_data/chains/eip155-282.json
+++ b/_data/chains/eip155-282.json
@@ -1,5 +1,5 @@
 {
-  "name": "Cronos zkEVM Testnet",
+  "name": "Deprecated Cronos zkEVM Testnet",
   "chain": "CronosZkEVMTestnet",
   "rpc": ["https://testnet.zkevm.cronos.org"],
   "faucets": ["https://zkevm.cronos.org/faucet"],
@@ -19,5 +19,6 @@
       "url": "https://explorer.zkevm.cronos.org/testnet",
       "standard": "none"
     }
-  ]
+  ],
+  "status": "deprecated"
 }

--- a/_data/chains/eip155-282.json
+++ b/_data/chains/eip155-282.json
@@ -1,7 +1,7 @@
 {
   "name": "Deprecated Cronos zkEVM Testnet",
   "chain": "CronosZkEVMTestnet",
-  "rpc": ["https://testnet.zkevm.cronos.org"],
+  "rpc": ["https://deprecated.testnet.zkevm.cronos.org"],
   "faucets": ["https://zkevm.cronos.org/faucet"],
   "nativeCurrency": {
     "name": "Cronos zkEVM Test Coin",

--- a/_data/chains/eip155-282.json
+++ b/_data/chains/eip155-282.json
@@ -1,6 +1,6 @@
 {
   "name": "Deprecated Cronos zkEVM Testnet",
-  "chain": "CronosZkEVMTestnet",
+  "chain": "deprecatedCronosZkEVMTestnet",
   "rpc": ["https://deprecated.testnet.zkevm.cronos.org"],
   "faucets": ["https://zkevm.cronos.org/faucet"],
   "nativeCurrency": {
@@ -9,7 +9,7 @@
     "decimals": 18
   },
   "infoURL": "https://docs-zkevm.cronos.org",
-  "shortName": "zkTCRO",
+  "shortName": "deprecated-zkTCRO",
   "chainId": 282,
   "networkId": 282,
   "slip44": 1,


### PR DESCRIPTION
@ligi, there's a new iteration of Cronos zkEVM testnet and the official chainId has changed from `282` to `240`. 

This PR is deprecating the older version of testnet. I will create another PR to add a new chainId.