### PR TITLE
Add Notes Network Mainnet (chainId 2643)

### DIFF
--- a/_data/chains/eip155-2643.json
+++ b/_data/chains/eip155-2643.json
@@ -1,0 +1,16 @@
+{
+  "name": "Notes Network Mainnet",
+  "title": "notes",
+  "chain": "NOTES",
+  "rpc": ["https://rpc-mainnet.noschain.org"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Kto",
+    "symbol": "KTO",
+    "decimals": 11
+  },
+  "infoURL": "https://nosscan.noschain.org/",
+  "shortName": "kto",
+  "chainId": 2643,
+  "networkId": 2643
+}


### PR DESCRIPTION
### What does this PR do?
This PR adds support for Notes Network Mainnet.

### Chain details
- **Name**: Notes Network Mainnet
- **Chain ID**: 2643
- **Symbol**: KTO
- **Decimals**: 11
- **RPC**: https://rpc-mainnet.noschain.org
- **Explorer**: https://nosscan.noschain.org