### PR TITLE
RPC for TEN Testnet Rollup has been updated.

### DIFF
--- a/_data/chains/eip155-443.json
+++ b/_data/chains/eip155-443.json
@@ -11,7 +11,7 @@
     "symbol": "ETH",
     "decimals": 18
   },
-  "rpc": ["https://testnet.ten.xyz"],
+  "rpc": ["https://rpc.testnet.ten.xyz"],
   "faucets": [],
   "infoURL": "https://ten.xyz",
   "explorers": [


### PR DESCRIPTION
Old RPC: https://testnet.ten.xyz
New RPC: https://rpc.testnet.ten.xyz