### PR TITLE
add GRAPHIX RPC for sepolia testnet

### DIFF
--- a/_data/chains/eip155-11155111.json
+++ b/_data/chains/eip155-11155111.json
@@ -15,7 +15,8 @@
     "wss://ethereum-sepolia-rpc.publicnode.com",
     "https://sepolia.drpc.org",
     "wss://sepolia.drpc.org",
-    "https://rpc-sepolia.rockx.com"
+    "https://rpc-sepolia.rockx.com",
+    "https://eth-sepolia.g.alchemy.com/v2/WddzdzI2o9S3COdT73d5w6AIogbKq4X-"
   ],
   "faucets": ["http://fauceth.komputing.org?chain=11155111&address=${ADDRESS}"],
   "nativeCurrency": {


### PR DESCRIPTION
This pull request adds a new RPC endpoint for the Sepolia Testnet to support testing and development activities. The RPC is provided by Alchemy and offers reliable access to the Sepolia Ethereum Testnet.

Changes
Updated file: _data/chains/eip155-11155111.json
Added the following RPC URL:
https://eth-sepolia.g.alchemy.com/v2/WddzdzI2o9S3COdT73d5w6AIogbKq4X-
Purpose
This RPC addition aims to enhance accessibility and improve developer experience when interacting with the Sepolia Testnet. The Alchemy RPC ensures stability and performance during testing.

Reference
RPC Provider Website: [Alchemy](https://www.alchemy.com/)
Network Name: Sepolia Testnet
Chain ID: 11155111