### PR TITLE
Add eip155-1682 network

### DIFF
--- a/_data/chains/eip155-1682.json
+++ b/_data/chains/eip155-1682.json
@@ -1,0 +1,26 @@
+{
+    "name": "Hardwood Mainnet",
+    "chain": "HEC",
+    "rpc": [
+        "https://xnode.privatex.io"
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+        "name": "Hardwood",
+        "symbol": "HEC",
+        "decimals": 18
+    },
+    "features": [{ "name": "EIP155" }],
+    "infoURL": "https://hecscan.privatex.io",
+    "shortName": "HEC",
+    "chainId": 1682,
+    "networkId": 1682,
+    "slip44": 60,
+    "explorers": [
+        {
+            "name": "HECScan",
+            "url": "https://hecscan.privatex.io",
+            "standard": "EIP3091"
+        }
+    ]
+}


### PR DESCRIPTION
**Title:** Add Hardwood Mainnet (EIP-155-1682) Network Configuration

**Acceptance Criteria:**
- [ ] IPFS file uploaded
- [ ] IPFS file tested
- [ ] `eip155-1682.json` corresponds well with the requirements presented in `README.md`

**Project Information:**
- **Explorer:** [HECScan](https://hecscan.privatex.io)
- **Website:** *To be added*
- **Technical Docs:** *To be added*
- **Dapp:** *To be added*
- **Faucet:** *Not available*
- **First RPC:** [https://xnode.privatex.io](https://xnode.privatex.io)
- **Technical Standards (EIP equivalent):** *To be added*

**Short Description:**
Hardwood Mainnet (HEC) is a decentralized blockchain network that enables secure and scalable transactions. Designed for efficiency and interoperability, it offers developers a reliable ecosystem for decentralized applications.

**Network Configuration:**
```json
{
    "name": "Hardwood Mainnet",
    "chain": "HEC",
    "rpc": [
        "https://xnode.privatex.io"
    ],
    "faucets": [],
    "nativeCurrency": {
        "name": "Hardwood",
        "symbol": "HEC",
        "decimals": 18
    },
    "features": [{ "name": "EIP155" }],
    "infoURL": "https://hecscan.privatex.io",
    "shortName": "HEC",
    "chainId": 1682,
    "networkId": 1682,
    "slip44": 60,
    "explorers": [
        {
            "name": "HECScan",
            "url": "https://hecscan.privatex.io",
            "standard": "EIP3091"
        }
    ]
}
```

This PR introduces support for the Hardwood Mainnet with chain ID `1682`. Please review the configuration and provide feedback if any adjustments are needed.

