### PR TITLE
Add SAX Chain (chainId 55080)

### DIFF
--- a/_data/chains/_data/chains/eip155-55080.json
+++ b/_data/chains/_data/chains/eip155-55080.json
@@ -1,0 +1,24 @@
+{
+  "name": "SAX Chain",
+  "chain": "SAX",
+  "icon": "",
+  "rpc": ["https://rpc.saxchain.org"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "SAX",
+    "symbol": "SAX",
+    "decimals": 18
+  },
+  "infoURL": "https://saxchain.org",
+  "shortName": "sax",
+  "chainId": 55080,
+  "networkId": 55080,
+  "slip44": 60,
+  "explorers": [
+    {
+      "name": "SAX Explorer",
+      "url": "https://explorer.saxchain.org",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds SAX Chain (EVM-compatible).

Name: SAX Chain
Chain ID: 55080 (EIP-155 unique)
RPC: https://rpc.saxchain.org (HTTPS)
Explorer: https://explorer.saxchain.org (EIP-3091 paths: /tx/, /address/, /block/)
Native currency: SAX (18 decimals)
Info URL: https://saxchain.org

Notes:
- Public RPC served behind Nginx + TLS (Let's Encrypt), rate-limited.
- We will open an issue on Chainlist to associate the network icon.
