### PR TITLE
Update HashKey Chain Testnet

### DIFF
--- a/_data/chains/eip155-133.json
+++ b/_data/chains/eip155-133.json
@@ -2,21 +2,21 @@
   "name": "HashKey Chain Testnet",
   "title": "HashKey Chain Testnet",
   "chain": "HashKey Chain Testnet",
-  "rpc": ["https://hashkeychain-testnet.alt.technology"],
+  "rpc": ["https://testnet.hsk.xyz"],
   "faucets": [],
   "nativeCurrency": {
     "name": "HashKey EcoPoints",
     "symbol": "HSK",
     "decimals": 18
   },
-  "infoURL": "https://hashkey.cloud",
-  "shortName": "HSKT",
+  "infoURL": "https://hsk.xyz",
+  "shortName": "hskt",
   "chainId": 133,
   "networkId": 133,
   "explorers": [
     {
       "name": "blockscout",
-      "url": "https://hashkeychain-testnet-explorer.alt.technology",
+      "url": "https://testnet-explorer.hsk.xyz",
       "icon": "blockscout",
       "standard": "EIP3091"
     }


### PR DESCRIPTION
This PR updates the following for the HashKey Chain Testnet:

- Updates the RPC endpoint.
- Sets a new infoURL.
- Corrects the explorer URL.
- Converts shortName to lowercase.