### PR TITLE
Update for TAC Mainnet and fix TAC Testnet

### DIFF
--- a/_data/chains/eip155-239.json
+++ b/_data/chains/eip155-239.json
@@ -3,7 +3,11 @@
   "title": "TAC Mainnet",
   "chain": "TAC",
   "icon": "tac",
-  "rpc": [],
+  "rpc": [
+    "https://rpc.tac.build",
+    "https://rpc.ankr.com/tac",
+    "https://ws.rpc.tac.build"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "TAC",
@@ -11,8 +15,20 @@
     "decimals": 18
   },
   "infoURL": "https://tac.build/",
-  "shortName": "tac",
+  "shortName": "tacchain_239-1",
+  "slip44": 60,
   "chainId": 239,
   "networkId": 239,
-  "explorers": []
+  "explorers": [
+    {
+      "name": "TAC Explorer",
+      "url": "https://explorer.tac.build",
+      "standard": "EIP3091"
+    },
+    {
+      "name": "Blockscout",
+      "url": "https://tac.blockscout.com",
+      "standard": "EIP3091"
+    }
+  ]
 }

--- a/_data/chains/eip155-2390.json
+++ b/_data/chains/eip155-2390.json
@@ -18,7 +18,7 @@
   "shortName": "tacchain_2390-1",
   "chainId": 2390,
   "networkId": 2390,
-  "slip44": 1,
+  "slip44": 60,
   "explorers": [
     {
       "name": "TAC Turin Blockscout",

--- a/_data/chains/eip155-2391.json
+++ b/_data/chains/eip155-2391.json
@@ -1,0 +1,29 @@
+{
+  "name": "TAC Saint Petersburg",
+  "title": "TAC Testnet SPB",
+  "chain": "TAC",
+  "icon": "tactestnet",
+  "rpc": [
+    "https://spb.rpc.tac.build",
+    "https://rpc.ankr.com/tac_spb",
+    "https://spb-ws.rpc.tac.build"
+  ],
+  "faucets": ["https://spb.faucet.tac.build/"],
+  "nativeCurrency": {
+    "name": "TAC",
+    "symbol": "TAC",
+    "decimals": 18
+  },
+  "infoURL": "https://tac.build/",
+  "shortName": "tacchain_2391-1",
+  "chainId": 2391,
+  "networkId": 2391,
+  "slip44": 60,
+  "explorers": [
+    {
+      "name": "TAC SPB Explorer",
+      "url": "https://spb.explorer.tac.build",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Hey @ligi sir gm, 

I know you're not actively merging PR because of the upcoming onchain registry. However, we just had our genesis mainnet, and there are many teams with automated deployment scripts still targeting this repo (including, but not limited to, Safe, Curve, and more). 

Asking all of them to fork this repo and change their deployment script is a big issue for everyone. 

As a previous donor to this project, I commit to keep donating for every new merge, and I really hope we can have a soft migration from the GitHub repo to the upcoming onchain registry, but it should be done in a way to minimize disruptions, at least wait for it to be live, or handover the merging privileges to someone else in the community. 

Without these merge activities, it's very hard to get the teams deploying on new chains or L2s. 

I hope you guys can understand our pain as builders.

With this specific PR i'm adding the details about TAC Mainnet, adding our second testnet that went live 2 months ago and correcting the first testnet data.

I hope you can understand my position. 

Many thanks, 

Marco