### PR TITLE
Add Ting Blockchain Testnet (Chain ID: 6666689)

### DIFF
--- a/_data/chains/eip155-6666689.json
+++ b/_data/chains/eip155-6666689.json
@@ -1,0 +1,26 @@
+{
+  "name": "The Ting Blockchain Testnet",
+  "chain": "Ting",
+  "rpc": [
+    "https://testnet.tingchain.org/"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ton",
+    "symbol": "Ton",
+    "decimals": 18
+  },
+  "infoURL": "https://tingscan.com/",
+  "shortName": "ting",
+  "chainId": 6666689,
+  "networkId": 6666689,
+  "icon": "ting",
+  "explorers": [
+    {
+      "name": "TingScan",
+      "url": "https://tingscan.com/",
+      "icon": "tingscan",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds The Ting Blockchain Testnet to Chainlist.
- Chain ID: 6666689
- Network name: The Ting Blockchain Testnet
- RPC: https://testnet.tingchain.org/
- Explorer: https://tingscan.com/