### PR TITLE
Update RPC endpoints for peaq chain

### DIFF
--- a/_data/chains/eip155-3338.json
+++ b/_data/chains/eip155-3338.json
@@ -3,9 +3,10 @@
   "chain": "peaq",
   "icon": "peaq",
   "rpc": [
-    "https://peaq-rpc.publicnode.com",
-    "https://peaq-rpc.dwellir.com",
-    "https://responsive-powerful-mansion.peaq-mainnet.quiknode.pro/29963d0a2deee01a20b091926b08d68db12bc68b"
+    "https://quicknode1.peaq.xyz",
+    "https://quicknode2.peaq.xyz",
+    "https://quicknode3.peaq.xyz",
+    "https://peaq-rpc.publicnode.com"
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
Update peaq RPC Endpoints

Summary:
Replaced old RPC URLs with updated and more reliable endpoints for the peaq network.

Details:
	•	Removed outdated or unused RPC URLs.
	•	Added new QuickNode endpoints for improved performance and redundancy.
	•	Kept peaq-rpc.publicnode.com as a fallback.