### PR TITLE
Add Powerloom Mainnet V2

### DIFF
--- a/_data/chains/eip155-7869.json
+++ b/_data/chains/eip155-7869.json
@@ -1,6 +1,6 @@
 {
   "name": "Powerloom Mainnet V2",
-  "chain": "POWER",
+  "chain": "Powerloom Mainnet V2",
   "rpc": ["https://rpc-v2.powerloom.network"],
   "faucets": [],
   "nativeCurrency": {
@@ -9,7 +9,7 @@
     "decimals": 18
   },
   "infoURL": "https://powerloom.network",
-  "shortName": "power",
+  "shortName": "powerloom",
   "chainId": 7869,
   "networkId": 7869,
   "icon": "power",

--- a/_data/chains/eip155-7869.json
+++ b/_data/chains/eip155-7869.json
@@ -1,0 +1,25 @@
+{
+  "name": "Powerloom Mainnet V2",
+  "chain": "POWER",
+  "rpc": ["https://rpc-v2.powerloom.network"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Powerloom Token",
+    "symbol": "POWER",
+    "decimals": 18
+  },
+  "infoURL": "https://powerloom.network",
+  "shortName": "power",
+  "chainId": 7869,
+  "networkId": 7869,
+  "icon": "power",
+  "status": "active",
+  "explorers": [
+    {
+      "name": "blockscout",
+      "url": "https://explorer-v2.powerloom.network",
+      "icon": "blockscout",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Context: https://x.com/Powerloom/status/1897669070688022845

`TL;DR: OP Stack has discontinued support for custom gas tokens. Powerloom has a new Arbitrum Orbit based chain with a new chainid but same icon. The older chain will continue to run until migration is complete`