### PR TITLE
Add EB-Chain (chain ID: 8721)

### DIFF
--- a/_data/chains/eip155-8721.json
+++ b/_data/chains/eip155-8721.json
@@ -1,0 +1,35 @@
+{
+  "name": "EBC Chain",
+  "chain": "EBC",
+  "rpc": [
+    "https://rpc.ebcscan.net",
+    "http://31.97.197.79:8545"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "EBC Token",
+    "symbol": "EBC",
+    "decimals": 18
+  },
+  "infoURL": "https://ebcscan.net",
+  "shortName": "ebc",
+  "chainId": 8721,
+  "networkId": 8721,
+  "icon": "ebc",
+  "explorers": [
+    {
+      "name": "EBC Scan",
+      "url": "https://ebcscan.net",
+      "icon": "ebc",
+      "standard": "EIP3091"
+    }
+  ],
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
+    }
+  ]
+}

--- a/_data/icons/ebc.json
+++ b/_data/icons/ebc.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "https://ebcscan.net/logo.png",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Adding EB-Chain - an EVM-compatible blockchain network.

Chain Details:
- Chain ID: 8721 (0x2211)
- Name: EB-Chain
- RPC: https://rpc.ebcscan.net
- Explorer: https://ebcscan.net
- Status: Active/Production

This chain is fully operational with:
✅ Unique Chain ID (8721)
✅ Production-ready infrastructure
✅ HTTPS endpoints
✅ Block explorer
✅ EVM compatibility

Documentation: https://ebcscan.net