### PR TITLE
Add Quai mainnet and Quai testnet

### DIFF
--- a/_data/chains/eip155-15000.json
+++ b/_data/chains/eip155-15000.json
@@ -1,8 +1,8 @@
 {
-  "name": "Quai Network Mainnet",
+  "name": "Quai Network Testnet",
   "chain": "QUAI",
   "icon": "quai",
-  "rpc": ["https://rpc.quai.network/cyprus1"],
+  "rpc": ["https://orchard.rpc.quai.network/cyprus1"],
   "features": [{ "name": "EIP155" }],
   "faucets": [],
   "nativeCurrency": {
@@ -11,14 +11,13 @@
     "decimals": 18
   },
   "infoURL": "https://qu.ai",
-  "shortName": "quai",
-  "chainId": 9,
-  "networkId": 9,
-  "redFlags": ["reusedChainId"],
+  "shortName": "quai-testnet",
+  "chainId": 15000,
+  "networkId": 15000,
   "explorers": [
     {
-      "name": "Quaiscan",
-      "url": "https://quaiscan.io",
+      "name": "Orchard Quaiscan",
+      "url": "https://orchard.quaiscan.io",
       "standard": "EIP3091"
     }
   ]

--- a/_data/icons/quai.json
+++ b/_data/icons/quai.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreih5hekf3lfvpbjcjlswylc6r3a4nbkogeesrf2pdtrhrwuy4a76cm",
+    "width": 500,
+    "height": 500,
+    "format": "svg"
+  }
+]


### PR DESCRIPTION
Regarding chain ID 9: Was previously used for a testnet, but the testnet does not exist anymore. There are no RPCs or block explorers. It's possible the mainnet is still online, but the mainnet block explorer (ubiqscan.io) isn't loading, and the testnet doesn't have any RPC or block explorer. This post indicates that they do not have a testnet: https://www.reddit.com/r/Ubiq/comments/1027jrl/looking_for_ubiq_testnet_peers_and_block_explorer/
Added "redFlags": ["reusedChainId"] just in case.

In addition, we are on listed chainlist.org: https://chainlist.org/chain/9
https://github.com/DefiLlama/chainlist/pull/1784