### PR TITLE
Added Haust Network Testnet chain

### DIFF
--- a/_data/chains/eip155-1523903251.json
+++ b/_data/chains/eip155-1523903251.json
@@ -3,7 +3,9 @@
   "title": "Haust Network Testnet",
   "chain": "haust-network-testnet",
   "rpc": ["https://rpc-testnet.haust.app"],
+  "features": [{ "name": "EIP155" }],
   "faucets": ["https://faucet.haust.app"],
+  "status": "active",
   "nativeCurrency": {
     "name": "HAUST",
     "symbol": "HAUST",
@@ -26,7 +28,5 @@
     "type": "L2",
     "chain": "eip155-11155111",
     "bridges": [{ "url": "https://bridge-testnet.haust.app" }]
-  },
-  "features": [{ "name": "EIP155" }],
-  "status": "active"
+  }
 }

--- a/_data/chains/eip155-1523903251.json
+++ b/_data/chains/eip155-1523903251.json
@@ -27,6 +27,6 @@
     "chain": "eip155-11155111",
     "bridges": [{ "url": "https://bridge-testnet.haust.app" }]
   },
-  "features":[{ "name": "EIP155" }],
+  "features": [{ "name": "EIP155" }],
   "status": "active"
 }

--- a/_data/chains/eip155-1523903251.json
+++ b/_data/chains/eip155-1523903251.json
@@ -1,0 +1,32 @@
+{
+  "name": "Haust Network Testnet",
+  "title": "Haust Network Testnet",
+  "chain": "haust-network-testnet",
+  "rpc": ["https://rpc-testnet.haust.app"],
+  "faucets": ["https://faucet.haust.app"],
+  "nativeCurrency": {
+    "name": "HAUST",
+    "symbol": "HAUST",
+    "decimals": 18
+  },
+  "infoURL": "https://haust.network/",
+  "shortName": "HaustTestnet",
+  "chainId": 1523903251,
+  "networkId": 1523903251,
+  "icon": "haust",
+  "explorers": [
+    {
+      "name": "Haust Network Testnet Explorer",
+      "url": "https://explorer-testnet.haust.app",
+      "icon": "haust",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-11155111",
+    "bridges": [{ "url": "https://bridge-testnet.haust.app" }]
+  },
+  "features":[{ "name": "EIP155" }],
+  "status": "active"
+}

--- a/_data/chains/eip155-490092.json
+++ b/_data/chains/eip155-490092.json
@@ -1,0 +1,22 @@
+{
+  "name": "PUMPFI CHAIN TESTNET",
+  "chain": "PUMPFI CHAIN TESTNET",
+  "rpc": ["https://rpc1testnet.pumpfi.me"],
+  "faucets": ["https://faucet.pumpfi.me"],
+  "nativeCurrency": {
+    "name": "PMPT",
+    "symbol": "PMPT",
+    "decimals": 18
+  },
+  "infoURL": "https://pumpfi.me",
+  "shortName": "pumpfi-testnet",
+  "chainId": 490092,
+  "networkId": 490092,
+  "explorers": [
+    {
+      "name": "Pumpfi Testnet Scan",
+      "url": "https://testnetscan.pumpfi.me",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
I have added Haust Network Testnet Chain. Please find the Icon for the network in the _data/icons/haust.json directory of the upstream repository.