### PR TITLE
Update nativeCurrency symbol for ENI chain to EGAS

### DIFF
--- a/_data/chains/eip155-173.json
+++ b/_data/chains/eip155-173.json
@@ -4,8 +4,8 @@
   "rpc": ["https://rpc.eniac.network"],
   "faucets": [],
   "nativeCurrency": {
-    "name": "ENI",
-    "symbol": "ENI",
+    "name": "EGAS",
+    "symbol": "EGAS",
     "decimals": 18
   },
   "infoURL": "https://eniac.network/",

--- a/_data/chains/eip155-6912115.json
+++ b/_data/chains/eip155-6912115.json
@@ -4,8 +4,8 @@
   "rpc": ["https://rpc-testnet.eniac.network"],
   "faucets": [],
   "nativeCurrency": {
-    "name": "ENI Testnet Token",
-    "symbol": "ENI",
+    "name": "EGAS",
+    "symbol": "EGAS",
     "decimals": 18
   },
   "infoURL": "https://eniac.network/",


### PR DESCRIPTION
Hi maintainers,

This PR updates the native token symbol of the ENI chain from ENI to EGAS.

The ENI token is planned for launch in March 2026, and until then, the network uses EGAS as the native gas token. Keeping ENI as the symbol currently causes MetaMask warnings and user confusion due to the mismatch.

We’ll update the symbol back to ENI once the official token is launched.

For context, the ENI roadmap is outlined here: https://medium.com/@ENI_Official/comprehensive-interpretation-of-the-eni-mainnet-roadmap-understanding-the-eni-ecosystem-strategy-3c0eefacd1bb

Thanks for your time and help