### PR TITLE
Update PulseChain explorer URL

### DIFF
--- a/_data/chains/eip155-369.json
+++ b/_data/chains/eip155-369.json
@@ -28,7 +28,7 @@
   "explorers": [
     {
       "name": "blockscout",
-      "url": "https://scan.pulsechain.com",
+      "url": "https://ipfs.scan.pulsechain.com",
       "icon": "blockscout",
       "standard": "EIP3091"
     },


### PR DESCRIPTION
This URL is now suitable for wallets and other tools to use. The previous URL was a static download page.