### PR TITLE
Add XMTP Chain

### DIFF
--- a/_data/chains/eip155-24132016.json
+++ b/_data/chains/eip155-24132016.json
@@ -1,0 +1,16 @@
+{
+  "name": "XMTP",
+  "chain": "ETH",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "USDC",
+    "symbol": "USDC",
+    "decimals": 18
+  },
+  "infoURL": "https://xmtp.org",
+  "shortName": "xmtp",
+  "chainId": 24132016,
+  "networkId": 24132016,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-241320161.json
+++ b/_data/chains/eip155-241320161.json
@@ -1,0 +1,16 @@
+{
+  "name": "XMTP Sepolia",
+  "chain": "ETH",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "USDC",
+    "symbol": "USDC",
+    "decimals": 18
+  },
+  "infoURL": "https://xmtp.org",
+  "shortName": "xmtp-sepolia",
+  "chainId": 241320161,
+  "networkId": 241320161,
+  "status": "incubating"
+}


### PR DESCRIPTION
Adds the XMTP mainnet and testnet chains

These chain IDs will be for the mainnet and testnet of the [XMTP](https://xmtp.org/) messaging AppChain