### PR TITLE
mark chain ID 98865 as legacy

### DIFF
--- a/_data/chains/eip155-98865.json
+++ b/_data/chains/eip155-98865.json
@@ -1,6 +1,6 @@
 {
-  "name": "Plume",
-  "title": "Plume Ethereum L2 Rollup Mainnet",
+  "name": "Plume (Legacy)",
+  "title": "Plume Ethereum L2 Rollup Mainnet (Legacy)",
   "chain": "ETH",
   "rpc": ["https://rpc.plumenetwork.xyz", "wss://rpc.plumenetwork.xyz"],
   "faucets": [],


### PR DESCRIPTION
Superseded by the new deployment in #6967.