### PR TITLE
Change L2 parent for Mint Sepolia

### DIFF
--- a/_data/chains/eip155-1687.json
+++ b/_data/chains/eip155-1687.json
@@ -23,7 +23,7 @@
   ],
   "parent": {
     "type": "L2",
-    "chain": "eip155-1",
+    "chain": "eip155-11155111",
     "bridges": [{ "url": "https://sepolia-testnet-bridge.mintchain.io" }]
   }
 }


### PR DESCRIPTION
Fixes bug with L2 parent for Mint Sepolia: Mainnet -> Sepolia 