### PR TITLE
Add Autonomys Taurus

### DIFF
--- a/_data/chains/eip155-490000.json
+++ b/_data/chains/eip155-490000.json
@@ -10,7 +10,7 @@
     "decimals": 18
   },
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
-  "infoURL": "https://www.autonomys.net",
+  "infoURL": "https://www.autonomys.xyz",
   "shortName": "ATN",
   "chainId": 490000,
   "networkId": 490000,

--- a/_data/chains/eip155-490000.json
+++ b/_data/chains/eip155-490000.json
@@ -1,11 +1,12 @@
 {
-  "name": "Autonomys Testnet Nova Domain",
-  "chain": "TATC",
-  "rpc": ["https://nova-0.gemini-3h.subspace.network/ws"],
+  "name": "Autonomys Taurus Testnet",
+  "chain": "autonomys-taurus-testnet",
+  "rpc": ["https://auto-evm.taurus.autonomys.xyz/ws"],
+  "icon": "autonomys",
   "faucets": [],
   "nativeCurrency": {
-    "name": "Test Auto Coin",
-    "symbol": "TATC",
+    "name": "tAI3",
+    "symbol": "tAI3",
     "decimals": 18
   },
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
@@ -15,8 +16,8 @@
   "networkId": 490000,
   "explorers": [
     {
-      "name": "astral",
-      "url": "https://nova.subspace.network",
+      "name": "Autonomys Taurus Testnet Explorer",
+      "url": "https://blockscout.taurus.autonomys.xyz",
       "icon": "blockscout",
       "standard": "EIP3091"
     }

--- a/_data/chains/eip155-490000.json
+++ b/_data/chains/eip155-490000.json
@@ -5,8 +5,8 @@
   "icon": "autonomys",
   "faucets": [],
   "nativeCurrency": {
-    "name": "tAI3",
-    "symbol": "tAI3",
+    "name": "AI3",
+    "symbol": "AI3",
     "decimals": 18
   },
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],

--- a/_data/icons/autonomys.json
+++ b/_data/icons/autonomys.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmdrBVyTi7BPLB8GiSMzUor9vEGDU1LqWwTvbwUQN5GTK3",
+    "width": 1000,
+    "height": 1000,
+    "format": "png"
+  }
+]

--- a/_data/icons/autonomys.json
+++ b/_data/icons/autonomys.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "ipfs://QmdrBVyTi7BPLB8GiSMzUor9vEGDU1LqWwTvbwUQN5GTK3",
+    "url": "ipfs://bafkreic62smuudotw6iq724fvysujakoonb3iwtwo6t4hr6ldursz5jyo4",
     "width": 1113,
     "height": 1096,
     "format": "png"

--- a/_data/icons/autonomys.json
+++ b/_data/icons/autonomys.json
@@ -1,8 +1,8 @@
 [
   {
     "url": "ipfs://QmdrBVyTi7BPLB8GiSMzUor9vEGDU1LqWwTvbwUQN5GTK3",
-    "width": 1000,
-    "height": 1000,
+    "width": 1113,
+    "height": 1096,
     "format": "png"
   }
 ]


### PR DESCRIPTION
This PR is related to the update of a network that was deployed using a Chain ID that already exists and is registered in ChainList. The issue is that this network is now deprecated, and the same team, Autonomys, has reused this Chain ID for the deployment of the Autonomys Taurus Testnet.