### PR TITLE
Autonity Update for autonity-apis

### DIFF
--- a/_data/chains/eip155-65100004.json
+++ b/_data/chains/eip155-65100004.json
@@ -5,8 +5,8 @@
     "https://autonity.rpc.web3cdn.network/testnet",
     "wss://autonity.rpc.web3cdn.network/testnet/ws",
     "https://autonity-piccadilly.rpc.subquery.network/public",
-    "https://picadilly.autonity-apis.com",
-    "wss://picadilly-ws.autonity-apis.com"
+    "https://piccadilly.autonity-apis.com",
+    "wss://piccadilly-ws.autonity-apis.com"
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
Fix slight typo in autonity-apis urls, correcting `picadilly` to `piccadilly`