### PR TITLE
chore: deprecate testnet-1 and devnet 3 Nibiru chains

### DIFF
--- a/_data/chains/eip155-7210.json
+++ b/_data/chains/eip155-7210.json
@@ -8,6 +8,7 @@
     "symbol": "NIBI",
     "decimals": 18
   },
+  "status": "deprecated",
   "infoURL": "https://nibiru.fi",
   "shortName": "nibiru-testnet-1",
   "chainId": 7210,

--- a/_data/chains/eip155-7222.json
+++ b/_data/chains/eip155-7222.json
@@ -8,6 +8,7 @@
     "symbol": "NIBI",
     "decimals": 18
   },
+  "status": "deprecated",
   "infoURL": "https://nibiru.fi",
   "shortName": "nibiru-devnet-3",
   "chainId": 7222,


### PR DESCRIPTION
Deprecates testnet-1 and devnet-3