### PR TITLE
Add Libra Testnet

### DIFF
--- a/_data/chains/eip155-111222.json
+++ b/_data/chains/eip155-111222.json
@@ -23,7 +23,6 @@
       "icon": "libra",
       "standard": "EIP3091"
     }
-  ],
-  "testnet": true,
-  "status": "active"
+  ]
 }
+

--- a/_data/chains/eip155-111222.json
+++ b/_data/chains/eip155-111222.json
@@ -1,0 +1,29 @@
+{
+  "name": "LibraChain Testnet",
+  "chain": "LIB",
+  "rpc": [
+    "https://testnet-rpc.librachain.com"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Libra",
+    "symbol": "LIB",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://librachain.com",
+  "shortName": "libtest",
+  "chainId": 111222,
+  "networkId": 111222,
+  "icon": "libra",
+  "explorers": [
+    {
+      "name": "LibraChain Explorer",
+      "url": "https://testnet.librachain.com",
+      "icon": "libra",
+      "standard": "EIP3091"
+    }
+  ],
+  "testnet": true,
+  "status": "active"
+}

--- a/_data/icons/libra.json
+++ b/_data/icons/libra.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "https://ipfs.librachain.global/uploads/coins/lib.png",
+    "width": 1000,
+    "height": 1000,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Add Libra Testnet (chainId: 111222)

Name: Libra Testnet

Chain ID: 111222

RPC URL: https://testnet-rpc.librachain.com

Block Explorer URL: https://testnet.librachain.com

Native Currency:

Name: Libra

Symbol: LIB

Decimals: 18

ICON: URL: https://ipfs.librachain.global/uploads/coins/lib.png