### PR TITLE
Add Kadena EVM chains

### DIFF
--- a/_data/chains/eip155-5900.json
+++ b/_data/chains/eip155-5900.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena Mainnet 20",
+  "chain": "KDA",
+  "rpc": [
+    "https://api.chainweb.com/chainweb/0.0/mainnet01/chain/20/evm/rpc",
+    "wss://api.chainweb.com/chainweb/0.0/mainnet01/chain/20/evm/ws"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Kadena",
+    "symbol": "KDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-mainnet-20",
+  "chainId": 5900,
+  "networkId": 5900,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/mainnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/mainnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-5901.json
+++ b/_data/chains/eip155-5901.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena Mainnet 21",
+  "chain": "KDA",
+  "rpc": [
+    "https://api.chainweb.com/chainweb/0.0/mainnet01/chain/21/evm/rpc",
+    "wss://api.chainweb.com/chainweb/0.0/mainnet01/chain/21/evm/ws"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Kadena",
+    "symbol": "KDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-mainnet-21",
+  "chainId": 5901,
+  "networkId": 5901,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/mainnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/mainnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-5902.json
+++ b/_data/chains/eip155-5902.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena Mainnet 22",
+  "chain": "KDA",
+  "rpc": [
+    "https://api.chainweb.com/chainweb/0.0/mainnet01/chain/22/evm/rpc",
+    "wss://api.chainweb.com/chainweb/0.0/mainnet01/chain/22/evm/ws"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Kadena",
+    "symbol": "KDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-mainnet-22",
+  "chainId": 5902,
+  "networkId": 5902,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/mainnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/mainnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-5903.json
+++ b/_data/chains/eip155-5903.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena Mainnet 23",
+  "chain": "KDA",
+  "rpc": [
+    "https://api.chainweb.com/chainweb/0.0/mainnet01/chain/23/evm/rpc",
+    "wss://api.chainweb.com/chainweb/0.0/mainnet01/chain/23/evm/ws"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Kadena",
+    "symbol": "KDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-mainnet-23",
+  "chainId": 5903,
+  "networkId": 5903,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/mainnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/mainnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-5904.json
+++ b/_data/chains/eip155-5904.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena Mainnet 24",
+  "chain": "KDA",
+  "rpc": [
+    "https://api.chainweb.com/chainweb/0.0/mainnet01/chain/24/evm/rpc",
+    "wss://api.chainweb.com/chainweb/0.0/mainnet01/chain/24/evm/ws"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Kadena",
+    "symbol": "KDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-mainnet-24",
+  "chainId": 5904,
+  "networkId": 5904,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/mainnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/mainnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-5905.json
+++ b/_data/chains/eip155-5905.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena Mainnet 25",
+  "chain": "KDA",
+  "rpc": [
+    "https://api.chainweb.com/chainweb/0.0/mainnet01/chain/25/evm/rpc",
+    "wss://api.chainweb.com/chainweb/0.0/mainnet01/chain/25/evm/ws"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Kadena",
+    "symbol": "KDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-mainnet-25",
+  "chainId": 5905,
+  "networkId": 5905,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/mainnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/mainnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-5906.json
+++ b/_data/chains/eip155-5906.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena Mainnet 26",
+  "chain": "KDA",
+  "rpc": [
+    "https://api.chainweb.com/chainweb/0.0/mainnet01/chain/26/evm/rpc",
+    "wss://api.chainweb.com/chainweb/0.0/mainnet01/chain/26/evm/ws"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Kadena",
+    "symbol": "KDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-mainnet-26",
+  "chainId": 5906,
+  "networkId": 5906,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/mainnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/mainnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-5907.json
+++ b/_data/chains/eip155-5907.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena Mainnet 27",
+  "chain": "KDA",
+  "rpc": [
+    "https://api.chainweb.com/chainweb/0.0/mainnet01/chain/27/evm/rpc",
+    "wss://api.chainweb.com/chainweb/0.0/mainnet01/chain/27/evm/ws"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Kadena",
+    "symbol": "KDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-mainnet-27",
+  "chainId": 5907,
+  "networkId": 5907,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/mainnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/mainnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-5908.json
+++ b/_data/chains/eip155-5908.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena Mainnet 28",
+  "chain": "KDA",
+  "rpc": [
+    "https://api.chainweb.com/chainweb/0.0/mainnet01/chain/28/evm/rpc",
+    "wss://api.chainweb.com/chainweb/0.0/mainnet01/chain/28/evm/ws"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Kadena",
+    "symbol": "KDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-mainnet-28",
+  "chainId": 5908,
+  "networkId": 5908,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/mainnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/mainnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-5909.json
+++ b/_data/chains/eip155-5909.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena Mainnet 29",
+  "chain": "KDA",
+  "rpc": [
+    "https://api.chainweb.com/chainweb/0.0/mainnet01/chain/29/evm/rpc",
+    "wss://api.chainweb.com/chainweb/0.0/mainnet01/chain/29/evm/ws"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Kadena",
+    "symbol": "KDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-mainnet-29",
+  "chainId": 5909,
+  "networkId": 5909,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/mainnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/mainnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-5910.json
+++ b/_data/chains/eip155-5910.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena Testnet 20",
+  "chain": "Kadena",
+  "rpc": [
+    "https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/20/evm/rpc",
+    "wss://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/20/evm/ws"
+  ],
+  "faucets": ["https://tools.kadena.io/faucet/evm"],
+  "nativeCurrency": {
+    "name": "Testnet Kadena",
+    "symbol": "tKDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-testnet-20",
+  "chainId": 5910,
+  "networkId": 5910,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/testnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/testnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-5911.json
+++ b/_data/chains/eip155-5911.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena Testnet 21",
+  "chain": "Kadena",
+  "rpc": [
+    "https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/21/evm/rpc",
+    "wss://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/21/evm/ws"
+  ],
+  "faucets": ["https://tools.kadena.io/faucet/evm"],
+  "nativeCurrency": {
+    "name": "Testnet Kadena",
+    "symbol": "tKDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-testnet-21",
+  "chainId": 5911,
+  "networkId": 5911,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/testnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/testnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-5912.json
+++ b/_data/chains/eip155-5912.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena Testnet 22",
+  "chain": "Kadena",
+  "rpc": [
+    "https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/22/evm/rpc",
+    "wss://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/22/evm/ws"
+  ],
+  "faucets": ["https://tools.kadena.io/faucet/evm"],
+  "nativeCurrency": {
+    "name": "Testnet Kadena",
+    "symbol": "tKDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-testnet-22",
+  "chainId": 5912,
+  "networkId": 5912,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/testnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/testnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-5913.json
+++ b/_data/chains/eip155-5913.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena Testnet 23",
+  "chain": "Kadena",
+  "rpc": [
+    "https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/23/evm/rpc",
+    "wss://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/23/evm/ws"
+  ],
+  "faucets": ["https://tools.kadena.io/faucet/evm"],
+  "nativeCurrency": {
+    "name": "Testnet Kadena",
+    "symbol": "tKDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-testnet-23",
+  "chainId": 5913,
+  "networkId": 5913,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/testnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/testnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-5914.json
+++ b/_data/chains/eip155-5914.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena Testnet 24",
+  "chain": "Kadena",
+  "rpc": [
+    "https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/24/evm/rpc",
+    "wss://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/24/evm/ws"
+  ],
+  "faucets": ["https://tools.kadena.io/faucet/evm"],
+  "nativeCurrency": {
+    "name": "Testnet Kadena",
+    "symbol": "tKDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-testnet-24",
+  "chainId": 5914,
+  "networkId": 5914,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/testnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/testnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-5915.json
+++ b/_data/chains/eip155-5915.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena Testnet 25",
+  "chain": "Kadena",
+  "rpc": [
+    "https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/25/evm/rpc",
+    "wss://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/25/evm/ws"
+  ],
+  "faucets": ["https://tools.kadena.io/faucet/evm"],
+  "nativeCurrency": {
+    "name": "Testnet Kadena",
+    "symbol": "tKDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-testnet-25",
+  "chainId": 5915,
+  "networkId": 5915,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/testnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/testnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-5916.json
+++ b/_data/chains/eip155-5916.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena Testnet 26",
+  "chain": "Kadena",
+  "rpc": [
+    "https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/26/evm/rpc",
+    "wss://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/26/evm/ws"
+  ],
+  "faucets": ["https://tools.kadena.io/faucet/evm"],
+  "nativeCurrency": {
+    "name": "Testnet Kadena",
+    "symbol": "tKDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-testnet-26",
+  "chainId": 5916,
+  "networkId": 5916,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/testnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/testnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-5917.json
+++ b/_data/chains/eip155-5917.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena Testnet 27",
+  "chain": "Kadena",
+  "rpc": [
+    "https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/27/evm/rpc",
+    "wss://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/27/evm/ws"
+  ],
+  "faucets": ["https://tools.kadena.io/faucet/evm"],
+  "nativeCurrency": {
+    "name": "Testnet Kadena",
+    "symbol": "tKDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-testnet-27",
+  "chainId": 5917,
+  "networkId": 5917,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/testnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/testnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-5918.json
+++ b/_data/chains/eip155-5918.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena Testnet 28",
+  "chain": "Kadena",
+  "rpc": [
+    "https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/28/evm/rpc",
+    "wss://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/28/evm/ws"
+  ],
+  "faucets": ["https://tools.kadena.io/faucet/evm"],
+  "nativeCurrency": {
+    "name": "Testnet Kadena",
+    "symbol": "tKDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-testnet-28",
+  "chainId": 5918,
+  "networkId": 5918,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/testnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/testnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-5919.json
+++ b/_data/chains/eip155-5919.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena Testnet 29",
+  "chain": "Kadena",
+  "rpc": [
+    "https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/29/evm/rpc",
+    "wss://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/29/evm/ws"
+  ],
+  "faucets": ["https://tools.kadena.io/faucet/evm"],
+  "nativeCurrency": {
+    "name": "Testnet Kadena",
+    "symbol": "tKDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-testnet-29",
+  "chainId": 5919,
+  "networkId": 5919,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/testnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/testnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-5920.json
+++ b/_data/chains/eip155-5920.json
@@ -1,0 +1,31 @@
+{
+  "name": "Kadena EVM Testnet 20",
+  "chain": "Kadena",
+  "rpc": [
+    "https://api.evm-testnet.chainweb.com/chainweb/0.0/evm-testnet/chain/20/evm/rpc",
+    "wss://api.evm-testnet.chainweb.com/chainweb/0.0/evm-testnet/chain/20/evm/ws"
+  ],
+  "faucets": ["https://tools.kadena.io/faucet/evm"],
+  "nativeCurrency": {
+    "name": "Testnet Kadena",
+    "symbol": "tKDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-evm-testnet-20",
+  "chainId": 5920,
+  "networkId": 5920,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/evm-testnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/evm-testnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626
+}

--- a/_data/chains/eip155-5921.json
+++ b/_data/chains/eip155-5921.json
@@ -1,0 +1,31 @@
+{
+  "name": "Kadena EVM Testnet 21",
+  "chain": "Kadena",
+  "rpc": [
+    "https://api.evm-testnet.chainweb.com/chainweb/0.0/evm-testnet/chain/21/evm/rpc",
+    "wss://api.evm-testnet.chainweb.com/chainweb/0.0/evm-testnet/chain/21/evm/ws"
+  ],
+  "faucets": ["https://tools.kadena.io/faucet/evm"],
+  "nativeCurrency": {
+    "name": "Testnet Kadena",
+    "symbol": "tKDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-evm-testnet-21",
+  "chainId": 5921,
+  "networkId": 5921,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/evm-testnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/evm-testnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626
+}

--- a/_data/chains/eip155-5922.json
+++ b/_data/chains/eip155-5922.json
@@ -1,0 +1,31 @@
+{
+  "name": "Kadena EVM Testnet 22",
+  "chain": "Kadena",
+  "rpc": [
+    "https://api.evm-testnet.chainweb.com/chainweb/0.0/evm-testnet/chain/22/evm/rpc",
+    "wss://api.evm-testnet.chainweb.com/chainweb/0.0/evm-testnet/chain/22/evm/ws"
+  ],
+  "faucets": ["https://tools.kadena.io/faucet/evm"],
+  "nativeCurrency": {
+    "name": "Testnet Kadena",
+    "symbol": "tKDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-evm-testnet-22",
+  "chainId": 5922,
+  "networkId": 5922,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/evm-testnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/evm-testnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626
+}

--- a/_data/chains/eip155-5923.json
+++ b/_data/chains/eip155-5923.json
@@ -1,0 +1,31 @@
+{
+  "name": "Kadena EVM Testnet 23",
+  "chain": "Kadena",
+  "rpc": [
+    "https://api.evm-testnet.chainweb.com/chainweb/0.0/evm-testnet/chain/23/evm/rpc",
+    "wss://api.evm-testnet.chainweb.com/chainweb/0.0/evm-testnet/chain/23/evm/ws"
+  ],
+  "faucets": ["https://tools.kadena.io/faucet/evm"],
+  "nativeCurrency": {
+    "name": "Testnet Kadena",
+    "symbol": "tKDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-evm-testnet-23",
+  "chainId": 5923,
+  "networkId": 5923,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/evm-testnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/evm-testnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626
+}

--- a/_data/chains/eip155-5924.json
+++ b/_data/chains/eip155-5924.json
@@ -1,0 +1,31 @@
+{
+  "name": "Kadena EVM Testnet 24",
+  "chain": "Kadena",
+  "rpc": [
+    "https://api.evm-testnet.chainweb.com/chainweb/0.0/evm-testnet/chain/24/evm/rpc",
+    "wss://api.evm-testnet.chainweb.com/chainweb/0.0/evm-testnet/chain/24/evm/ws"
+  ],
+  "faucets": ["https://tools.kadena.io/faucet/evm"],
+  "nativeCurrency": {
+    "name": "Testnet Kadena",
+    "symbol": "tKDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-evm-testnet-24",
+  "chainId": 5924,
+  "networkId": 5924,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/evm-testnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/evm-testnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626
+}

--- a/_data/chains/eip155-5925.json
+++ b/_data/chains/eip155-5925.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena EVM Testnet 25",
+  "chain": "Kadena",
+  "rpc": [
+    "https://api.evm-testnet.chainweb.com/chainweb/0.0/evm-testnet/chain/25/evm/rpc",
+    "wss://api.evm-testnet.chainweb.com/chainweb/0.0/evm-testnet/chain/25/evm/ws"
+  ],
+  "faucets": ["https://tools.kadena.io/faucet/evm"],
+  "nativeCurrency": {
+    "name": "Testnet Kadena",
+    "symbol": "tKDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-evm-testnet-25",
+  "chainId": 5925,
+  "networkId": 5925,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/evm-testnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/evm-testnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-5926.json
+++ b/_data/chains/eip155-5926.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena EVM Testnet 26",
+  "chain": "Kadena",
+  "rpc": [
+    "https://api.evm-testnet.chainweb.com/chainweb/0.0/evm-testnet/chain/26/evm/rpc",
+    "wss://api.evm-testnet.chainweb.com/chainweb/0.0/evm-testnet/chain/26/evm/ws"
+  ],
+  "faucets": ["https://tools.kadena.io/faucet/evm"],
+  "nativeCurrency": {
+    "name": "Testnet Kadena",
+    "symbol": "tKDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-evm-testnet-26",
+  "chainId": 5926,
+  "networkId": 5926,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/evm-testnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/evm-testnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-5927.json
+++ b/_data/chains/eip155-5927.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena EVM Testnet 27",
+  "chain": "Kadena",
+  "rpc": [
+    "https://api.evm-testnet.chainweb.com/chainweb/0.0/evm-testnet/chain/27/evm/rpc",
+    "wss://api.evm-testnet.chainweb.com/chainweb/0.0/evm-testnet/chain/27/evm/ws"
+  ],
+  "faucets": ["https://tools.kadena.io/faucet/evm"],
+  "nativeCurrency": {
+    "name": "Testnet Kadena",
+    "symbol": "tKDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-evm-testnet-27",
+  "chainId": 5927,
+  "networkId": 5927,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/evm-testnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/evm-testnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-5928.json
+++ b/_data/chains/eip155-5928.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena EVM Testnet 28",
+  "chain": "Kadena",
+  "rpc": [
+    "https://api.evm-testnet.chainweb.com/chainweb/0.0/evm-testnet/chain/28/evm/rpc",
+    "wss://api.evm-testnet.chainweb.com/chainweb/0.0/evm-testnet/chain/28/evm/ws"
+  ],
+  "faucets": ["https://tools.kadena.io/faucet/evm"],
+  "nativeCurrency": {
+    "name": "Testnet Kadena",
+    "symbol": "tKDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-evm-testnet-28",
+  "chainId": 5928,
+  "networkId": 5928,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/evm-testnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/evm-testnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-5929.json
+++ b/_data/chains/eip155-5929.json
@@ -1,0 +1,32 @@
+{
+  "name": "Kadena EVM Testnet 29",
+  "chain": "Kadena",
+  "rpc": [
+    "https://api.evm-testnet.chainweb.com/chainweb/0.0/evm-testnet/chain/29/evm/rpc",
+    "wss://api.evm-testnet.chainweb.com/chainweb/0.0/evm-testnet/chain/29/evm/ws"
+  ],
+  "faucets": ["https://tools.kadena.io/faucet/evm"],
+  "nativeCurrency": {
+    "name": "Testnet Kadena",
+    "symbol": "tKDA",
+    "decimals": 18
+  },
+  "infoURL": "https://www.kadena.io",
+  "shortName": "kda-evm-testnet-29",
+  "chainId": 5929,
+  "networkId": 5929,
+  "explorers": [
+    {
+      "name": "Kadena Explorer",
+      "url": "https://explorer.kadena.io/evm-testnet",
+      "standard": "none"
+    },
+    {
+      "name": "Chainweb Explorer",
+      "url": "https://explorer.kadena.io/evm-testnet",
+      "standard": "none"
+    }
+  ],
+  "slip44": 626,
+  "status": "incubating"
+}


### PR DESCRIPTION
This is a request to add EVM chains for the following Kadena networks:
*   mainnet (chainIds: 5900-5909): Kadena mainnet
*   testnet: (chainIds: 5910-5919): permanent Kadena testnet
*   evm-testnet (chainIds: 5920-5929): feature testnet for adding EVM support to Kadena

Kadena is a multi-chain blockchain that uses Chainweb consensus. Currently the Kadena mainnet includes 20 chains that use Pact as smart contract language. Kadena is in the process of adding additional EVM chains to its networks.

Initially, only chainIds 5920-5924 have active status. The remaining chains will be activated over the next few months as new chains are rolled out.