### PR TITLE
Update silicon testnet info

### DIFF
--- a/_data/chains/eip155-1414.json
+++ b/_data/chains/eip155-1414.json
@@ -1,6 +1,6 @@
 {
-  "name": "Silicon zkEVM Sepolia Testnet(Deprecated)",
-  "title": "Silicon zkEVM Sepolia Testnet(Deprecated)",
+  "name": "Silicon zkEVM Sepolia Testnet",
+  "title": "Silicon zkEVM Sepolia Testnet",
   "chain": "Silicon",
   "rpc": [],
   "faucets": [],
@@ -10,15 +10,21 @@
     "decimals": 18
   },
   "infoURL": "",
-  "shortName": "silicon-sepolia-testnet-deprecated",
+  "shortName": "silicon-sepolia-testnet",
   "chainId": 1414,
   "networkId": 1414,
   "icon": "silicon",
-  "explorers": [],
+  "explorers": [
+    {
+      "name": "siliconscope-sepolia",
+      "url": "https://scope-1414.silicon.network",
+      "standard": "EIP3091"
+    }
+  ],
   "parent": {
     "type": "L2",
     "chain": "eip155-11155111",
-    "bridges": []
+    "bridges": [{ "url": "https://bridge-sepolia.silicon.network" }]
   },
-  "status": "deprecated"
+  "status": "incubating"
 }

--- a/_data/chains/eip155-1722641160.json
+++ b/_data/chains/eip155-1722641160.json
@@ -1,6 +1,6 @@
 {
-  "name": "Silicon zkEVM Sepolia Testnet",
-  "title": "Silicon zkEVM Sepolia Testnet",
+  "name": "Silicon zkEVM Sepolia Testnet(Deprecated)",
+  "title": "Silicon zkEVM Sepolia Testnet(Deprecated)",
   "chain": "Silicon",
   "rpc": [
     "https://rpc-sepolia.silicon.network",
@@ -13,17 +13,11 @@
     "decimals": 18
   },
   "infoURL": "https://docs.silicon.network",
-  "shortName": "silicon-sepolia-testnet",
+  "shortName": "silicon-sepolia-testnet-deprecated",
   "chainId": 1722641160,
   "networkId": 1722641160,
   "icon": "silicon",
-  "explorers": [
-    {
-      "name": "siliconscope-sepolia",
-      "url": "https://scope-sepolia.silicon.network",
-      "standard": "EIP3091"
-    }
-  ],
+  "explorers": [],
   "parent": {
     "type": "L2",
     "chain": "eip155-11155111",


### PR DESCRIPTION
# Sepolia Testnet
* We reviewed problems together with the Polygon team but couldn’t find a suitable solution, so we will update the testnet setup.
* We will revert to using the deprecated chain and set the currently active chain to inactive.
