### PR TITLE
Title: Add NetworkCoin  Ai Mainnet (101888) and Testnet (1018888)

### DIFF
--- a/_data/chains/eip155-101888.json
+++ b/_data/chains/eip155-101888.json
@@ -1,0 +1,25 @@
+{
+  "name": "NetworkCoin Ai",
+  "chain": "NetworkCoin Ai",
+  "network": "mainnet",
+  "rpc": [
+    "https://rpc.mainnet.networkcoin.ai/"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "COIN AI",
+    "symbol": "Ai",
+    "decimals": 18
+  },
+  "infoURL": "https://networkcoin.ai",
+  "shortName": "coinai",
+  "chainId": 101888,
+  "networkId": 101888,
+  "explorers": [
+    {
+      "name": "NetworkCoin Ai Explorer",
+      "url": "https://explorer.networkcoin.ai/",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-1018888.json
+++ b/_data/chains/eip155-1018888.json
@@ -1,0 +1,27 @@
+{
+  "name": "NetworkCoin Ai Testnet",
+  "chain": "NetworkCoin Ai",
+  "network": "testnet",
+  "rpc": [
+    "https://rpc.testnet.networkcoin.ai/"
+  ],
+  "faucets": [
+    "https://faucet.networkcoin.ai/"
+  ],
+  "nativeCurrency": {
+    "name": "COIN AI",
+    "symbol": "Ai",
+    "decimals": 18
+  },
+  "infoURL": "https://networkcoin.ai",
+  "shortName": "coinaitest",
+  "chainId": 1018888,
+  "networkId": 1018888,
+  "explorers": [
+    {
+      "name": "NetworkCoin Testnet Explorer",
+      "url": "https://testnet.networkcoin.ai/",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds support for the NetworkCoin Ai EVM-compatible chain.

**Mainnet:**
- Chain ID: 101888
- Symbol: Ai
- RPC: https://rpc.mainnet.networkcoin.ai/
- Explorer: https://explorer.networkcoin.ai/

**Testnet:**
- Chain ID: 1018888
- Symbol: Ai
- RPC: https://rpc.testnet.networkcoin.ai/
- Explorer: https://testnet.networkcoin.ai/
- Faucet: https://faucet.networkcoin.ai/

Official website: https://networkcoin.ai
