### PR TITLE
Add IBVM Testnet Chain (ChainId:2107)

### DIFF
--- a/_data/chains/eip155-2107.json
+++ b/_data/chains/eip155-2107.json
@@ -1,0 +1,27 @@
+{
+  "name": "International Bitcoin Virtual Machine Testnet",
+  "chain": "IBVM Testnet",
+  "icon": "ibvmtest",
+  "rpc": [
+    "https://rpc-testnet.ibvm.io/",
+    "wss://rpc-testnet.ibvm.io/ws/"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "IBVM Bitcoin",
+    "symbol": "BTC",
+    "decimals": 18
+  },
+  "infoURL": "https://ibvm.io/",
+  "shortName": "IBVM",
+  "chainId": 2107,
+  "networkId": 2107,
+  "explorers": [
+    {
+      "name": "IBVM Testnet explorer",
+      "url": "https://testnet-explorer.ibvm.io",
+      "standard": "EIP3091"
+    }
+  ],
+  "status": "active"
+}

--- a/_data/icons/ibvmtest.json
+++ b/_data/icons/ibvmtest.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmaGwqFhPkWfr5pv7sfNP8xzhSBiBCx8WWZ8hjCSbcftry",
+    "width": 2091,
+    "height": 2091,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
This PR adds the IBVM Testnet to Chainlist.

IBVM (International Bitcoin Virtual Machine) is a Layer 2 blockchain built on top of Bitcoin. It leverages zk-rollup technology to provide scalable, EVM-compatible smart contract functionality while using BTC as the native gas token.

We kindly request the inclusion of the IBVM Testnet to help developers and users easily connect via supported wallets and explore the capabilities of our network.

Chain details and metadata are included in this submission. Please let us know if any further information is required.