### PR TITLE
Add USBC (US Benchmark Coin) Sandbox testnet (chainId: 203001)

### DIFF
--- a/_data/chains/eip155-203001.json
+++ b/_data/chains/eip155-203001.json
@@ -1,0 +1,19 @@
+{
+  "name": "US Benchmark Coin Sandbox",
+  "chain": "USBC-Testnet",
+  "rpc": ["http://rpc-sandbox.usbc.xyz:8545"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "US Benchmark Coin",
+    "symbol": "USBC",
+    "decimals": 18
+  },
+  "infoURL": "https://usbc.xyz",
+  "shortName": "usbc-sandbox",
+  "chainId": 203001,
+  "networkId": 203001,
+  "icon": "usbc",
+  "explorers": [],
+  "status": "testnet"
+}
+


### PR DESCRIPTION
### Add US Benchmark Coin Sandbox Testnet

This PR adds the **US Benchmark Coin Sandbox** EVM-compatible test network to the ethereum-lists registry.

---

### 🔗 Chain Information

- **Name:** US Benchmark Coin Sandbox
- **Chain ID:** 203001
- **Network ID:** 203001
- **RPC URL:** http://rpc-sandbox.usbc.xyz:8545
- **Currency:** USBC
- **Status:** testnet
- **Info URL:** https://usbc.xyz
- **Icon:** Not included
- **Explorer:** Not available at this time

---

The chain is currently used in a sandbox/test environment for development and early integration testing. A block explorer may be added in a future update.
