### PR TITLE
Add EADX Network (chainId 198724)

### DIFF
--- a/_data/chains/eip155-198724.json
+++ b/_data/chains/eip155-198724.json
@@ -1,0 +1,19 @@
+{
+  "name": "EADX Network",
+  "chain": "EADX",
+  "icon": "eadx",
+  "rpc": ["https://rpc.eadx.network"],
+  "faucets": [],
+  "nativeCurrency": { "name": "EDX", "symbol": "EDX", "decimals": 18 },
+  "infoURL": "https://eadxexchange.com",
+  "shortName": "eadx",
+  "chainId": 198724,
+  "networkId": 198724,
+  "explorers": [
+    {
+      "name": "EADX Explorer",
+      "url": "https://explorer.eadx.network",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/icons/eadx.json
+++ b/_data/icons/eadx.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafybeiavsr72fjlr7sjchih7yuqlw57uuwkosvigo3angiylbj5kzztq74/logo.png",
+    "width": 256,
+    "height": 256,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
This PR adds the EADX Network (chainId 198724) with RPC, explorer (EIP-3091), and icon referenced via IPFS.