### PR TITLE
Add new Sonic Testnet 14601 Chain

### DIFF
--- a/_data/chains/eip155-14601.json
+++ b/_data/chains/eip155-14601.json
@@ -1,0 +1,19 @@
+{
+  "name": "Sonic Testnet",
+  "chain": "sonic-testnet",
+  "rpc": [
+    "https://rpc.testnet.soniclabs.com"
+  ],
+  "faucets": ["https://testnet.soniclabs.com/account"],
+  "nativeCurrency": {
+    "name": "Sonic",
+    "symbol": "S",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://testnet.soniclabs.com",
+  "shortName": "sonicTestnet",
+  "chainId": 14601,
+  "networkId": 14601,
+  "icon": "sonic"
+}


### PR DESCRIPTION
Added Sonic's new Pectra compatible testnet chain 14601.

https://x.com/0xseg/status/1958495888273248681