### PR TITLE
Add The Ting Blockchain Testnet (chainId: 6666689) to Chainlist

### DIFF
--- a/_data/chains/eip155-6666689.json
+++ b/_data/chains/eip155-6666689.json
@@ -1,27 +1,27 @@
 {
-  "name": "The Ting Blockchain Testnet Explorer",
-  "chain": "TingTestnet",
-  "icon": "",
-  "rpc": [
-    "https://testnet.tingchain.org/"
-  ],
-  "faucets": [],
-  "nativeCurrency": {
-    "name": "Ton",
-    "symbol": "Ton",
-    "decimals": 18
-  },
-  "infoURL": "https://tingscan.com/",
-  "shortName": "tingtest",
-  "chainId": 6666689,
-  "networkId": 6666689,
-  "explorers": [
-    {
-      "name": "TingScan",
-      "url": "https://tingscan.com/",
-      "standard": "EIP3091"
-    }
-  ],
-  "testnet": true,
-  "slug": "ting-testnet"
+    "name": "The Ting Blockchain Testnet Explorer",
+    "chain": "TingTestnet",
+    "icon": "",
+    "rpc": [
+        "https://testnet.tingchain.org/"
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+        "name": "Ton",
+        "symbol": "Ton",
+        "decimals": 18
+    },
+    "infoURL": "https://tingscan.com/",
+    "shortName": "tingtest",
+    "chainId": 6666689,
+    "networkId": 6666689,
+    "explorers": [
+        {
+            "name": "TingScan",
+            "url": "https://tingscan.com/",
+            "standard": "EIP3091"
+        }
+    ],
+    "testnet": true,
+    "slug": "ting-testnet"
 }

--- a/_data/chains/eip155-6666689.json
+++ b/_data/chains/eip155-6666689.json
@@ -3,7 +3,7 @@
     "chain": "TingTestnet",
     "icon": "",
     "rpc": [
-        "https://testnet.tingchain.org/"
+        "https://testnet.tingchain.org"
     ],
     "faucets": [],
     "nativeCurrency": {
@@ -11,14 +11,14 @@
         "symbol": "Ton",
         "decimals": 18
     },
-    "infoURL": "https://tingscan.com/",
+    "infoURL": "https://tingscan.com",
     "shortName": "tingtest",
     "chainId": 6666689,
     "networkId": 6666689,
     "explorers": [
         {
             "name": "TingScan",
-            "url": "https://tingscan.com/",
+            "url": "https://tingscan.com",
             "standard": "EIP3091"
         }
     ],

--- a/_data/chains/eip155-6666689.json
+++ b/_data/chains/eip155-6666689.json
@@ -1,0 +1,27 @@
+{
+  "name": "The Ting Blockchain Testnet Explorer",
+  "chain": "TingTestnet",
+  "icon": "",
+  "rpc": [
+    "https://testnet.tingchain.org/"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ton",
+    "symbol": "Ton",
+    "decimals": 18
+  },
+  "infoURL": "https://tingscan.com/",
+  "shortName": "tingtest",
+  "chainId": 6666689,
+  "networkId": 6666689,
+  "explorers": [
+    {
+      "name": "TingScan",
+      "url": "https://tingscan.com/",
+      "standard": "EIP3091"
+    }
+  ],
+  "testnet": true,
+  "slug": "ting-testnet"
+}


### PR DESCRIPTION
This PR adds The Ting Blockchain Testnet to Chainlist with the following details:

Network Name: The Ting Blockchain Testnet Explorer
Chain ID: 6666689
RPC URL: https://testnet.tingchain.org/
Explorer: [TingScan](https://tingscan.com/)
Native Currency: Ton (Ton)
Total Supply: 1,000,000,000 Ton
Network Type: Testnet
This addition allows users to connect their wallets (e.g., MetaMask) to The Ting Blockchain Testnet more easily.

Please review and merge. Let me know if any modifications are needed. Thank you! 🚀