### PR TITLE
Create eip155-7890.json

### DIFF
--- a/_data/chains/eip155-7890.json
+++ b/_data/chains/eip155-7890.json
@@ -12,7 +12,6 @@
   "shortName": "panchain",
   "chainId": 7890,
   "networkId": 7890,
-  "icon": "panchain",
   "explorers": [
     {
       "name": "Blockscout",


### PR DESCRIPTION
This PR adds Panchain, a custom Proof-of-Authority (PoA) blockchain network.

- Name: Panchain
- Chain ID: 7890
- RPC: https://rpc.panchain.io (public, HTTPS, CORS enabled)
- Explorer: https://scan.panchain.io (Blockscout, EIP-3091 compliant)
- Native Currency: Pan Coin (PC)

Panchain aims to provide fast and secure PoA-based transactions for scalable dApps and enterprise solutions.