### PR TITLE
Add Parallax mainnet & testnet (PRLX)

### DIFF
--- a/_data/chains/eip155-2110.json
+++ b/_data/chains/eip155-2110.json
@@ -1,0 +1,18 @@
+{
+  "name": "Parallax",
+  "chain": "PARALLAX",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Parallax",
+    "symbol": "PRLX",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://github.com/microstack-tech/parallax-whitepaper",
+  "shortName": "prlx",
+  "chainId": 2110,
+  "networkId": 2110,
+  "icon": "ethereum",
+  "explorers": []
+}

--- a/_data/chains/eip155-2111.json
+++ b/_data/chains/eip155-2111.json
@@ -1,0 +1,18 @@
+{
+  "name": "Parallax Testnet",
+  "chain": "PARALLAX",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Parallax",
+    "symbol": "tPRLX",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://github.com/microstack-tech/parallax-whitepaper",
+  "shortName": "prlx",
+  "chainId": 2111,
+  "networkId": 2111,
+  "icon": "ethereum",
+  "explorers": []
+}


### PR DESCRIPTION
This PR registers **Parallax** in `ethereum-lists/chains`.  

The purpose of this submission is to **lock in the chainId (2110) and networkId (2110)** for Parallax. Public RPC endpoints and an explorer will be added in a future update once the mainnet is live in November.  

**Parallax** is a new timechain protocol that merges Bitcoin’s monetary discipline with Ethereum’s programmability. It operates under Bitcoin’s fixed rules — Proof of Work, 10-minute blocks, halving cycles, and a capped 21M supply — while embedding the Ethereum Virtual Machine for smart contract execution.  

**Key properties:**  
- **Consensus:** Proof of Work (Ethash)  
- **Block Interval:** 10 minutes (600s)  
- **Difficulty Adjustment:** Every 2016 blocks (≈ 2 weeks), bounded by ×4/÷4 (Bitcoin-style)  
- **Block Reward:** 50 coins, halving every 210,000 blocks (~4 years)  
- **Supply Cap:** 21,000,000 PRLX  
- **Execution Environment:** Ethereum Virtual Machine (EVM)  
- **Fee Model:** First-price auction (no burning, no EIP-1559)  

**Ethos & Neutrality**  
- No premine, no foundation allocation, no privileged accounts.  
- Genesis block will include the title of a reputable news article to prove it was not pre-mined.  
- Monetary rules (21M cap, halving schedule, PoW consensus) are immutable and cannot be changed via governance.  
- Accessible Ethash mining favors GPUs, promoting decentralization.  

**References:**  
- Whitepaper: [Parallax Whitepaper (GitHub)](https://github.com/microstack-tech/parallax-whitepaper)  
- Updates: [@prlxchain on X](https://x.com/prlxchain)  