### PR TITLE
EOS EVM is not Mainnet L2 rollup

### DIFF
--- a/_data/chains/eip155-15557.json
+++ b/_data/chains/eip155-15557.json
@@ -20,10 +20,5 @@
       "url": "https://explorer.testnet.evm.eosnetwork.com",
       "standard": "EIP3091"
     }
-  ],
-  "parent": {
-    "type": "L2",
-    "chain": "eip155-1",
-    "bridges": [{ "url": "https://bridge.testnet.evm.eosnetwork.com" }]
-  }
+  ]
 }

--- a/_data/chains/eip155-17777.json
+++ b/_data/chains/eip155-17777.json
@@ -19,13 +19,5 @@
       "url": "https://explorer.evm.eosnetwork.com",
       "standard": "EIP3091"
     }
-  ],
-  "parent": {
-    "type": "L2",
-    "chain": "eip155-1",
-    "bridges": [
-      { "url": "https://bridge.evm.eosnetwork.com" },
-      { "url": "https://app.multichain.org" }
-    ]
-  }
+  ]
 }


### PR DESCRIPTION
And neither is testnet.

It's connected to EOS Native chain, which is not EVM chain.