### PR TITLE
Add Testnet Pika Chain Configuration and Icon

### DIFF
--- a/_data/chains/eip155-4422.json
+++ b/_data/chains/eip155-4422.json
@@ -9,7 +9,6 @@
       "symbol": "tPKA",
       "decimals": 18
     },
-  
     "features": [
       {
         "name": "EIP155"

--- a/_data/chains/eip155-4422.json
+++ b/_data/chains/eip155-4422.json
@@ -20,8 +20,8 @@
     ],
     "infoURL": "https://pikaminter.com",
     "shortName": "PikaMinter",
-    "chainId": 210210,
-    "networkId": 210210,
+    "chainId": 4422,
+    "networkId": 4422,
     "explorers": []
   }
   

--- a/_data/chains/eip155-4422.json
+++ b/_data/chains/eip155-4422.json
@@ -1,0 +1,27 @@
+{
+    "name": "Testnet Pika",
+    "chain": "tPKA",
+    "rpc": ["https://testnet-rpc1.pikascan.com"],
+    "faucets": [],
+    "icon": "pkasmartchain",
+    "nativeCurrency": {
+      "name": "Testnet Pika",
+      "symbol": "tPKA",
+      "decimals": 18
+    },
+  
+    "features": [
+      {
+        "name": "EIP155"
+      },
+      {
+        "name": "EIP1559"
+      }
+    ],
+    "infoURL": "https://pikaminter.com",
+    "shortName": "PikaMinter",
+    "chainId": 210210,
+    "networkId": 210210,
+    "explorers": []
+  }
+  

--- a/_data/icons/pkasmartchain.json
+++ b/_data/icons/pkasmartchain.json
@@ -1,0 +1,9 @@
+[
+    {
+      "url": "ipfs://QmXmBxoHWyPfpYP3gLfVB2d5DfVKT4FXKb4Bt6m7nf19wL",
+      "width": 500,
+      "height": 500,
+      "format": "png"
+    }
+  ]
+  


### PR DESCRIPTION
This PR adds the configuration and icon for the Testnet Pika chain to the Chainlist repository.

Changes:

Created _data/chains/eip155-4422.json with the following configuration:

Chain Name: Testnet Pika
Chain ID: 4422
RPC URL: https://testnet-rpc1.pikascan.com
Native Currency: tPKA (symbol), with 18 decimals
Features: EIP155, EIP1559
Info URL: https://pikaminter.com
Short Name: PikaMinter
Created _data/icons/pkasmartchain.json for the chain icon:

Icon hosted on IPFS: ipfs://QmXmBxoHWyPfpYP3gLfVB2d5DfVKT4FXKb4Bt6m7nf19wL
Format: PNG, 500x500 dimensions
Purpose: This addition will allow users to easily add the Testnet Pika chain (chain ID: 4422) to their wallets via Chainlist, ensuring convenient access to RPC and network information.