### PR TITLE
Add PGP Smart Chain(ChainID:12343)

### DIFF
--- a/_data/chains/eip155-12343.json
+++ b/_data/chains/eip155-12343.json
@@ -1,0 +1,28 @@
+{
+  "name": "PGP Smart Chain",
+  "chain": "PGP",
+  "icon": "pgp",
+  "rpc": [
+    "https://rpc.pgprotocol.net",
+    "https://mainnet.rpc.pgprotocol.net"
+  ],
+  "faucets": [
+    "https://faucet.pgprotocol.net"
+  ],
+  "nativeCurrency": {
+    "name": "PGA Token",
+    "symbol": "PGA",
+    "decimals": 18
+  },
+  "infoURL": "https://pgprotocol.net",
+  "shortName": "pgp",
+  "chainId": 12343,
+  "networkId": 12343,
+  "explorers": [
+    {
+      "name": "PGPScan",
+      "url": "https://explorer.pgprotocol.net",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Description:
This PR proposes the addition of PGP Smart Chain, an EVM-compatible blockchian optimized for scalability, DeFi, and real-world uility.

- Chian Nmae: PGP Smart Chain
- ChainID / NetworkID: 12343
- RPC: https:rpc.pgprotocol.net
- Explorer: https;//explorer.pgprotocol.net
- Faucet: https://faucet.pgprotocol.net
- Website: https://pgprotocol.net
- Native Token: PGA (18 decimals)

The chian is maintained by the core PGP development team. We welcome integration and community contribution.
