### PR TITLE
Update RPC URLs and explorer links for Global Trust Network and Stability Protocol Testnet

### DIFF
--- a/_data/chains/eip155-101010.json
+++ b/_data/chains/eip155-101010.json
@@ -2,7 +2,9 @@
   "name": "Global Trust Network",
   "chain": "GTN",
   "icon": "gtn",
-  "rpc": ["https://gtn.stabilityprotocol.com"],
+  "rpc": [
+    "https://rpc.stabilityprotocol.com"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "FREE",
@@ -16,9 +18,11 @@
   "explorers": [
     {
       "name": "blockscout",
-      "url": "https://stability.blockscout.com",
+      "url": "https://explorer.stabilityprotocol.com",
       "standard": "EIP3091"
     }
   ],
-  "redFlags": ["reusedChainId"]
+  "redFlags": [
+    "reusedChainId"
+  ]
 }

--- a/_data/chains/eip155-101010.json
+++ b/_data/chains/eip155-101010.json
@@ -2,9 +2,7 @@
   "name": "Global Trust Network",
   "chain": "GTN",
   "icon": "gtn",
-  "rpc": [
-    "https://rpc.stabilityprotocol.com"
-  ],
+  "rpc": ["https://rpc.stabilityprotocol.com"],
   "faucets": [],
   "nativeCurrency": {
     "name": "FREE",
@@ -22,7 +20,5 @@
       "standard": "EIP3091"
     }
   ],
-  "redFlags": [
-    "reusedChainId"
-  ]
+  "redFlags": ["reusedChainId"]
 }

--- a/_data/chains/eip155-20180427.json
+++ b/_data/chains/eip155-20180427.json
@@ -2,7 +2,9 @@
   "name": "Stability Testnet",
   "chain": "stabilityTestnet",
   "icon": "stabilitytestnet",
-  "rpc": ["https://free.testnet.stabilityprotocol.com"],
+  "rpc": [
+    "https://rpc.testnet.stabilityprotocol.com"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "FREE",
@@ -17,7 +19,7 @@
   "explorers": [
     {
       "name": "blockscout",
-      "url": "https://stability-testnet.blockscout.com",
+      "url": "https://explorer.testnet.stabilityprotocol.com",
       "standard": "EIP3091"
     }
   ]

--- a/_data/chains/eip155-20180427.json
+++ b/_data/chains/eip155-20180427.json
@@ -2,9 +2,7 @@
   "name": "Stability Testnet",
   "chain": "stabilityTestnet",
   "icon": "stabilitytestnet",
-  "rpc": [
-    "https://rpc.testnet.stabilityprotocol.com"
-  ],
+  "rpc": ["https://rpc.testnet.stabilityprotocol.com"],
   "faucets": [],
   "nativeCurrency": {
     "name": "FREE",


### PR DESCRIPTION
* Changed RPC URLs to new endpoints for both chains
* Updated block explorer URLs to reflect the new domain structure