### PR TITLE
Add new chain: eip155:61022448 (Dkargo testnet: warehouse)

### DIFF
--- a/_data/chains/eip155-61022448.json
+++ b/_data/chains/eip155-61022448.json
@@ -1,15 +1,15 @@
 {
-    "name": "dKargo Warehouse Testnet",
-    "chain": "dKargo Warehouse",
-    "rpc": ["https://warehouse-full01.dkargo.io"],
-    "faucets": [],
-    "nativeCurrency": {
-        "name": "dKargo",
-        "symbol": "DKA",
-        "decimals": 18
-    },
-    "infoURL": "https://dkargo.io",
-    "shortName": "dkargowarehouse",
-    "chainId": 61022448,
-    "networkId": 61022448
+  "name": "dKargo Warehouse Testnet",
+  "chain": "dKargo Warehouse",
+  "rpc": ["https://warehouse-full01.dkargo.io"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "dKargo",
+    "symbol": "DKA",
+    "decimals": 18
+  },
+  "infoURL": "https://dkargo.io",
+  "shortName": "dkargowarehouse",
+  "chainId": 61022448,
+  "networkId": 61022448
 }

--- a/_data/chains/eip155-61022448.json
+++ b/_data/chains/eip155-61022448.json
@@ -1,0 +1,15 @@
+{
+    "name": "dKargo Warehouse Testnet",
+    "chain": "dKargo Warehouse",
+    "rpc": ["https://warehouse-full01.dkargo.io"],
+    "faucets": [],
+    "nativeCurrency": {
+        "name": "dKargo",
+        "symbol": "DKA",
+        "decimals": 18
+    },
+    "infoURL": "https://dkargo.io",
+    "shortName": "dkargowarehouse",
+    "chainId": 61022448,
+    "networkId": 61022448
+}


### PR DESCRIPTION
This PR adds a new chain entry to the ethereum-lists/chains repository, based on the CAIP‑2 standard.

Chain Information

Chain Name: dKargo Warehouse Testnet
Chain ID: eip155:61022448
Network Characteristics: An L3 Rollup chain built on Arbitrum Sepolia
This chain entry follows the CAIP‑2 specification for defining a unique chain identifier in the format <namespace>:<reference>. The new chain is intended to support testing and scalability within the dKargo ecosystem. For further details, please refer to the [CAIP‑2 specification](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md?plain=1).