### PR TITLE
Update BLAST Chain (Chain ID 238) details

### DIFF
--- a/_data/chains/eip155-238.json
+++ b/_data/chains/eip155-238.json
@@ -2,21 +2,23 @@
   "name": "Blast Mainnet",
   "chain": "ETH",
   "icon": "blastIcon",
-  "rpc": ["https://rpc.blastblockchain.com"],
+  "rpc": [
+    "https://zkevmrpc.blastchain.org"
+  ],
   "faucets": [],
   "nativeCurrency": {
-    "name": "Ether",
-    "symbol": "ETH",
+    "name": "One World Chain",
+    "symbol": "OWCT",
     "decimals": 18
   },
-  "infoURL": "https://docs.blastblockchain.com",
+  "infoURL": "https://docs.blastchain.org",
   "shortName": "blast",
   "chainId": 238,
   "networkId": 238,
   "explorers": [
     {
       "name": "Blast Mainnet",
-      "url": "https://scan.blastblockchain.com",
+      "url": "https://blastchain.org",
       "standard": "EIP3091"
     }
   ]


### PR DESCRIPTION
Updates for BLAST Mainnet (Chain ID 238):
- New RPC URL: `https://zkevmrpc.blastchain.org`
- Currency: Updated to OWCT (One World Chain Token)
- Explorer: `https://blastchain.org/`
- Docs: `https://docs.blastchain.org`