### PR TITLE
Update bttc networks.

### DIFF
--- a/_data/chains/eip155-1029.json
+++ b/_data/chains/eip155-1029.json
@@ -1,0 +1,23 @@
+{
+  "name": "BitTorrent Chain Donau",
+  "chain": "BTTC",
+  "icon": "bttc",
+  "rpc": ["https://pre-rpc.bt.io"],
+  "faucets": ["https://testfaucet.bt.io"],
+  "nativeCurrency": {
+    "name": "BitTorrent",
+    "symbol": "BTT",
+    "decimals": 18
+  },
+  "infoURL": "https://bt.io",
+  "shortName": "BTT",
+  "chainId": 1029,
+  "networkId": 1029,
+  "explorers": [
+    {
+      "name": "BitTorrent Chain Donau Explorer",
+      "url": "https://testnet.bttcscan.com",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-199.json
+++ b/_data/chains/eip155-199.json
@@ -1,6 +1,7 @@
 {
   "name": "BitTorrent Chain Mainnet",
   "chain": "BTTC",
+  "icon": "bttc",
   "rpc": [
     "https://rpc.bt.io",
     "https://bittorrent.drpc.org",

--- a/_data/icons/bttc.json
+++ b/_data/icons/bttc.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmW7DmMmWVH4xTWf573AkaUD87tsWZyAxwjyvYx8vU6bjK",
+    "width": 96,
+    "height": 96,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Update BTTC Networks:
1. Add icon information for 199 network.
2. Add chain information for 1029 network.