### PR TITLE
feat(docs): change name of taiko mainnet and testnet

### DIFF
--- a/_data/chains/eip155-167000.json
+++ b/_data/chains/eip155-167000.json
@@ -1,5 +1,5 @@
 {
-  "name": "Taiko Mainnet",
+  "name": "Taiko Alethia",
   "chain": "ETH",
   "status": "active",
   "icon": "taiko",

--- a/_data/chains/eip155-167009.json
+++ b/_data/chains/eip155-167009.json
@@ -1,5 +1,5 @@
 {
-  "name": "Taiko Hekla L2",
+  "name": "Taiko Hekla",
   "chain": "ETH",
   "status": "active",
   "icon": "taiko",


### PR DESCRIPTION
@ligi we have recently changed the name of our existing Taiko Mainnet to Taiko Alethia, You can find it here: https://docs.taiko.xyz/core-concepts/what-is-taiko-alethia/

Also changed the name of Taiko Hekla L2 to "Taiko Hekla" for uniformity.