### PR TITLE
Update Hydra Testnet faucet and RPC URLs because of DNS issues

### DIFF
--- a/_data/chains/eip155-8844.json
+++ b/_data/chains/eip155-8844.json
@@ -1,8 +1,8 @@
 {
   "name": "Hydra Chain Testnet",
   "chain": "HYDRA",
-  "rpc": ["https://rpc.testnet.hydrachain.org"],
-  "faucets": ["https://app.testnet.hydrachain.org/faucet"],
+  "rpc": ["https://rpc-testnet.hydrachain.org"],
+  "faucets": ["https://testnetapp.hydrachain.org/faucet"],
   "nativeCurrency": {
     "name": "tHydra",
     "symbol": "tHYDRA",


### PR DESCRIPTION
The PR includes an update of the Testnet faucet and rpc URLs that has to be made because of DNS problems