### PR TITLE
Add 0g Galileo test net

### DIFF
--- a/_data/chains/eip155-16601.json
+++ b/_data/chains/eip155-16601.json
@@ -1,0 +1,23 @@
+{
+  "name": "0G-Galileo-Testnet",
+  "chain": "0G-Testnet",
+  "rpc": ["https://evmrpc-testnet.0g.ai"],
+  "faucets": ["https://faucet.0g.ai"],
+  "nativeCurrency": {
+    "name": "OG",
+    "symbol": "OG",
+    "decimals": 18
+  },
+  "infoURL": "https://0g.ai",
+  "shortName": "0gai-testnet",
+  "chainId": 16601,
+  "networkId": 16601,
+  "icon": "0gai",
+  "explorers": [
+    {
+      "name": "0G BlockChain Explorer",
+      "url": "https://chainscan-galileo.0g.ai",
+      "standard": "none"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds 0G's test net details for v3 release:

- **Added**: New 0G Galileo Testnet (Chain ID: 16601)

Reference: 
Official documentation: [0G Testnet Overview](https://docs.0g.ai/developer-hub/testnet/testnet-overview)
