### PR TITLE
Add XOS Testnet

### DIFF
--- a/_data/chains/eip155-1267.json
+++ b/_data/chains/eip155-1267.json
@@ -1,0 +1,30 @@
+{
+  "name": "XOS Testnet",
+  "chain": "XOS",
+  "icon": "xos",
+  "rpc": [
+    "https://testnet-rpc.x.ink",
+    "https://testnet-rpc.xoscan.io",
+    "wss://testnet-rpc.x.ink",
+    "wss://testnet-rpc.xoscan.io"
+  ],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "XOS Token",
+    "symbol": "XOS",
+    "decimals": 18
+  },
+  "infoURL": "https://x.ink",
+  "shortName": "xos-testnet",
+  "chainId": 1267,
+  "networkId": 1267,
+  "slip44": 1,
+  "explorers": [
+    {
+      "name": "xoscan",
+      "url": "https://testnet.xoscan.io",
+      "standard": "EIP3091"
+    }
+  ]
+} 

--- a/_data/icons/xos.json
+++ b/_data/icons/xos.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreie77o7ehz2i7vbrxsrdvshyadtegakvvtljapyrzbhqfzo23n62fa",
+    "width": 500,
+    "height": 500,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
## Add XOS Testnet

- Chain ID: 1267
- Network ID: 1267
- Name: XOS Testnet
- RPC: 
  - https://testnet-rpc.x.ink/
  - https://testnet-rpc.xoscan.io/
- Explorer: https://testnet.xoscan.io