### PR TITLE
Add: Sova Mainnet config (chainId: 100021)

### DIFF
--- a/_data/chains/eip155-100021.json
+++ b/_data/chains/eip155-100021.json
@@ -1,0 +1,24 @@
+{
+  "name": "Sova",
+  "chain": "ETH",
+  "icon": "sova",
+  "rpc": ["https://rpc.sova.io"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://sova.io",
+  "shortName": "sova",
+  "chainId": 100021,
+  "networkId": 100021,
+  "explorers": [
+    {
+      "name": "blockscout",
+      "url": "https://explorer.sova.io",
+      "icon": "blockscout",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Add Sova Mainnet (chainId: 100021)

Parent chain: ETH Mainnet (1)
Native currency: ETH (18 decimals)