### PR TITLE
Update Jovay mainnet network config

### DIFF
--- a/_data/chains/eip155-5734951.json
+++ b/_data/chains/eip155-5734951.json
@@ -3,7 +3,7 @@
   "chain": "ETH",
   "status": "incubating",
   "rpc": [
-    "https://api.zan.top/public/jovay-mainnet",
+    "https://rpc.jovay.io",
     "https://api.zan.top/node/v1/jovay/mainnet/${ZAN_API_KEY}",
     "wss://api.zan.top/node/ws/v1/jovay/mainnet/${ZAN_API_KEY}"
   ],

--- a/_data/chains/eip155-5734951.json
+++ b/_data/chains/eip155-5734951.json
@@ -21,7 +21,7 @@
   "explorers": [
     {
       "name": "Jovay Explorer",
-      "url": "https://explorer.jovay.io",
+      "url": "https://explorer.jovay.io/l2",
       "standard": "none"
     }
   ],

--- a/_data/chains/eip155-5734951.json
+++ b/_data/chains/eip155-5734951.json
@@ -1,7 +1,7 @@
 {
   "name": "Jovay Mainnet",
   "chain": "ETH",
-  "status": "incubating",
+  "status": "active",
   "rpc": [
     "https://rpc.jovay.io",
     "https://api.zan.top/node/v1/jovay/mainnet/${ZAN_API_KEY}",


### PR DESCRIPTION
Update Jovay network default public rpc endpoint

Hello Team!

I've updated the data for Jovay Mainnet.

Changes:

Updated the default rpc endpoint for the Jovay Mainnet network.