### PR TITLE
Update Plume's name

### DIFF
--- a/_data/chains/eip155-98866.json
+++ b/_data/chains/eip155-98866.json
@@ -1,5 +1,5 @@
 {
-  "name": "Plume Mainnet",
+  "name": "Plume",
   "title": "Plume Ethereum L2 Rollup Mainnet",
   "chain": "PLUME",
   "rpc": ["https://rpc.plume.org", "wss://rpc.plume.org"],


### PR DESCRIPTION
This PR updates Plume's mainnet name so that it matches that of [Viem](https://github.com/wevm/viem/blob/main/src/chains/definitions/plumeMainnet.ts).