### PR TITLE
Add Consciousness Chain with ChainID 2500

### DIFF
--- a/_data/chains/eip155-2500.json
+++ b/_data/chains/eip155-2500.json
@@ -1,0 +1,25 @@
+{
+  "name": "Consciousness Chain",
+  "chain": "CCC",
+  "rpc": [
+    "https://rpc.consciousnesschain.com",
+    "wss://wss.consciousnesschain.com"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Consciousness Chain Token",
+    "symbol": "CCC",
+    "decimals": 18
+  },
+  "infoURL": "https://explorer.cccscan.org",
+  "shortName": "ccc",
+  "chainId": 2500,
+  "networkId": 2500,
+  "explorers": [
+    {
+      "name": "Conscious Chain Scan",
+      "url": "https://explorer.cccscan.org",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Added Consciousness Chain Mainnet with ChainID 2500.
- Created _data/chains/eip155-2500.json with chain metadata.
- Verified ChainID 2500 is unique via chainlist.org.
- Formatted with `npx prettier --write _data/*/*.json`.
- Passed `./gradlew run` checks.