### PR TITLE
Adds Proof of Play Boss Chain

### DIFF
--- a/_data/chains/eip155-70701.json
+++ b/_data/chains/eip155-70701.json
@@ -1,0 +1,32 @@
+{
+  "name": "Proof of Play - Boss",
+  "chainId": 70701,
+  "shortName": "pop-boss",
+  "chain": "ETH",
+  "networkId": 70701,
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "rpc": ["https://rpc.boss.proofofplay.com"],
+  "faucets": [],
+  "explorers": [
+    {
+      "name": "Proof of Play Boss Explorer",
+      "url": "https://explorer.boss.proofofplay.com",
+      "icon": "pop-boss",
+      "standard": "EIP3091"
+    }
+  ],
+  "infoURL": "https://proofofplay.com",
+  "icon": "pop-boss",
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-42161",
+    "bridges": [
+      { "url": "https://bridge.arbitrum.io" },
+      { "url": "https://relay.link/bridge/boss/" }
+    ]
+  }
+}

--- a/_data/icons/pop-boss.json
+++ b/_data/icons/pop-boss.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmW3NPDe6WRqucrWbe8pg3GqSMPi8V6Qa1fAiaQuqjxSJC",
+    "width": 1256,
+    "height": 1256,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
This pull request includes the addition of a new chain configuration and its associated icon data. The most important changes include adding the configuration for the "Proof of Play - Boss" chain and adding its icon details.

Chain configuration:

* [`_data/chains/eip155-70701.json`](diffhunk://#diff-648add5b7fcd6e1db3cbfbc9b36d86a1582cc9a8aa1c73b08b055352823e17a9R1-R32): Added new chain configuration for "Proof of Play - Boss" with details such as `chainId`, `networkId`, `rpc`, `explorers`, and `parent` chain information.

Icon data:

* [`_data/icons/pop-boss.json`](diffhunk://#diff-4a2eba94f93589daedc0d8f3ac557f2b6e7fc11f5364b63acd6af79124ec094eR1-R8): Added icon details for the "Proof of Play - Boss" chain, including the URL, dimensions, and format of the icon.