### PR TITLE
Add chain ID 863 - Radius Testnet

### DIFF
--- a/_data/chains/eip155-863.json
+++ b/_data/chains/eip155-863.json
@@ -11,6 +11,5 @@
   "infoURL": "https://www.theradius.xyz/",
   "shortName": "radius-testnet",
   "chainId": 863,
-  "networkId": 863,
-  "status": "incubating"
+  "networkId": 863
 }

--- a/_data/chains/eip155-863.json
+++ b/_data/chains/eip155-863.json
@@ -1,0 +1,16 @@
+{
+  "name": "Radius Testnet",
+  "chain": "Radius",
+  "rpc": ["https://dev-secure.rpc.theradius.xyz"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Useless",
+    "symbol": "USLS",
+    "decimals": 18
+  },
+  "infoURL": "https://www.theradius.xyz/",
+  "shortName": "radius-testnet",
+  "chainId": 863,
+  "networkId": 863,
+  "status": "incubating"
+}


### PR DESCRIPTION
- Chain Name: Radius Testnet
- Chain ID: 863
- RPC URL: https://dev-secure.rpc.theradius.xyz
- Block Explorer: (None for now)
- Native Currency: Useless (USLS)
