### PR TITLE
New ChainID for Esacoins

### DIFF
--- a/_data/chains/eip155-64879.json
+++ b/_data/chains/eip155-64879.json
@@ -1,7 +1,7 @@
 {
   "name": "EsaCoins",
   "chain": "EsaCoins",
-  "rpc": ["http://65.108.151.70:8545"],
+  "rpc": ["https://mainnet.esa.co.in"],
   "faucets": [],
   "nativeCurrency": {
     "name": "EsaCoins",

--- a/_data/chains/eip155-64879.json
+++ b/_data/chains/eip155-64879.json
@@ -1,0 +1,17 @@
+{
+  "name": "EsaCoins",
+  "chain": "EsaCoins",
+  "rpc": ["http://65.108.151.70:8545"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "EsaCoins",
+    "symbol": "ESC",
+    "decimals": 18
+  },
+  "infoURL": "https://esa.co.in",
+  "shortName": "ESC",
+  "chainId": 64879,
+  "networkId": 64879,
+  "icon": "EsaCoins",
+  "explorers": []
+}

--- a/_data/chains/eip155-83278.json
+++ b/_data/chains/eip155-83278.json
@@ -1,15 +1,15 @@
 {
-  "name": "Esa",
-  "chain": "Esa",
-  "rpc": ["http://65.108.151.70:8545"],
+  "name": "EsaCoins Testnet",
+  "chain": "ESC",
+  "rpc": ["https://testnet.esa.co.in"],
   "faucets": [],
   "nativeCurrency": {
-    "name": "Esa",
-    "symbol": "Esa",
+    "name": "EsaCoins",
+    "symbol": "ESC",
     "decimals": 18
   },
-  "infoURL": "https://esculap.us",
-  "shortName": "Esa",
+  "infoURL": "https://esa.co.in",
+  "shortName": "eacoins_testnet",
   "chainId": 83278,
   "networkId": 83278,
   "icon": "EsaCoins",


### PR DESCRIPTION
New esacoins network for mainnet (The same icon used)

Updated the previous chain to be testnet