### PR TITLE
Adding Matsnet Testnet config file

### DIFF
--- a/_data/chains/eip155-31611.json
+++ b/_data/chains/eip155-31611.json
@@ -1,0 +1,24 @@
+{
+  "name": "Mezo Matsnet Testnet",
+  "chain": "Mezo",
+  "rpc": ["https://rpc.test.mezo.org"],
+  "faucets": ["https://mezo.org/matsnet"],
+  "nativeCurrency": {
+    "name": "Bitcoin",
+    "symbol": "BTC",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://mezo.org/",
+  "shortName": "mezo",
+  "chainId": 31611,
+  "networkId": 31611,
+  "explorers": [
+    {
+      "name": "blockscout",
+      "url": "https://explorer.test.mezo.org",
+      "icon": "blockscout",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
In this PR we add `eip155-31611.json` config file to include Mezo Matsnet Testnet to the chainlist listing.