### PR TITLE
Add AVI Coin mainnet (Chain ID 369369)

### DIFF
--- a/_data/chains/eip155-369369.json
+++ b/_data/chains/eip155-369369.json
@@ -1,0 +1,24 @@
+{
+  "name": "AVI Coin",
+  "chain": "AVI",
+  "rpc": [
+    "https://rpc.avicoin.org"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "AVI Coin",
+    "symbol": "AVI",
+    "decimals": 18
+  },
+  "infoURL": "https://www.avicoin.org",
+  "shortName": "avi",
+  "chainId": 369369,
+  "networkId": 369369,
+  "explorers": [
+    {
+      "name": "AVI Coin Explorer",
+      "url": "https://explorer.avicoin.org",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Submitting AVI Coin to Chainlist. 

This is a Layer 1 Proof-of-Work blockchain with native currency AVI and public explorer + RPC.
