### PR TITLE
Updated Kaia Testnet rpc endpoint

### DIFF
--- a/_data/chains/eip155-1001.json
+++ b/_data/chains/eip155-1001.json
@@ -1,7 +1,7 @@
 {
   "name": "Kaia Testnet Kairos",
   "chain": "KAIA",
-  "rpc": ["https://public-en.kairos.node.kaia.io"],
+  "rpc": ["https://public-en-kairos.node.kaia.io"],
   "faucets": ["https://faucet.kaia.io"],
   "nativeCurrency": {
     "name": "KAIA",

--- a/_data/chains/eip155-1001.json
+++ b/_data/chains/eip155-1001.json
@@ -1,5 +1,5 @@
 {
-  "name": "Kaia Testnet Kairos",
+  "name": "Kaia Kairos Testnet",
   "chain": "KAIA",
   "rpc": ["https://public-en-kairos.node.kaia.io"],
   "faucets": ["https://faucet.kaia.io"],


### PR DESCRIPTION
Updated Testnet RPC url as per below Kaia docs
https://docs.kaia.io/references/public-en/#testnet-kairos-public-json-rpc-endpoints