### PR TITLE
Added Fastnode's public endpoint for Atleta Testnet

### DIFF
--- a/_data/chains/eip155-2340.json
+++ b/_data/chains/eip155-2340.json
@@ -6,7 +6,8 @@
     "https://rpc.ankr.com/atleta_olympia",
     "wss://testnet-rpc.atleta.network",
     "https://atleta-testnet.htw.tech/",
-    "https://public-atleta.nownodes.io"
+    "https://public-atleta.nownodes.io",
+    "https://public-atla-testnet.fastnode.io"
   ],
   "faucets": ["https://app-olympia.atleta.network/faucet"],
   "nativeCurrency": {


### PR DESCRIPTION
Added Fastnode’s public endpoint for Atleta Testnet. No breaking changes or modifications to existing functionality.