### PR TITLE
Add Redmansion Chain (chainId: 192)

### DIFF
--- a/_data/chains/eip155-192.json
+++ b/_data/chains/eip155-192.json
@@ -1,0 +1,24 @@
+{
+  "name": "Redmansion Chain",
+  "chain": "RMC",
+  "icon": "redmansion",
+  "rpc": ["https://redmansion.io/srpc/"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Redmansion Coin",
+    "symbol": "RMC",
+    "decimals": 18
+  },
+  "infoURL": "https://www.redmansion.io",
+  "shortName": "rmc",
+  "chainId": 192,
+  "networkId": 192,
+  "explorers": [
+    {
+      "name": "Redmansion explorer",
+      "url": "https://redmansion.io",
+      "icon": "redmansion",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/icons/redmansion.json
+++ b/_data/icons/redmansion.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://Qmd49EoSchLo4LbHvdmAx6cFcL4gLgo7hzDyUjB1hPrTTP",
+    "width": 150,
+    "height": 150,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Redmansion Chain (ChainID: 192)

This PR adds metadata for Redmansion Chain, a new EVM-compatible public chain focused on literary creation, copyright registration, and royalty distribution for Web3-native authors and artists.

The chain is fully operational, publicly accessible, and includes:

🟢 Public RPC Endpoint: https://redmansion.io/srpc/

🔍 Explorer: https://redmansion.io

🌐 Website / For Creator: https://www.redmansion.io

📦 GitHub: https://github.com/redmansionorg

[Chain Overview and Project Summary for Redmansion Chain.txt](https://github.com/user-attachments/files/21555016/Chain.Overview.and.Project.Summary.for.Redmansion.Chain.txt)

🧠 OpenTimestamp-integrated consensus

🖼️ Official logo (PNG, 256x256, included in this PR)

📚 Chain Overview and Project Summary for Redmansion Chain

The chain is deployed, actively maintained, and already in use for NFT-based novel and artwork publishing.

Please let us know if further information is required. Thank you for maintaining this great list!