### PR TITLE
Update Oasis Emerald Testnet symbol

### DIFF
--- a/_data/chains/eip155-42261.json
+++ b/_data/chains/eip155-42261.json
@@ -8,8 +8,8 @@
   ],
   "faucets": ["https://faucet.testnet.oasis.io/"],
   "nativeCurrency": {
-    "name": "Emerald Rose",
-    "symbol": "ROSE",
+    "name": "Emerald Test Rose",
+    "symbol": "TEST",
     "decimals": 18
   },
   "infoURL": "https://docs.oasis.io/dapp/emerald",


### PR DESCRIPTION
To match official Oasis docs:
https://github.com/oasisprotocol/docs/blob/afc1f64/src/AddToMetaMask.tsx#L90-L94

This also matches how Oasis Sapphire symbol is named:

https://github.com/ethereum-lists/chains/blob/7cbf777d84336963b09c34175304bded9599dc21/_data/chains/eip155-23294.json#L8-L10
https://github.com/ethereum-lists/chains/blob/7cbf777d84336963b09c34175304bded9599dc21/_data/chains/eip155-23295.json#L11-L13

cc @matevz 