### PR TITLE
Update RPC endpoints and infoURL for peaq

### DIFF
--- a/_data/chains/eip155-3338.json
+++ b/_data/chains/eip155-3338.json
@@ -3,10 +3,8 @@
   "chain": "peaq",
   "icon": "peaq",
   "rpc": [
-    "https://peaq.api.onfinality.io/public",
     "https://peaq-rpc.dwellir.com",
     "https://peaq-rpc.publicnode.com",
-    "https://evm.peaq.network",
     "https://responsive-powerful-mansion.peaq-mainnet.quiknode.pro/29963d0a2deee01a20b091926b08d68db12bc68b"
   ],
   "faucets": [],
@@ -15,7 +13,7 @@
     "symbol": "PEAQ",
     "decimals": 18
   },
-  "infoURL": "https://www.peaq.network",
+  "infoURL": "https://www.peaq.xyz",
   "shortName": "PEAQ",
   "chainId": 3338,
   "networkId": 3338,

--- a/_data/chains/eip155-3338.json
+++ b/_data/chains/eip155-3338.json
@@ -3,8 +3,8 @@
   "chain": "peaq",
   "icon": "peaq",
   "rpc": [
-    "https://peaq-rpc.dwellir.com",
     "https://peaq-rpc.publicnode.com",
+    "https://peaq-rpc.dwellir.com",
     "https://responsive-powerful-mansion.peaq-mainnet.quiknode.pro/29963d0a2deee01a20b091926b08d68db12bc68b"
   ],
   "faucets": [],


### PR DESCRIPTION

Description:
	•	Updated peaq chain RPC endpoints by removing deprecated and non-functional URLs.
	•	Added/kept only reliable and active RPC endpoints for improved stability and performance.
	•	Updated infoURL from https://www.peaq.network to the new domain https://www.peaq.xyz to reflect the latest official project site.


Summary of changes:
	•	Removed: https://peaq.api.onfinality.io/public, https://evm.peaq.network
	•	Updated: infoURL to new domain

This update ensures up-to-date endpoints and official info link for users and integrators.
