### PR TITLE
Added PrimeaChain (Chain ID 698369)

### DIFF
--- a/_data/chains/eip155-698369.json
+++ b/_data/chains/eip155-698369.json
@@ -1,0 +1,29 @@
+{
+	"name": "PrimeaChain",
+	"chain": "primeachain",
+	"chainId": 698369,
+	"shortName": "PRIM",
+	"networkId": 698369,
+	"slip44": 698369,
+	"nativeCurrency": {
+		"name": "PrimeaCoin",
+		"symbol": "PRIM",
+		"decimals": 18
+	},
+	"rpc": [
+		"https://rpc.primeanetwork.com",
+		"https://rpc1.primeanetwork.com",
+		"https://rpc2.primeanetwork.com"
+	],
+	"faucets": [
+		"https://faucet.primeanetwork.com"
+	],
+	"infoURL": "https://primeanetwork.com",
+	"explorers": [
+		{
+			"name": "PrimeaScan",
+			"url": "https://explorer.primeanetwork.com",
+			"standard": "EIP3091"
+		}
+	]
+}


### PR DESCRIPTION
Adding PrimeaChain to Ethereum-Lists.

Chain ID: 698369
RPC: https://rpc.primeanetwork.com/, https://rpc1.primeanetwork.com/, https://rpc2.primeanetwork.com/
Faucet: https://faucet.primeanetwork.com/
Block Explorer: https://explorer.primeanetwork.com/