### PR TITLE
Rename XYL TestNet to Xylume TestNet, and update icon and info.

### DIFF
--- a/_data/chains/eip155-6934.json
+++ b/_data/chains/eip155-6934.json
@@ -1,5 +1,5 @@
 {
-  "name": "XYL TestNet",
+  "name": "Xylume TestNet",
   "chain": "XYL",
   "rpc": ["https://xyl-testnet.glitch.me/rpc/"],
   "faucets": ["https://debxylen.github.io/XYL_TestNet/faucet.html"],
@@ -11,23 +11,18 @@
   "features": [
     { "name": "EIP155" },
     { "name": "EIP1559" },
-    { "name": "XYL-DynaPoW" },
-    { "name": "Smart Contracts" },
-    { "name": "Custom Gas Model" },
-    { "name": "XYL-VM" },
-    { "name": "Dynamic Difficulty Adjustment" },
-    { "name": "Low-Latency Transactions" }
+    { "name": "Directed Acyclic Graph (DAG)" }
   ],
-  "infoURL": "https://debxylen.github.io/XYL_TestNet",
+  "infoURL": "https://debxylen.github.io/Xylume_TestNet",
   "shortName": "xyl",
   "chainId": 6934,
   "networkId": 6934,
-  "icon": "xyl-test",
+  "icon": "xylume-testnet",
   "explorers": [
     {
-      "name": "XYL Explorer",
-      "url": "https://debxylen.github.io/BlockExplorer",
-      "icon": "xyl-test",
+      "name": "Xylume Explorer",
+      "url": "https://debxylen.github.io/XylumeExplorer",
+      "icon": "xylume-testnet",
       "standard": "EIP3091"
     }
   ]

--- a/_data/icons/xyl-test.json
+++ b/_data/icons/xyl-test.json
@@ -1,8 +1,0 @@
-[
-  {
-    "url": "ipfs://QmYLd4jRsRiSnGERvzBGmMuXGo6q5AYhmr8UFtmXzGhRc5",
-    "width": 505,
-    "height": 505,
-    "format": "png"
-  }
-]

--- a/_data/icons/xylume-testnet.json
+++ b/_data/icons/xylume-testnet.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmRk9t6g5otTX6XcQjvFwsfzn2KjZwbstptH9C7uG2kVdD",
+    "width": 500,
+    "height": 500,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
XYL TestNet just got a v3, and is now renamed to Xylume TestNet. New Icon and information has been updated.