### PR TITLE
Remove deprecated rpc of overprotocol mainnet

### DIFF
--- a/_data/chains/eip155-54176.json
+++ b/_data/chains/eip155-54176.json
@@ -2,7 +2,7 @@
   "name": "OverProtocol Mainnet",
   "chain": "OverProtocol",
   "icon": "overIcon",
-  "rpc": ["https://rpc.overprotocol.com", "https://rpc2.overprotocol.com"],
+  "rpc": ["https://rpc.overprotocol.com"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Over",


### PR DESCRIPTION
`rpc2.overprotocol.com` is deprecated.