### PR TITLE
Update fraxtal testnet native currency

### DIFF
--- a/_data/chains/eip155-2522.json
+++ b/_data/chains/eip155-2522.json
@@ -8,8 +8,8 @@
   ],
   "faucets": [],
   "nativeCurrency": {
-    "name": "Frax Ether",
-    "symbol": "frxETH",
+    "name": "Frax",
+    "symbol": "FRAX",
     "decimals": 18
   },
   "infoURL": "https://testnet.frax.com",


### PR DESCRIPTION
Following our [North Star proposal](https://gov.frax.finance/t/fip-428-frax-north-star-proposal-v2/3652) the native currency  of the testnet changed to Frax (FRAX). Mainnet will soon follow on the 29th.