### PR TITLE
Add CARV mainnet & testnet

### DIFF
--- a/_data/chains/eip155-2278.json
+++ b/_data/chains/eip155-2278.json
@@ -1,0 +1,24 @@
+{
+  "name": "CARV Mainnet",
+  "chain": "CARV Mainnet",
+  "rpc": [""],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "CARV",
+    "symbol": "CARV",
+    "decimals": 18
+  },
+  "infoURL": "https://carv.io/",
+  "shortName": "carv-mainnet",
+  "chainId": 2278,
+  "networkId": 2278,
+  "icon": "carv",
+  "explorers": [
+    {
+      "name": "CARV Mainnet Explorer",
+      "url": "",
+      "standard": "EIP3091"
+    }
+  ],
+  "status": "incubating"
+}

--- a/_data/chains/eip155-22781.json
+++ b/_data/chains/eip155-22781.json
@@ -4,8 +4,8 @@
   "rpc": [""],
   "faucets": [],
   "nativeCurrency": {
-    "name": "CARV",
-    "symbol": "CARV",
+    "name": "Sepolia Ether",
+    "symbol": "ETH",
     "decimals": 18
   },
   "infoURL": "https://carv.io/",
@@ -20,5 +20,10 @@
       "standard": "EIP3091"
     }
   ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-11155111",
+    "bridges": [{ "url": "" }]
+  },
   "status": "incubating"
 }

--- a/_data/chains/eip155-22781.json
+++ b/_data/chains/eip155-22781.json
@@ -1,0 +1,24 @@
+{
+  "name": "CARV Testnet",
+  "chain": "CARV Testnet",
+  "rpc": [""],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "CARV",
+    "symbol": "CARV",
+    "decimals": 18
+  },
+  "infoURL": "https://carv.io/",
+  "shortName": "carv-testnet",
+  "chainId": 22781,
+  "networkId": 22781,
+  "icon": "carv",
+  "explorers": [
+    {
+      "name": "CARV Testnet Explorer",
+      "url": "",
+      "standard": "EIP3091"
+    }
+  ],
+  "status": "incubating"
+}

--- a/_data/icons/carv.json
+++ b/_data/icons/carv.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmYNabmgMz1aPzSbGCAUeH7wpYH3WUDXunTma1v9SLGgUu",
+    "width": 500,
+    "height": 500,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
This PR adds both CARV testnet/mainnet and reserves 2278/22781 for the upcoming mainnet/testnet network launch.