### PR TITLE
Create eip155-347.json

### DIFF
--- a/_data/chains/eip155-347.json
+++ b/_data/chains/eip155-347.json
@@ -1,0 +1,22 @@
+{
+  "name": "Kross Network Mainnet",
+  "chain": "KSS",
+  "rpc": ["https://rpc-v1.kross.network"],
+  "nativeCurrency": {
+    "name": "Kross",
+    "symbol": "KSS",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://kross.network",
+  "shortName": "kss",
+  "chainId": 347,
+  "networkId": 347,
+  "icon": "kross",
+  "explorers": [{
+    "name": "Kross Network Explorer",
+    "url": "https://explorer.kross.network",
+    "icon": "kross",
+    "standard": "EIP3091"
+  }]
+}


### PR DESCRIPTION
Adding chain with ID 347 (Kross Network Mainnet)

Please find the details below:

This PR adds `eip155-347.json` for Kross Network.

- Chain ID: 347
- Name: Kross Network Mainnet
- Symbol: KSS
- RPC: https://rpc-v1.kross.network
- Icon: kross (IPFS-based, defined in `_data/icons/kross.json`)

Thank you!
