### PR TITLE
Add chain information for JuChain Testnet (Chain ID: 66633666)

### DIFF
--- a/_data/chains/eip155-66633666.json
+++ b/_data/chains/eip155-66633666.json
@@ -1,0 +1,25 @@
+{
+  "name": "JuChain Testnet",
+  "chainId": 66633666,
+  "shortName": "JU",
+  "chain": "JuChain",
+  "network": "testnet",
+  "networkId": 66633666,
+  "nativeCurrency": {
+    "name": "JuChain Testnet Coin",
+    "symbol": "JU",
+    "decimals": 18
+  },
+  "rpc": [
+    "http://testnet-rpc.juchain.org"
+  ],
+  "faucets": [],
+  "explorers": [
+    {
+      "name": "JuChain Testnet Explorer",
+      "url": "https://explorer-testnet.juchain.org",
+      "standard": "EIP3091"
+    }
+  ],
+  "infoURL": "https://testnet.juchain.org/"
+}


### PR DESCRIPTION
This PR adds support for JuChain Testnet with the following details:
- Chain ID: 66633666
- RPC URL: http://testnet-rpc.juchain.org
- Native Currency: JU
- Explorer: https://explorer-testnet.juchain.org/