### PR TITLE
Add Bittensor (TAO) EVM-enabled mainnet

### DIFF
--- a/_data/chains/eip155-945.json
+++ b/_data/chains/eip155-945.json
@@ -1,12 +1,12 @@
 {
   "name": "Subtensor EVM Testnet",
   "chain": "Bittensor",
-  "rpc": ["https://evm-testnet.dev.opentensor.ai"],
+  "rpc": ["https://test.chain.opentensor.ai"],
   "faucets": [],
   "nativeCurrency": {
     "name": "testTAO",
     "symbol": "TAO",
-    "decimals": 9
+    "decimals": 18
   },
   "infoURL": "https://bittensor.com/",
   "shortName": "bittensor-evm-testnet",

--- a/_data/chains/eip155-964.json
+++ b/_data/chains/eip155-964.json
@@ -1,0 +1,17 @@
+{
+  "name": "Subtensor EVM",
+  "chain": "Bittensor",
+  "rpc": ["https://lite.chain.opentensor.ai"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "TAO",
+    "symbol": "TAO",
+    "decimals": 18
+  },
+  "infoURL": "https://bittensor.com/",
+  "shortName": "bittensor-evm-mainnet",
+  "chainId": 964,
+  "networkId": 964,
+  "slip44": 1005,
+  "icon": "bittensor"
+}


### PR DESCRIPTION
This PR changes some info for testnet added in #5798 and adds the mainnet chainID as well.