### PR TITLE
Update World Mobile Chain - Info, RPC, Explorer and Icon

### DIFF
--- a/_data/chains/eip155-869.json
+++ b/_data/chains/eip155-869.json
@@ -1,7 +1,8 @@
 {
   "name": "WorldMobileChain-Mainnet",
   "chain": "WMC",
-  "rpc": [],
+  "icon": "worldmobilechain",
+  "rpc": ["https://worldmobilechain-mainnet.g.alchemy.com/public"],
   "faucets": [],
   "nativeCurrency": {
     "name": "World Mobile Token",
@@ -12,5 +13,12 @@
   "shortName": "WMC",
   "chainId": 869,
   "networkId": 869,
-  "status": "incubating"
+  "explorers": [
+    {
+      "name": "World Mobile Chain Explorer",
+      "url": "https://explorer.worldmobile.io",
+      "standard": "none"
+    }
+  ],
+  "status": "active"
 }

--- a/_data/icons/worldmobilechain.json
+++ b/_data/icons/worldmobilechain.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreiaa7ku47xm2736wexq53pihf7rfzeec7vwgvkhakd3sitogv4mi6m",
+    "width": 32,
+    "height": 32,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
This PR updates the metadata for the World Mobile Chain Mainnet (chainId: 869) with the following changes:

Chain Status: 
* Changed chain status from incubating to active 

Explorer: 
* Added Explorer for World Mobile Chain Mainnet. 

RPC Updates:
* Add Public RPC for the Chain

Icon: 
* Add Icon for World Mobile Chain 

Thank you for your time and assistance :)