### PR TITLE
Fix Boba BNB L2 parent

### DIFF
--- a/_data/chains/eip155-56288.json
+++ b/_data/chains/eip155-56288.json
@@ -28,7 +28,7 @@
   ],
   "parent": {
     "type": "L2",
-    "chain": "eip155-5",
+    "chain": "eip155-56",
     "bridges": [
       {
         "url": "https://gateway.boba.network"


### PR DESCRIPTION
Boba BNB settles to BNB chain, not Goerli