### PR TITLE
feat: Add xlayer testnet2

### DIFF
--- a/_data/chains/eip155-1952.json
+++ b/_data/chains/eip155-1952.json
@@ -1,0 +1,18 @@
+{
+  "name": "X Layer Testnet2",
+  "chain": "X Layer",
+  "rpc": ["https://testrpc.xlayer.tech/terigon", "https://xlayertestrpc.okx.com/terigon"],
+  "nativeCurrency": {
+    "name": "X Layer Global Utility Token in testnet",
+    "symbol": "OKB",
+    "decimals": 18
+  },
+  "features": [],
+  "infoURL": "https://www.okx.com/xlayer",
+  "shortName": "tokb",
+  "chainId": 1952,
+  "networkId": 1952,
+  "slip44": 1,
+  "icon": "xlayerTestnet2",
+  "status": "active"
+}

--- a/_data/chains/eip155-1952.json
+++ b/_data/chains/eip155-1952.json
@@ -1,6 +1,6 @@
 {
   "name": "X Layer Testnet2",
-  "chain": "X Layer",
+  "chain": "X Layer Testnet2",
   "rpc": ["https://testrpc.xlayer.tech/terigon", "https://xlayertestrpc.okx.com/terigon"],
   "nativeCurrency": {
     "name": "X Layer Global Utility Token in testnet",


### PR DESCRIPTION
# Chain Name

X Layer Testnet2
# Description 

X Layer Testnet2 is a public blockchain designed for testing applications on the X Layer network. It enables developers and users to experiment with smart contracts, transactions, and infrastructure integrations in a safe environment prior to mainnet deployment.
X Layer Testnet2 supports rapid block confirmation, low gas fees, and full Solidity compatibility, making it ideal for dApp testing and protocol simulations.
Its native test token, OKB, is used exclusively for development and testing purposes.

# Key technical specs:
	
•	Block time: ~3s
•	Chain ID: 1952
•	Token: OKB (testnet only)
# Endpoints
	
RPC: 
	⁃	https://testrpc.xlayer.tech/terigon 
	⁃	https://xlayertestrpc.okx.com/terigon

