### PR TITLE
add new Plume testnet

### DIFF
--- a/_data/chains/eip155-161221135.json
+++ b/_data/chains/eip155-161221135.json
@@ -1,6 +1,6 @@
 {
-  "name": "Plume Testnet",
-  "title": "Plume Sepolia Rollup Testnet",
+  "name": "Plume Testnet (Legacy)",
+  "title": "Plume Sepolia Rollup Testnet (Legacy)",
   "chain": "ETH",
   "rpc": [],
   "faucets": [],
@@ -10,7 +10,7 @@
     "decimals": 18
   },
   "infoURL": "https://plumenetwork.xyz/",
-  "shortName": "plume-testnet",
+  "shortName": "plume-testnet-legacy",
   "chainId": 161221135,
   "networkId": 161221135,
   "slip44": 1,

--- a/_data/chains/eip155-161221135.json
+++ b/_data/chains/eip155-161221135.json
@@ -1,7 +1,7 @@
 {
   "name": "Plume Testnet (Legacy)",
   "title": "Plume Sepolia L2 Rollup Testnet (Legacy)",
-  "chain": "ETH",
+  "chain": "PLUME Testnet Legacy",
   "rpc": [],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-161221135.json
+++ b/_data/chains/eip155-161221135.json
@@ -1,6 +1,6 @@
 {
   "name": "Plume Testnet (Legacy)",
-  "title": "Plume Sepolia Rollup Testnet (Legacy)",
+  "title": "Plume Sepolia L2 Rollup Testnet (Legacy)",
   "chain": "ETH",
   "rpc": [],
   "faucets": [],

--- a/_data/chains/eip155-98864.json
+++ b/_data/chains/eip155-98864.json
@@ -1,7 +1,7 @@
 {
   "name": "Plume Devnet (Legacy)",
   "title": "Plume Sepolia L2 Rollup Devnet (Legacy)",
-  "chain": "ETH",
+  "chain": "PLUME Devnet Legacy",
   "rpc": [
     "https://test-rpc.plumenetwork.xyz",
     "wss://test-rpc.plumenetwork.xyz"

--- a/_data/chains/eip155-98864.json
+++ b/_data/chains/eip155-98864.json
@@ -1,6 +1,6 @@
 {
-  "name": "Plume Devnet",
-  "title": "Plume Sepolia L2 Rollup Devnet",
+  "name": "Plume Devnet (Legacy)",
+  "title": "Plume Sepolia L2 Rollup Devnet (Legacy)",
   "chain": "ETH",
   "rpc": [
     "https://test-rpc.plumenetwork.xyz",
@@ -18,6 +18,7 @@
   "networkId": 98864,
   "slip44": 1,
   "icon": "plume",
+  "status": "deprecated",
   "explorers": [
     {
       "name": "Blockscout",

--- a/_data/chains/eip155-98865.json
+++ b/_data/chains/eip155-98865.json
@@ -1,7 +1,7 @@
 {
   "name": "Plume (Legacy)",
   "title": "Plume Ethereum L2 Rollup Mainnet (Legacy)",
-  "chain": "ETH",
+  "chain": "PLUME Legacy",
   "rpc": ["https://rpc.plumenetwork.xyz", "wss://rpc.plumenetwork.xyz"],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-98866.json
+++ b/_data/chains/eip155-98866.json
@@ -1,7 +1,7 @@
 {
   "name": "Plume Mainnet",
   "title": "Plume Ethereum L2 Rollup Mainnet",
-  "chain": "ETH",
+  "chain": "PLUME",
   "rpc": [
     "https://phoenix-rpc.plumenetwork.xyz",
     "wss://phoenix-rpc.plumenetwork.xyz"

--- a/_data/chains/eip155-98867.json
+++ b/_data/chains/eip155-98867.json
@@ -1,7 +1,7 @@
 {
   "name": "Plume Testnet",
   "title": "Plume Sepolia L2 Rollup Testnet",
-  "chain": "ETH",
+  "chain": "PLUME Testnet",
   "rpc": [
     "https://testnet-rpc.plumenetwork.xyz",
     "wss://testnet-rpc.plumenetwork.xyz"

--- a/_data/chains/eip155-98867.json
+++ b/_data/chains/eip155-98867.json
@@ -1,6 +1,6 @@
 {
   "name": "Plume Testnet",
-  "title": "Plume Sepolia Rollup Testnet",
+  "title": "Plume Sepolia L2 Rollup Testnet",
   "chain": "ETH",
   "rpc": [
     "https://testnet-rpc.plumenetwork.xyz",

--- a/_data/chains/eip155-98867.json
+++ b/_data/chains/eip155-98867.json
@@ -6,7 +6,7 @@
     "https://testnet-rpc.plumenetwork.xyz",
     "wss://testnet-rpc.plumenetwork.xyz"
   ],
-  "faucets": [],
+  "faucets": ["https://faucet.plumenetwork.xyz"],
   "nativeCurrency": {
     "name": "Plume",
     "symbol": "PLUME",

--- a/_data/chains/eip155-98867.json
+++ b/_data/chains/eip155-98867.json
@@ -1,0 +1,35 @@
+{
+  "name": "Plume Testnet",
+  "title": "Plume Sepolia Rollup Testnet",
+  "chain": "ETH",
+  "rpc": [
+    "https://testnet-rpc.plumenetwork.xyz",
+    "wss://testnet-rpc.plumenetwork.xyz"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Plume",
+    "symbol": "PLUME",
+    "decimals": 18
+  },
+  "infoURL": "https://plumenetwork.xyz/",
+  "shortName": "plume-testnet",
+  "chainId": 98867,
+  "networkId": 98867,
+  "slip44": 1,
+  "icon": "plume",
+  "status": "incubating",
+  "explorers": [
+    {
+      "name": "Blockscout",
+      "url": "https://testnet-explorer.plumenetwork.xyz",
+      "icon": "blockscout",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-11155111",
+    "bridges": [{ "url": "https://testnet-bridge.plumenetwork.xyz" }]
+  }
+}


### PR DESCRIPTION
Adds the newest version of Plume testnet, which supersedes and deprecates the previous versions of Plume testnet and Plume devnet.