### PR TITLE
add VirBiCoin

### DIFF
--- a/_data/chains/eip155-329.json
+++ b/_data/chains/eip155-329.json
@@ -1,0 +1,28 @@
+{
+  "name": "VirBiCoin",
+  "chain": "VBC",
+  "icon": "vbc",
+  "rpc": ["https://rpc.digitalregion.jp"],
+  "features": [
+    {
+      "name": "EIP155"
+    }
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "VirBiCoin",
+    "symbol": "VBC",
+    "decimals": 18
+  },
+  "infoURL": "https://vbc.digitalregion.jp",
+  "shortName": "vbc",
+  "chainId": 329,
+  "networkId": 329,
+  "explorers": [
+    {
+      "name": "VirBiCoin Explorer",
+      "url": "https://explorer.digitalregion.jp",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/icons/vbc.json
+++ b/_data/icons/vbc.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreihwi6alsxnjlox2tu3yg2ahbn3dqaltktgwip7fg73vr6yujvdy5y",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Add VirBiCoin
This PR adds the VirBiCoin EVM-compatible main network to the ethereum-lists registry.

---

🔗 Chain Information
Name: VirBiCoin
Chain ID: 329
Network ID: 329
RPC URL: https://rpc.digitalregion.jp/
Currency: VBC
Status: Mainnet Active
Info URL: https://vbc.digitalregion.jp/
Icon: https://ipfs.io/ipfs/bafkreihwi6alsxnjlox2tu3yg2ahbn3dqaltktgwip7fg73vr6yujvdy5y
Explorer: https://explorer.digitalregion.jp/

---

Thanks!