### PR TITLE
Update block explorer for chainId 128123

### DIFF
--- a/_data/chains/eip155-128123.json
+++ b/_data/chains/eip155-128123.json
@@ -17,7 +17,7 @@
   "explorers": [
     {
       "name": "Etherlink Testnet Explorer",
-      "url": "https://testnet-explorer.etherlink.com",
+      "url": "https://testnet.explorer.etherlink.com",
       "standard": "EIP3091"
     }
   ]


### PR DESCRIPTION
New link: https://testnet.explorer.etherlink.com/
Source: https://docs.etherlink.com/get-started/network-information