### PR TITLE
Add KPA Smart Chain Testnet

### DIFF
--- a/_data/chains/eip155-9091.json
+++ b/_data/chains/eip155-9091.json
@@ -1,0 +1,23 @@
+{
+  "name": "KPA Smart Chain Testnet",
+  "chain": "KSC",
+  "rpc": [
+    "https://testnet-rpc1.koppachain.com/",
+    "https://testnet-rpc2.koppachain.com/",
+    "https://testnet-rpc3.koppachain.com/",
+    "https://testnet-rpc4.koppachain.com/"
+  ],
+  "faucets": ["https://mint.koppachain.com"],
+  "nativeCurrency": {
+    "name": "KPA Smart Chain Testnet",
+    "symbol": "tKPA",
+    "decimals": 18
+  },
+  "features": [],
+  "infoURL": "https://koppachain.com",
+  "shortName": "KPA",
+  "chainId": 9091,
+  "networkId": 9091,
+  "icon": "koppa",
+  "explorers": []
+}

--- a/_data/icons/koppa.json
+++ b/_data/icons/koppa.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmbEzU7QQ4uJR2XTmkGAW9GNEsTMt6o8oYshPVeWVbSGaC",
+    "width": 1200,
+    "height": 1200,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
This pull request adds the KPA Smart Chain Testnet to the Ethereum Chains repository.

Details of the addition:

Chain Name: KPA Smart Chain Testnet
Symbol: tKPA
Chain ID: 9091
RPC URLs:
https://testnet-rpc1.koppachain.com/
https://testnet-rpc2.koppachain.com/
https://testnet-rpc3.koppachain.com/
https://testnet-rpc4.koppachain.com/
Native Currency: KPA Smart Chain Testnet (tKPA)
Faucet URL: [Mint KPA](https://mint.koppachain.com/)
Info URL: [KoppaChain](https://koppachain.com/)
Explorer URL: [KPA Scan](https://testnet.kpascan.com/)
Icon: The icon for the KPA Smart Chain Testnet has been added.
This addition aims to enhance the ecosystem of supported chains and provide developers with access to the KPA Smart Chain Testnet for testing and development.