### PR TITLE
Updated edeXa testnet rpcs

### DIFF
--- a/_data/chains/eip155-1995.json
+++ b/_data/chains/eip155-1995.json
@@ -1,12 +1,7 @@
 {
   "name": "edeXa Testnet",
   "chain": "edeXa",
-  "rpc": [
-    "https://testnet.edexa.network/rpc",
-    "wss://testnet.edexa.network/wss",
-    "https://testnet.edexa.com/rpc",
-    "wss://testnet.edexa.com/wss"
-  ],
+  "rpc": ["https://rpc.testnet.edexa.network", "https://rpc.testnet.edexa.com"],
   "faucets": ["https://faucet.edexa.com/"],
   "nativeCurrency": {
     "name": "edeXa",


### PR DESCRIPTION
The old RPCs remain accessible for now, but these are the new preferred ones.