### PR TITLE
Register additional RPC URLs for Mezo (31612)

### DIFF
--- a/_data/chains/eip155-31612.json
+++ b/_data/chains/eip155-31612.json
@@ -5,7 +5,9 @@
     "https://rpc_evm-mezo.imperator.co",
     "wss://ws_evm-mezo.imperator.co",
     "https://jsonrpc-mezo.boar.network",
-    "wss://jsonrpcws-mezo.boar.network"
+    "wss://jsonrpcws-mezo.boar.network",
+    "https://rpc-internal.mezo.org",
+    "wss://rpc-ws-internal.mezo.org"
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
We register additional RPC URLs for Mezo (31612) to support the new mainnet.