### PR TITLE
Add NutriEmp Chain (GRAMZ) — chainId 432

### DIFF
--- a/_data/chains/eip155-432.json
+++ b/_data/chains/eip155-432.json
@@ -1,0 +1,21 @@
+{
+  "name": "NutriEmp Chain",
+  "chain": "nutriemp-chain",
+  "rpc": ["https://rpc.nutriemp-chain.link", "https://rpc.nutriemp.com"],
+  "faucets": [],
+  "nativeCurrency": { "name": "GRAMZ", "symbol": "GRAMZ", "decimals": 18 },
+  "infoURL": "https://nutriemp.com",
+  "shortName": "nutriemp",
+  "chainId": 432,
+  "networkId": 432,
+  "icon": "GRAMZ",
+  "features": [{ "name": "EIP155" }],
+  "explorers": [
+    {
+      "name": "NutriEmp Explorer",
+      "url": "https://explorer.nutriemp-chain.link",
+      "standard": "EIP3091",
+      "icon": "GRAMZ"
+    }
+  ]
+}

--- a/_data/icons/GRAMZ.json
+++ b/_data/icons/GRAMZ.json
@@ -1,0 +1,10 @@
+
+
+[
+  {
+    "url": "ipfs://bafybeih7p2zkgxc6i6ygihz556y22aruacwybtfaif7554hqnd2a745uce/",
+    "width": 500,
+    "height": 500,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
This PR adds NutriEmp Chain to the chain list:

Chain ID: 432

Native currency: GRAMZ

RPC URLs and Explorer included

Icon added under _data/icons/GRAMZ.json

Let me know if anything needs updating.
Regards.