### PR TITLE
Add Ting Chain Testnet (chainId: 6666689) to Chainlist

### DIFF
--- a/_data/chains/eip155-6666689.json
+++ b/_data/chains/eip155-6666689.json
@@ -1,0 +1,23 @@
+{
+  "name": "Ting Blockchain",
+  "chain": "TING",
+  "rpc": ["https://rpc.tingchain.com"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ting Token",
+    "symbol": "TING",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://tingchain.com",
+  "shortName": "ting",
+  "chainId": 123456,
+  "networkId": 123456,
+  "explorers": [
+    {
+      "name": "Ting Explorer",
+      "url": "https://explorer.tingchain.com",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-6666689.json
+++ b/_data/chains/eip155-6666689.json
@@ -1,22 +1,22 @@
 {
-  "name": "Ting Blockchain",
-  "chain": "TING",
-  "rpc": ["https://rpc.tingchain.com"],
+  "name": "The Ting Blockchain Testnet Explorer",
+  "chain": "Ting",
+  "rpc": ["https://testnet.tingchain.org"],
   "faucets": [],
   "nativeCurrency": {
-    "name": "Ting Token",
-    "symbol": "TING",
+    "name": "Ton",
+    "symbol": "Ton",
     "decimals": 18
   },
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
-  "infoURL": "https://tingchain.com",
-  "shortName": "ting",
-  "chainId": 123456,
-  "networkId": 123456,
+  "infoURL": "https://tingscan.com",
+  "shortName": "ting-testnet",
+  "chainId": 6666689,
+  "networkId": 6666689,
   "explorers": [
     {
-      "name": "Ting Explorer",
-      "url": "https://explorer.tingchain.com",
+      "name": "TingScan",
+      "url": "https://tingscan.com",
       "standard": "EIP3091"
     }
   ]


### PR DESCRIPTION
This PR adds the Ting Chain Testnet to Chainlist.

## ✅ Chain Information:
- **Network Name:** Ting Chain Testnet  
- **Chain ID:** 6666689  
- **RPC URLs:**  
  - https://testnet.tingchain.org/  
- **Explorer URL:** https://tingscan.com  
- **Native Currency:**  
  - Name: Ton  
  - Symbol: Ton  
  - Decimals: 18  
- **EIP Features:** EIP-155, EIP-1559  

## 📌 Additional Notes:
- The JSON file follows the standard format used in the Chainlist repository.
- Please review and merge if everything is correct.  

Thank you! 🚀