### PR TITLE
Add TALNTnet mainnet and testnet chains

### DIFF
--- a/_data/chains/eip155-845300011.json
+++ b/_data/chains/eip155-845300011.json
@@ -1,0 +1,34 @@
+{
+  "name": "TALNTnet",
+  "chainId": 845300011,
+  "networkId": 845300011,
+  "shortName": "talntnet",
+  "chain": "TALNTNET",
+  "icon": "talntnet",
+  "nativeCurrency": {
+    "name": "TALNT Net Token",
+    "symbol": "TALNT",
+    "decimals": 18
+  },
+  "rpc": ["https://talntnet-rpc.appchain.base.org"],
+  "faucets": [],
+  "explorers": [
+    {
+      "name": "TALNTnet Explorer",
+      "url": "https://talntnet-explorer.appchain.base.org",
+      "standard": "EIP3091"
+    }
+  ],
+  "infoURL": "https://www.talnt.net/",
+  "features": [],
+  "status": "active",
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-8453",
+    "bridges": [
+      {
+        "url": "https://docs.base.org"
+      }
+    ]
+  }
+}

--- a/_data/chains/eip155-8453200011.json
+++ b/_data/chains/eip155-8453200011.json
@@ -1,0 +1,34 @@
+{
+  "name": "TALNTnet Testnet",
+  "chainId": 8453200011,
+  "networkId": 8453200011,
+  "shortName": "talntnet-testnet",
+  "chain": "TALNTNET-TESTNET",
+  "icon": "talntnet",
+  "nativeCurrency": {
+    "name": "TALNT Net Token",
+    "symbol": "TALNT",
+    "decimals": 18
+  },
+  "rpc": ["https://talntnet-rpc-testnet.appchain.base.org"],
+  "faucets": [],
+  "explorers": [
+    {
+      "name": "TALNTnet Testnet Explorer",
+      "url": "https://talntnet-explorer-testnet.appchain.base.org",
+      "standard": "EIP3091"
+    }
+  ],
+  "infoURL": "https://www.talnt.net/",
+  "features": [],
+  "status": "active",
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-84532",
+    "bridges": [
+      {
+        "url": "https://docs.base.org"
+      }
+    ]
+  }
+}

--- a/_data/icons/talntnet.json
+++ b/_data/icons/talntnet.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreiedq7yiupuremffyx7oznqq5j52jxl2qfcqxwdapvjequ54gu2ayy",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
This PR adds chain configuration for TALNTnet Mainnet and Testnet, which are AppChain solutions built on Base.

## About TALNTnet
TALNTnet is a optimism stack based AppChain that settles to Base mainnet Base. The chain will support the https://decentralized.pictures/ film and arts funding platform which has been in operation for several years, and is now in the process of migrating to this new Base AppChain.

## Chains Added
- TALNTnet Mainnet (chainId: 845300011)
- TALNTnet Testnet (chainId: 8453200011)

## Verification
- Both chains have been validated with the schema checker and pass all validation
- The IPFS CID for the icon (bafkreiedq7yiupuremffyx7oznqq5j52jxl2qfcqxwdapvjequ54gu2ayy) is publicly accessible
- Parent chains have been correctly referenced (Base Mainnet and Base Sepolia)
- All fields comply with the repository's requirements

## Additional Information
- Website: https://www.talnt.net/ (Will be live very soon!)


Thank you for considering this PR!