### PR TITLE
Update Phala Network

### DIFF
--- a/_data/chains/eip155-2035.json
+++ b/_data/chains/eip155-2035.json
@@ -1,15 +1,16 @@
 {
   "name": "Phala Network",
-  "chain": "PHA",
+  "chain": "ETH",
   "rpc": [],
   "faucets": [],
   "nativeCurrency": {
-    "name": "Phala",
-    "symbol": "PHA",
+    "name": "Ether",
+    "symbol": "ETH",
     "decimals": 18
   },
   "infoURL": "https://phala.network",
-  "shortName": "pha",
+  "shortName": "phala",
   "chainId": 2035,
-  "networkId": 2035
+  "networkId": 2035,
+  "status": "incubating"
 }


### PR DESCRIPTION
Phala is going to be a L2 with Ether as the gas fee token. Update the config to reflect it.