### PR TITLE
Add Studio Blockchain Mainnet and Icon

### DIFF
--- a/_data/chains/eip155-240240.json
+++ b/_data/chains/eip155-240240.json
@@ -12,7 +12,11 @@
     "symbol": "STO",
     "decimals": 18
   },
-  "features": [{ "name": "EIP155" }],
+  "features": [
+    {
+      "name": "EIP155"
+    }
+  ],
   "infoURL": "https://studio-blockchain.com",
   "shortName": "sto",
   "chainId": 240240,

--- a/_data/chains/eip155-240241.json
+++ b/_data/chains/eip155-240241.json
@@ -1,0 +1,36 @@
+{
+  "name": "Studio Blockchain Mainnet",
+  "chain": "STO",
+  "icon": "studio",
+  "rpc": [
+    "https://mainnet.studio-blockchain.com",
+    "https://mainnet2.studio-blockchain.com",
+    "https://mainnet3.studio-blockchain.com",
+    "https://mainnet.studio-scan.com",
+    "https://mainnet2.studio-scan.com",
+    "wss://mainnet.studio-blockchain.com:8547"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Studio Token",
+    "symbol": "STO",
+    "decimals": 18
+  },
+  "features": [
+    {
+      "name": "EIP155"
+    }
+  ],
+  "infoURL": "https://studio-blockchain.com",
+  "shortName": "stom",
+  "chainId": 240241,
+  "networkId": 240241,
+  "explorers": [
+    {
+      "name": "Studio Explorer",
+      "url": "https://explorer.studio-blockchain.com",
+      "standard": "EIP3091"
+    }
+  ],
+  "status": "active"
+}


### PR DESCRIPTION
This pull request adds the Studio Blockchain Mainnet (chainId 240241) to the chains list. Our testnet (chainId 240240) was previously added, but this PR introduces our mainnet as a separate network.

This PR includes:

Studio Blockchain icon (studio.json) in the icons directory
Studio Blockchain Mainnet configuration (eip155-240241.json) with the following RPC endpoints:
https://mainnet.studio-blockchain.com/
https://mainnet2.studio-blockchain.com/
https://mainnet3.studio-blockchain.com/
https://mainnet.studio-scan.com/
https://mainnet2.studio-scan.com/
WebSocket: wss://mainnet.studio-blockchain.com:8547
The Studio Blockchain Mainnet is now live and ready for integration with wallets and dApps through chainlist.org.

Thank you for considering this addition!