### PR TITLE
Rebranding: eCredits to eSync Network

### DIFF
--- a/_data/chains/eip155-63000.json
+++ b/_data/chains/eip155-63000.json
@@ -23,7 +23,7 @@
     },
     {
       "name": "eSync Network Mainnet Beacon Explorer",
-      "url": "https://beacon-explorer.esync.network/",
+      "url": "https://beacon-explorer.esync.network",
       "icon": "esync",
       "standard": "EIP3091"
     }

--- a/_data/chains/eip155-63000.json
+++ b/_data/chains/eip155-63000.json
@@ -1,23 +1,30 @@
 {
-  "name": "eCredits Mainnet",
+  "name": "eSync Network Mainnet",
+  "title": "eSync Network Mainnet",
   "chain": "ECS",
-  "rpc": ["https://rpc.ecredits.com"],
+  "rpc": ["https://rpc.esync.network", "https://rpc.ecredits.com"],
   "faucets": [],
   "nativeCurrency": {
     "name": "eCredits",
     "symbol": "ECS",
     "decimals": 18
   },
-  "infoURL": "https://ecredits.com",
-  "shortName": "ecs",
+  "infoURL": "https://esync.network",
+  "shortName": "esync-mainnet",
   "chainId": 63000,
   "networkId": 63000,
-  "icon": "ecredits",
+  "icon": "esync",
   "explorers": [
     {
-      "name": "eCredits MainNet Explorer",
-      "url": "https://explorer.ecredits.com",
-      "icon": "ecredits",
+      "name": "eSync Network Mainnet Explorer",
+      "url": "https://explorer.esync.network",
+      "icon": "esync",
+      "standard": "EIP3091"
+    },
+    {
+      "name": "eSync Network Mainnet Beacon Explorer",
+      "url": "https://beacon-explorer.esync.network/",
+      "icon": "esync",
       "standard": "EIP3091"
     }
   ]

--- a/_data/chains/eip155-63000.json
+++ b/_data/chains/eip155-63000.json
@@ -20,12 +20,6 @@
       "url": "https://explorer.esync.network",
       "icon": "esync",
       "standard": "EIP3091"
-    },
-    {
-      "name": "eSync Network Mainnet Beacon Explorer",
-      "url": "https://beacon-explorer.esync.network",
-      "icon": "esync",
-      "standard": "EIP3091"
     }
   ]
 }


### PR DESCRIPTION
- eCredits was rebranded to eSync Network. Previously it was only done for testnet, now also mainnet.

- added additional RPC endpoint with new esync.network domain