### PR TITLE
Adding a new chain OpenLedger mainnet to the configuration.

### DIFF
--- a/_data/chains/eip155-1612.json
+++ b/_data/chains/eip155-1612.json
@@ -1,0 +1,32 @@
+{
+  "name": "OpenLedger Mainnet",
+  "chain": "OpenLedger",
+  "rpc": ["https://rpc.openledger.xyz"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Open",
+    "symbol": "OPEN",
+    "decimals": 18
+  },
+  "infoURL": "https://www.openledger.xyz",
+  "shortName": "open",
+  "chainId": 1612,
+  "networkId": 1612,
+  "icon": "openledger",
+  "explorers": [
+    {
+      "name": "OpenLedger Explorer",
+      "url": "https://scan.openledger.xyz",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-1",
+    "bridges": [
+      {
+        "url": "https://bridge.openledger.xyz/"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR adds support for the OpenLedger mainnet by updating the configuration. A new JSON file has been included with the relevant chain data, following EIP-1612 standards. The existing openledger icon, already used for the testnet, is reused for the mainnet.