### PR TITLE
Update to GH Actions V4

### DIFF
--- a/.github/workflows/prettier_check.yml
+++ b/.github/workflows/prettier_check.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
-        uses: actions/checkout@v2
-      - uses: actions/cache@v2
+        uses: actions/checkout@v4
+      - uses: actions/cache@v4
         name: Configure npm caching
         with:
           path: ~/.npm

--- a/.github/workflows/validate_json.yml
+++ b/.github/workflows/validate_json.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repo
-      uses: actions/checkout@v2
-    - uses: actions/cache@v2
+      uses: actions/checkout@v4
+    - uses: actions/cache@v4
       name: Configure npm caching
       with:
         path: ~/.npm


### PR DESCRIPTION
Github is currently doing a brownout period for cache V2 which is causing PR checks to fail.
https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down