### PR TITLE
Update title case for ZKcandy

### DIFF
--- a/_data/chains/eip155-302.json
+++ b/_data/chains/eip155-302.json
@@ -1,5 +1,5 @@
 {
-  "name": "zkCandy Sepolia Testnet",
+  "name": "ZKcandy Sepolia Testnet",
   "chain": "ETH",
   "rpc": ["https://sepolia.rpc.zkcandy.io"],
   "faucets": [],
@@ -15,7 +15,7 @@
   "icon": "zkcandy",
   "explorers": [
     {
-      "name": "zkCandy Block Explorer",
+      "name": "ZKcandy Block Explorer",
       "url": "https://sepolia.explorer.zkcandy.io",
       "icon": "zkcandy",
       "standard": "EIP3091"


### PR DESCRIPTION
Updating the name of the ZKcandy Sepolia Testnet from "zkCandy" to "ZKcandy" to match documentation and keep branding consistent.

Source: https://litepaper.zkcandy.io