### PR TITLE
Update Block Explorer URL for eip155-420420421.json

### DIFF
--- a/_data/chains/eip155-420420421.json
+++ b/_data/chains/eip155-420420421.json
@@ -17,7 +17,7 @@
     {
       "name": "subscan",
       "icon": "subscan",
-      "url": "https://assethub-westend.subscan.io",
+      "url": "https://westend-asset-hub-eth-explorer.parity.io",
       "standard": "EIP3091"
     }
   ]


### PR DESCRIPTION
Update url to https://westend-asset-hub-eth-explorer.parity.io

This redirects to subscan and extract the proper explorer url from the provided transaction hash