### PR TITLE
peaq: remove deprecated PublicNode RPC endpoint

### DIFF
--- a/_data/chains/eip155-3338.json
+++ b/_data/chains/eip155-3338.json
@@ -5,8 +5,7 @@
   "rpc": [
     "https://quicknode1.peaq.xyz",
     "https://quicknode2.peaq.xyz",
-    "https://quicknode3.peaq.xyz",
-    "https://peaq-rpc.publicnode.com"
+    "https://quicknode3.peaq.xyz"
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
Update peaq RPC Endpoints

Summary:
Removes the deprecated https://peaq-rpc.publicnode.com endpoint
from the Peaq mainnet (chainId 3338) RPC list. No other changes.

Details:
• Removed deprecated RPC URL https://peaq-rpc.publicnode.com
