### PR TITLE
Add D.Energy Mainnet and Testnet

### DIFF
--- a/_data/chains/eip155-4441.json
+++ b/_data/chains/eip155-4441.json
@@ -16,7 +16,7 @@
   "explorers": [
     {
       "name": "Denergy Explorer",
-      "url": "https://explorer.denergychain.com/",
+      "url": "https://explorer.denergychain.com",
       "icon": "denergy",
       "standard": "EIP3091"
     }

--- a/_data/chains/eip155-4441.json
+++ b/_data/chains/eip155-4441.json
@@ -1,0 +1,24 @@
+{
+  "name": "Denergy",
+  "chain": "DEN",
+  "rpc": ["https://rpc.denergychain.com/"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "WATT",
+    "symbol": "WATT",
+    "decimals": 18
+  },
+  "infoURL": "https://d.energy/",
+  "shortName": "den",
+  "chainId": 4441,
+  "networkId": 4441,
+  "icon": "denergy",
+  "explorers": [
+    {
+      "name": "Denergy Explorer",
+      "url": "https://explorer.denergychain.com/",
+      "icon": "denergy",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-4442.json
+++ b/_data/chains/eip155-4442.json
@@ -9,14 +9,14 @@
     "decimals": 18
   },
   "infoURL": "https://d.energy/",
-  "shortName": "den",
+  "shortName": "den-testnet",
   "chainId": 4442,
   "networkId": 4442,
   "icon": "denergy",
   "explorers": [
     {
       "name": "Denergy Explorer",
-      "url": "https://explorer.denergytestnet.com/",
+      "url": "https://explorer.denergytestnet.com",
       "icon": "denergy",
       "standard": "EIP3091"
     }

--- a/_data/chains/eip155-4442.json
+++ b/_data/chains/eip155-4442.json
@@ -1,0 +1,24 @@
+{
+  "name": "Denergy Testnet",
+  "chain": "DEN",
+  "rpc": ["https://rpc.denergytestnet.com/"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "T-WATT",
+    "symbol": "TWATT",
+    "decimals": 18
+  },
+  "infoURL": "https://d.energy/",
+  "shortName": "den",
+  "chainId": 4442,
+  "networkId": 4442,
+  "icon": "denergy",
+  "explorers": [
+    {
+      "name": "Denergy Explorer",
+      "url": "https://explorer.denergytestnet.com/",
+      "icon": "denergy",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/icons/denergy.json
+++ b/_data/icons/denergy.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmdZMYDb12zN4ErNoSob7yotqqQBMobCDbhumMY3DV1kG1",
+    "width": 512,
+    "height": 503,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
This PR introduces the following changes:
- DEnergy Mainnet (Chain ID: 4441)
- DEnergy Testnet (Chain ID: 4442)
- DEnergy Icon