### PR TITLE
chore: deprecate bartio

### DIFF
--- a/_data/chains/eip155-80084.json
+++ b/_data/chains/eip155-80084.json
@@ -1,12 +1,9 @@
 {
   "name": "Berachain bArtio",
   "chain": "Berachain bArtio",
-  "rpc": [
-    "https://bartio.rpc.berachain.com",
-    "https://bera-testnet.nodeinfra.com",
-    "https://bartio.rpc.b-harvest.io"
-  ],
-  "faucets": ["https://bartio.faucet.berachain.com"],
+  "status": "deprecated",
+  "rpc": [],
+  "faucets": [],
   "nativeCurrency": {
     "name": "BERA Token",
     "symbol": "BERA",


### PR DESCRIPTION
Berachain has deprecated Bartio recently, updated data to reflect this.