### PR TITLE
Update fraxtal mainnet native currency and shortname

### DIFF
--- a/_data/chains/eip155-252.json
+++ b/_data/chains/eip155-252.json
@@ -8,12 +8,12 @@
   ],
   "faucets": [],
   "nativeCurrency": {
-    "name": "Frax Ether",
-    "symbol": "frxETH",
+    "name": "Frax",
+    "symbol": "FRAX",
     "decimals": 18
   },
   "infoURL": "https://mainnet.frax.com",
-  "shortName": "fraxtal",
+  "shortName": "frax",
   "chainId": 252,
   "networkId": 252,
   "icon": "fraxtal",


### PR DESCRIPTION
Following our [North Star proposal](https://gov.frax.finance/t/fip-428-frax-north-star-proposal-v2/3652) the native currency of fraxta mainnetl changes today to Frax (FRAX).