### PR TITLE
Add Denergy Mainnet (4441) and Testnet (4442)

### DIFF
--- a/_data/chains/eip155-4441.json
+++ b/_data/chains/eip155-4441.json
@@ -1,0 +1,17 @@
+{
+  "name": "Denergy",
+  "chain": "DEN",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "WATT",
+    "symbol": "WATT",
+    "decimals": 18
+  },
+  "infoURL": "https://d.energy/",
+  "shortName": "den",
+  "chainId": 4441,
+  "networkId": 4441,
+  "icon": "denergy",
+  "explorers": []
+}

--- a/_data/chains/eip155-4442.json
+++ b/_data/chains/eip155-4442.json
@@ -1,0 +1,24 @@
+{
+  "name": "Denergy Testnet",
+  "chain": "DEN",
+  "rpc": ["https://rpc.denergytestnet.com/"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "WATT",
+    "symbol": "WATT",
+    "decimals": 18
+  },
+  "infoURL": "https://d.energy/",
+  "shortName": "den-testnet",
+  "chainId": 4442,
+  "networkId": 4442,
+  "icon": "denergy",
+  "explorers": [
+    {
+      "name": "Denergy Explorer",
+      "url": "https://explorer.denergytestnet.com",
+      "icon": "denergy",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-4442.json
+++ b/_data/chains/eip155-4442.json
@@ -16,7 +16,7 @@
   "explorers": [
     {
       "name": "Denergy Explorer",
-      "url": "https://explorer.denergytestnet.com",
+      "url": "https://explorernew.denergytestnet.com",
       "icon": "denergy",
       "standard": "EIP3091"
     }

--- a/_data/icons/denergy.json
+++ b/_data/icons/denergy.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmdZMYDb12zN4ErNoSob7yotqqQBMobCDbhumMY3DV1kG1",
+    "width": 512,
+    "height": 503,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
## Summary
- Added Denergy Testnet configuration with chain ID 4442
- Added Denergy Mainnet configuration with chain ID 4441
- Added DEnergy icon

## Details
- Mainnet RPC and explorer URLs are temporarily empty pending live deployment
- Explorer for both the Chains are built on top of Blockscout
- Icon uploaded to IPFS: QmdZMYDb12zN4ErNoSob7yotqqQBMobCDbhumMY3DV1kG1

## Test plan
- [x] Schema validation passes
- [x] JSON formatting applied with Prettier
- [x] Icon accessible via IPFS