### PR TITLE
Updated edexa mainnet rpcs

### DIFF
--- a/_data/chains/eip155-5424.json
+++ b/_data/chains/eip155-5424.json
@@ -1,12 +1,7 @@
 {
   "name": "edeXa Mainnet",
   "chain": "edeXa",
-  "rpc": [
-    "https://mainnet.edexa.network/rpc",
-    "wss://mainnet.edexa.network/wss",
-    "https://mainnet.edexa.com/rpc",
-    "wss://mainnet.edexa.com/wss"
-  ],
+  "rpc": ["https://rpc.edexa.network", "https://rpc.edexa.com"],
   "faucets": [],
   "features": [
     {


### PR DESCRIPTION
The old RPCs remain accessible for now, but these are the new preferred ones.