### PR TITLE
feat: add 3dpass chain (chainId: 1333)

### DIFF
--- a/_data/chains/eip155-1333.json
+++ b/_data/chains/eip155-1333.json
@@ -1,0 +1,16 @@
+{
+  "name": "3dpass - The Ledger of Things",
+  "chain": "3DP",
+  "rpc": ["https://rpc-http.3dpass.org"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "3dpass",
+    "symbol": "P3D",
+    "decimals": 18
+  },
+  "infoURL": "https://3dpass.org",
+  "shortName": "3dp",
+  "chainId": 1333,
+  "networkId": 1333,
+  "explorers": []
+}


### PR DESCRIPTION
## Summary
- Added 3dpass chain configuration with chainId 1333
- Chain name: 3dpass - The Ledger of Things
- Native currency: P3D

## Details
- RPC endpoint: https://rpc-http.3dpass.org
- Network ID: 1333
- Chain ID: 1333
- Symbol: P3D
- Decimals: 18

## Test plan
- [x] Ran `./gradlew run` - all tests pass
- [x] JSON formatted with prettier
- [x] Verified chain ID 1333 is not already in use