### PR TITLE
add Plume devnet

### DIFF
--- a/_data/chains/eip155-98864.json
+++ b/_data/chains/eip155-98864.json
@@ -1,0 +1,34 @@
+{
+  "name": "Plume Testnet",
+  "title": "Plume Sepolia Rollup Testnet",
+  "chain": "ETH",
+  "rpc": [
+    "https://testnet-rpc.plumenetwork.xyz/http",
+    "wss://testnet-rpc.plumenetwork.xyz/ws"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Plume Sepolia Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://www.plumenetwork.xyz/",
+  "shortName": "plume-testnet",
+  "chainId": 161221135,
+  "networkId": 161221135,
+  "slip44": 1,
+  "icon": "plume",
+  "explorers": [
+    {
+      "name": "Blockscout",
+      "url": "https://testnet-explorer.plumenetwork.xyz",
+      "icon": "blockscout",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-11155111",
+    "bridges": [{ "url": "https://testnet-bridge.plumenetwork.xyz" }]
+  }
+}

--- a/_data/chains/eip155-98864.json
+++ b/_data/chains/eip155-98864.json
@@ -1,10 +1,10 @@
 {
-  "name": "Plume Testnet",
-  "title": "Plume Sepolia Rollup Testnet",
+  "name": "Plume Devnet",
+  "title": "Plume Sepolia L2 Rollup Devnet",
   "chain": "ETH",
   "rpc": [
-    "https://testnet-rpc.plumenetwork.xyz/http",
-    "wss://testnet-rpc.plumenetwork.xyz/ws"
+    "https://test-rpc.plumenetwork.xyz/http",
+    "wss://test-rpc.plumenetwork.xyz/ws"
   ],
   "faucets": [],
   "nativeCurrency": {
@@ -13,22 +13,21 @@
     "decimals": 18
   },
   "infoURL": "https://www.plumenetwork.xyz/",
-  "shortName": "plume-testnet",
-  "chainId": 161221135,
-  "networkId": 161221135,
+  "shortName": "plume-devnet",
+  "chainId": 98864,
+  "networkId": 98864,
   "slip44": 1,
   "icon": "plume",
   "explorers": [
     {
       "name": "Blockscout",
-      "url": "https://testnet-explorer.plumenetwork.xyz",
+      "url": "https://test-explorer.plumenetwork.xyz",
       "icon": "blockscout",
       "standard": "EIP3091"
     }
   ],
   "parent": {
     "type": "L2",
-    "chain": "eip155-11155111",
-    "bridges": [{ "url": "https://testnet-bridge.plumenetwork.xyz" }]
+    "chain": "eip155-11155111"
   }
 }

--- a/_data/icons/plume.json
+++ b/_data/icons/plume.json
@@ -1,8 +1,8 @@
 [
   {
-    "url": "ipfs://QmNUpqkYWYJoDXKUpZ8FVbGyN6HCwxYonKNAieCf2oTzGn",
-    "width": 1062,
-    "height": 1062,
+    "url": "ipfs://QmT7dJKK2VXMtF9mJ6EfMTJXBntJyVvZcA8beLA2RCFbsW",
+    "width": 400,
+    "height": 400,
     "format": "png"
   }
 ]


### PR DESCRIPTION
Adds the latest version of Plume devnet, which supersedes the deprecated Plume testnet removed in #6250: https://x.com/plumenetwork/status/1834623547496714340