### PR TITLE
Add ALLx Chain (chainId 19777)

### DIFF
--- a/eip155-19777.json
+++ b/eip155-19777.json
@@ -1,0 +1,25 @@
+{
+  "name": "ALLx Chain",
+  "chain": "ALLx",
+  "icon": "allx",
+  "rpc": [
+    "https://rpc.allxchain.io"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "ALLx",
+    "symbol": "ALLx",
+    "decimals": 18
+  },
+  "infoURL": "https://allxchain.io",
+  "shortName": "allx",
+  "chainId": 19777,
+  "networkId": 19777,
+  "explorers": [
+    {
+      "name": "ALLx Explorer",
+      "url": "https://explorer.allxchain.io",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
This PR registers ALLx Chain to the EIP-155 chain list.

- Chain ID: 19777
- Name: ALLx
- Currency: ALLx (18 decimals)
- RPC: https://rpc.allxchain.io
- Explorer: https://explorer.allxchain.io
- Icon: allx.png in images/icons/