### PR TITLE
Update ZCX to ZTC for ZenChain

### DIFF
--- a/_data/chains/eip155-8108.json
+++ b/_data/chains/eip155-8108.json
@@ -1,13 +1,13 @@
 {
-  "name": "Zenchain",
-  "chain": "ZCX",
+  "name": "ZenChain",
+  "chain": "ZTC",
   "icon": "zenchain",
   "rpc": [],
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "faucets": [],
   "nativeCurrency": {
-    "name": "ZCX",
-    "symbol": "ZCX",
+    "name": "ZTC",
+    "symbol": "ZTC",
     "decimals": 18
   },
   "infoURL": "https://zenchain.io",

--- a/_data/chains/eip155-8408.json
+++ b/_data/chains/eip155-8408.json
@@ -1,6 +1,6 @@
 {
-  "name": "Zenchain Testnet",
-  "chain": "ZCX",
+  "name": "ZenChain Testnet",
+  "chain": "ZTC",
   "icon": "zenchain",
   "rpc": [
     "https://zenchain-testnet.api.onfinality.io/public",
@@ -9,8 +9,8 @@
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "faucets": ["https://facuet.zenchain.io"],
   "nativeCurrency": {
-    "name": "ZCX",
-    "symbol": "ZCX",
+    "name": "ZTC",
+    "symbol": "ZTC",
     "decimals": 18
   },
   "infoURL": "https://zenchain.io",


### PR DESCRIPTION
Hi,

The ZenChain network is updating its native currency symbol from ZCX to ZTC.

Thank you,

Kris Bitney