### PR TITLE
Add Reactive Mainnet + fix testnet rpc

### DIFF
--- a/_data/chains/eip155-1597.json
+++ b/_data/chains/eip155-1597.json
@@ -1,0 +1,28 @@
+{
+  "name": "Reactive Mainnet",
+  "title": "Reactive Network",
+  "chain": "REACT",
+  "rpc": [
+    "https://mainnet-rpc.reactive.network",
+    "https://mainnet-rpc.rkt.ink"
+  ],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "React",
+    "symbol": "REACT",
+    "decimals": 18
+  },
+  "infoURL": "https://reactive.network",
+  "shortName": "react",
+  "icon": "reactive",
+  "chainId": 1597,
+  "networkId": 1597,
+  "explorers": [
+    {
+      "name": "reactscan",
+      "url": "https://reactscan.net",
+      "standard": "none"
+    }
+  ]
+}

--- a/_data/chains/eip155-5318008.json
+++ b/_data/chains/eip155-5318008.json
@@ -2,7 +2,7 @@
   "name": "Reactive Kopli",
   "title": "Reactive Network Testnet Kopli",
   "chain": "REACT",
-  "rpc": ["https://kopli-rpc.reactive.network", "http://kopli-rpc.rkt.ink"],
+  "rpc": ["https://kopli-rpc.reactive.network", "https://kopli-rpc.rkt.ink"],
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "faucets": ["https://dev.reactive.network/docs/kopli-testnet#faucet"],
   "nativeCurrency": {

--- a/_data/icons/reactive.json
+++ b/_data/icons/reactive.json
@@ -1,8 +1,8 @@
 [
   {
-    "url": "ipfs://QmZewyubd3zC17pmmGbjix6gFsppYpLsP3ntu3aB7rCJmW",
-    "width": 800,
-    "height": 800,
+    "url": "ipfs://bafkreih2sitkbspgnboiwga7k4zwz22h4u3qqpswxdr3miqtdwuovw2cte",
+    "width": 320,
+    "height": 320,
     "format": "png"
   }
 ]


### PR DESCRIPTION
Changes:

* Added Reactive Mainnet information
* Fixed RPC url for Reactive Kopli Testnet
* Updated IPFS image to meet file size requirements

Chores:

* Gradle build successful
* Prettier