### PR TITLE
add Load Network chain and icon

### DIFF
--- a/_data/chains/eip155-9496.json
+++ b/_data/chains/eip155-9496.json
@@ -1,22 +1,22 @@
 {
-  "name": "WeaveVM Testnet",
-  "chain": "WVM",
-  "rpc": ["https://testnet.wvm.dev", "https://testnet-rpc.wvm.dev"],
-  "faucets": [],
+  "name": "Load Alphanet",
+  "chain": "LOAD",
+  "rpc": ["https://alphanet.load.network"],
+  "faucets": ["https://load.network/faucet"],
   "nativeCurrency": {
-    "name": "Testnet WeaveVM Token",
-    "symbol": "tWVM",
+    "name": "Testnet Load Token",
+    "symbol": "tLOAD",
     "decimals": 18
   },
-  "infoURL": "https://wvm.dev",
-  "shortName": "twvm",
+  "infoURL": "https://load.network",
+  "shortName": "tload",
   "chainId": 9496,
   "networkId": 9496,
-  "icon": "weavevm",
+  "icon": "loadnetwork",
   "explorers": [
     {
-      "name": "WeaveVM Explorer",
-      "url": "https://explorer.wvm.dev",
+      "name": "Load Network Explorer",
+      "url": "https://explorer.load.network",
       "standard": "EIP3091"
     }
   ]

--- a/_data/icons/loadnetwork.json
+++ b/_data/icons/loadnetwork.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreidgb2du22hxgj23jhyi2gipiovejn75cp6agmrklhxclu63v5pjxu",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]

--- a/_data/icons/weavevm.json
+++ b/_data/icons/weavevm.json
@@ -1,8 +1,0 @@
-[
-  {
-    "url": "ipfs://QmZrL43kuLcK14gQo1cVbzwczcVULxN6NKb4EcjYpFpE7w",
-    "width": 500,
-    "height": 500,
-    "format": "png"
-  }
-]


### PR DESCRIPTION
WeaveVM rebranded to Load Network (https://blog.load.network/weavevm-is-now-load-network/). 

This PR updates the 9496 metadata and adds a new loadnetwork icon.