### PR TITLE
Updated GAN Chain Specs to Mainnet

### DIFF
--- a/_data/chains/eip155-4048.json
+++ b/_data/chains/eip155-4048.json
@@ -1,16 +1,16 @@
 {
-  "name": "GAN Testnet",
+  "name": "GANchain L1",
   "chain": "GAN",
   "icon": "gpu",
   "rpc": ["https://rpc.gpu.net"],
   "faucets": [],
   "nativeCurrency": {
-    "name": "GP Token",
-    "symbol": "GP",
+    "name": "GPUnet",
+    "symbol": "GPU",
     "decimals": 18
   },
   "infoURL": "https://docs.gpu.net/",
-  "shortName": "GANTestnet",
+  "shortName": "GANchain",
   "chainId": 4048,
   "networkId": 4048,
   "explorers": [


### PR DESCRIPTION
As we move to main-net, we need to update our Name, Token and Ticker for GAN Chain.

Updated Chain Name to GAN Chain L1 from GAN Testnet
Updated Token Name to GPUnet
Updated Ticker to $GPU