### PR TITLE
Add Primea Network Mainnet explorer and update RPC endpoints

### DIFF
--- a/_data/chains/eip155-698369.json
+++ b/_data/chains/eip155-698369.json
@@ -2,10 +2,10 @@
   "name": "Primea Network Mainnet",
   "chain": "Primea Network Mainnet",
   "rpc": [
-    "http://rpc.primeanetwork.com/rpc-http",
-    "https://rpc.primeanetwork.com/rpc-https",
-    "ws://rpc.primeanetwork.com/rpc-ws",
-    "wss://rpc.primeanetwork.com/rpc-wss"
+    "http://rpc.primeanetwork.com/",
+    "https://rpc.primeanetwork.com/",
+    "ws://rpc.primeanetwork.com/ws",
+    "wss://rpc.primeanetwork.com/wss"
   ],
   "faucets": [],
   "nativeCurrency": {
@@ -18,5 +18,11 @@
   "chainId": 698369,
   "networkId": 698369,
   "icon": "prim",
-  "explorers": []
+  "explorers": [
+    {
+      "name": "Primea Explorer",
+      "url": "http://200.115.122.215:8080",
+      "standard": "EIP3091"
+    }
+  ]
 }


### PR DESCRIPTION
This PR updates the metadata for the Primea Network Mainnet (chainId: 698369) with the following changes:

### 🔧 RPC Updates:
- Added both secure (`https`) and insecure (`http`) RPC URLs.
- Added WebSocket endpoints (`ws` and `wss`) for real-time features like `eth_subscribe`.

### 🔎 Explorer Addition:
- Added a new explorer URL: `http://200.115.122.215:8080`
- Marked as EIP-3091 compliant to support deep linking in wallets and dApps (e.g. /tx/, /address/, /block/)

### ✅ Result:
These changes enhance developer integration, enable tooling compatibility, and provide users with a way to visually inspect blockchain data on Primea Mainnet.

Let me know if you'd prefer the explorer be referenced via DNS instead of a raw IP, and I’ll update accordingly.
