### PR TITLE
Add new RPC endpoint for The Ting Blockchain Testnet

### DIFF
--- a/_data/chains/eip155-6666689.json
+++ b/_data/chains/eip155-6666689.json
@@ -1,7 +1,9 @@
 {
   "name": "The Ting Blockchain Testnet Explorer",
   "chain": "Ting",
-  "rpc": ["https://testnet.tingchain.org"],
+  "rpc": ["https://testnet.tingchain.org",
+          "https://public.0xrpc.com/6666689"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ton",

--- a/_data/chains/eip155-6666689.json
+++ b/_data/chains/eip155-6666689.json
@@ -1,8 +1,9 @@
 {
   "name": "The Ting Blockchain Testnet Explorer",
   "chain": "Ting",
-  "rpc": ["https://testnet.tingchain.org",
-          "https://public.0xrpc.com/6666689"
+  "rpc": [
+    "https://testnet.tingchain.org",
+    "https://public.0xrpc.com/6666689"
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
This PR adds a new public RPC endpoint for The Ting Blockchain Testnet:
https://public.0xrpc.com/6666689

Ensures redundancy and better availability for developers.

The existing RPC (https://testnet.tingchain.org) remains unchanged.

Verified that the new RPC is functional and responsive.

Please review and merge. 🚀