### PR TITLE
update: Swellchain definitions

### DIFF
--- a/_data/chains/eip155-1923.json
+++ b/_data/chains/eip155-1923.json
@@ -1,7 +1,10 @@
 {
-  "name": "Swell Network",
-  "chain": "Swell L2",
-  "rpc": ["https://swell-mainnet.alt.technology"],
+  "name": "Swellchain",
+  "chain": "ETH",
+  "rpc": [
+    "https://swell-mainnet.alt.technology",
+    "https://rpc.ankr.com/swell"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
@@ -9,14 +12,14 @@
     "decimals": 18
   },
   "infoURL": "https://app.swellnetwork.io/layer2/swell-l2",
-  "shortName": "swell-l2",
+  "shortName": "swellchain",
   "chainId": 1923,
   "networkId": 1923,
+  "icon": "swell",
   "explorers": [
     {
-      "name": "swell-l2",
-      "icon": "swell",
-      "url": "https://swell-mainnet-explorer.alt.technology",
+      "name": "Swellchain Explorer",
+      "url": "https://explorer.swellnetwork.io",
       "standard": "none"
     }
   ]

--- a/_data/chains/eip155-1923.json
+++ b/_data/chains/eip155-1923.json
@@ -1,10 +1,7 @@
 {
   "name": "Swellchain",
   "chain": "ETH",
-  "rpc": [
-    "https://swell-mainnet.alt.technology",
-    "https://rpc.ankr.com/swell"
-  ],
+  "rpc": ["https://swell-mainnet.alt.technology", "https://rpc.ankr.com/swell"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",

--- a/_data/chains/eip155-1924.json
+++ b/_data/chains/eip155-1924.json
@@ -1,7 +1,11 @@
 {
-  "name": "Swell Network Testnet",
-  "chain": "Swell L2 Testnet",
-  "rpc": ["https://swell-testnet.alt.technology"],
+  "name": "Swellchain Testnet",
+  "chain": "ETH",
+  "rpc": [
+    "https://swell-testnet.alt.technology",
+    "https://rpc.ankr.com/swell-testnet"
+  ],
+
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
@@ -9,13 +13,13 @@
     "decimals": 18
   },
   "infoURL": "https://app.swellnetwork.io/layer2/swell-l2",
-  "shortName": "swell-l2-testnet",
+  "shortName": "swellchain-sep",
   "chainId": 1924,
   "networkId": 1924,
+  "icon": "swell",
   "explorers": [
     {
-      "name": "swell-l2-testnet",
-      "icon": "swell",
+      "name": "Swellchain Testnet Explorer",
       "url": "https://swell-testnet-explorer.alt.technology",
       "standard": "none"
     }


### PR DESCRIPTION
old: Swell Network
new: Swellchain

I've run the prettier and the RPC format is different for the mainnet and testnet (single line vs multiline)
just lmk if you want to have it changed-  idc tbh @ligi 


(der commit typo bleibt jetzt bitte für ewig, hehe)