### PR TITLE
fix kzSync sepolia l2 parent

### DIFF
--- a/_data/chains/eip155-300.json
+++ b/_data/chains/eip155-300.json
@@ -28,7 +28,7 @@
   ],
   "parent": {
     "type": "L2",
-    "chain": "eip155-1",
+    "chain": "eip155-11155111",
     "bridges": [{ "url": "https://bridge.zksync.io/" }]
   },
   "redFlags": ["reusedChainId"]


### PR DESCRIPTION
kzSync Sepolia settles to Sepolia, not Mainnet