### PR TITLE
Add Phron Testnet to Chainlist

### DIFF
--- a/_data/chains/eip155-7744.json
+++ b/_data/chains/eip155-7744.json
@@ -1,0 +1,24 @@
+{
+  "name": "Phron Testnet",
+  "chain": "PHR",
+  "icon": "phron",
+  "rpc": ["https://testnet.phron.ai", "wss://testnet.phron.ai"],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "faucets": ["https://faucet.phron.ai"],
+  "nativeCurrency": {
+    "name": "Phron",
+    "symbol": "TPHR",
+    "decimals": 18
+  },
+  "infoURL": "https://phron.ai",
+  "shortName": "phr",
+  "chainId": 7744,
+  "networkId": 7744,
+  "explorers": [
+    {
+      "name": "phronscan",
+      "url": "https://testnet.phronscan.io",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/icons/phron.json
+++ b/_data/icons/phron.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://Qmf77sTNKpnTbwYjauyQ7KpxV5EbgTPP27Fmx24svB84gY",
+    "width": 129,
+    "height": 129,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
This pull request adds the  Phron Testnet to the Chainlist.

Chain Details:
Chain Name: Phron Testnet
Chain ID: 7744
RPC URL: https://testnet.phron.ai
Symbol: TPHR
Currency Symbol: PHR

We welcome any feedback or suggestions to improve the integration. Thank you for considering our addition to Chainlist!