### PR TITLE
Deprecate Old Version of World Mobile Testnet

### DIFF
--- a/_data/chains/eip155-42070.json
+++ b/_data/chains/eip155-42070.json
@@ -1,18 +1,19 @@
 {
-  "name": "WMC Testnet",
-  "chain": "WMC",
+  "name": "deprecatedWMC Testnet",
+  "chain": "deprecatedWMC",
   "icon": "wmc",
-  "rpc": ["https://rpc-testnet-base.worldmobile.net"],
-  "faucets": ["https://faucet-testnet-base.worldmobile.net"],
+  "rpc": ["https://deprecated.rpc-testnet-base.worldmobile.net"],
+  "faucets": ["https://deprecated.faucet-testnet-base.worldmobile.net"],
   "nativeCurrency": {
     "name": "WMTx",
     "symbol": "WMTx",
     "decimals": 18
   },
   "infoURL": "https://worldmobiletoken.com",
-  "shortName": "wmtx",
+  "shortName": "deprecated-wmtx",
   "chainId": 42070,
   "networkId": 42070,
+  "status": "deprecated",
   "explorers": [
     {
       "name": "WMC Explorer",


### PR DESCRIPTION
@ligi, there's a new iteration of World Mobile Tesetnet and the official chainId has changed from 42070 to 323432.

This PR is deprecating the older version of testnet. I will create another PR to add a new Chain/chainId.

Thank you.