### PR TITLE
RHINO berachain mainnet RPC array

### DIFF
--- a/_data/chains/eip155-80094.json
+++ b/_data/chains/eip155-80094.json
@@ -4,7 +4,9 @@
   "rpc": [
     "https://rpc.berachain.com",
     "https://berachain-rpc.publicnode.com",
-    "wss://berachain-rpc.publicnode.com"
+    "wss://berachain-rpc.publicnode.com",
+    "https://rpc.berachain-apis.com",
+    "wss://rpc.berachain-apis.com"
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
Add Berachain (80094) mainnet RPC array endpoint.  More info at https://berachain-apis.com