### PR TITLE
remove wrong RPC endpoint for Sepolia

### DIFF
--- a/_data/chains/eip155-11155111.json
+++ b/_data/chains/eip155-11155111.json
@@ -5,7 +5,6 @@
   "rpc": [
     "https://rpc.sepolia.org",
     "https://rpc2.sepolia.org",
-    "https://rpc-sepolia.rockx.com",
     "https://rpc.sepolia.ethpandaops.io",
     "https://sepolia.infura.io/v3/${INFURA_API_KEY}",
     "wss://sepolia.infura.io/v3/${INFURA_API_KEY}",
@@ -15,7 +14,6 @@
     "wss://ethereum-sepolia-rpc.publicnode.com",
     "https://sepolia.drpc.org",
     "wss://sepolia.drpc.org",
-    "https://rpc-sepolia.rockx.com",
     "https://eth-sepolia.g.alchemy.com/v2/WddzdzI2o9S3COdT73d5w6AIogbKq4X-"
   ],
   "faucets": ["http://fauceth.komputing.org?chain=11155111&address=${ADDRESS}"],


### PR DESCRIPTION
Remove the wrong RPC URL in sepolia RPC urls list (eip155-11155111.json)

closes #7194 