### PR TITLE
Remove RPC link from Status Network Sepolia - chainId: 1660990954

### DIFF
--- a/_data/chains/eip155-1660990954.json
+++ b/_data/chains/eip155-1660990954.json
@@ -3,8 +3,7 @@
   "title": "Status Network Sepolia",
   "chain": "ETH",
   "rpc": [
-    "https://public.sepolia.rpc.status.network",
-    "wss://status-sepolia-rpc.eu-north-2.gateway.fm/ws"
+    "https://public.sepolia.rpc.status.network"
   ],
   "faucets": ["https://faucet.status.network/"],
   "nativeCurrency": {

--- a/_data/chains/eip155-1660990954.json
+++ b/_data/chains/eip155-1660990954.json
@@ -2,9 +2,7 @@
   "name": "Status Network Sepolia",
   "title": "Status Network Sepolia",
   "chain": "ETH",
-  "rpc": [
-    "https://public.sepolia.rpc.status.network"
-  ],
+  "rpc": ["https://public.sepolia.rpc.status.network"],
   "faucets": ["https://faucet.status.network/"],
   "nativeCurrency": {
     "name": "Ether",


### PR DESCRIPTION
Hello team!

Doing this PR to remove a legacy endpoint of Status Network Sepolia Testnet.

We followed the guide and the maintainer checklist so hopefully all is good!

Many thanks,
the Status Network team