### PR TITLE
Fix XLayer Testnet chain configuration - Update chainId from 195 to 1952

### DIFF
--- a/_data/chains/eip155-195.json
+++ b/_data/chains/eip155-195.json
@@ -11,8 +11,8 @@
   "features": [],
   "infoURL": "https://www.okx.com/xlayer",
   "shortName": "tokb",
-  "chainId": 195,
-  "networkId": 195,
+  "chainId": 1952,
+  "networkId": 1952,
   "slip44": 1,
   "icon": "xlayerTestnet",
   "explorers": [


### PR DESCRIPTION
## Summary
This PR fixes the XLayer Testnet configuration in the chains registry. The current chainId (195) is incorrect and should be updated to 1952.

## Changes Made
- Updated `chainId` from 195 to 1952
- Updated `networkId` from 195 to 1952  
- Verified RPC endpoint configuration
- Updated chain configuration to match the actual XLayer Testnet deployment

## Verification
The correct chain parameters have been verified through direct RPC calls to the XLayer Testnet:

```bash
# Chain ID verification
curl -X POST -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' \
  https://testrpc.xlayer.tech/terigon
# Result: {"jsonrpc":"2.0","id":1,"result":"0x7a0"} (0x7a0 = 1952)

# Network ID verification  
curl -X POST -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"net_version","params":[],"id":1}' \
  https://testrpc.xlayer.tech/terigon
# Result: {"jsonrpc":"2.0","id":1,"result":"1952"}
```

## Context
As maintainers of the XLayer project, we identified that the current chain configuration does not match our actual testnet deployment. This update ensures that users can properly connect to XLayer Testnet using the correct chain parameters.

## References
- XLayer Official: https://web3.okx.com/zh-hans/xlayer/docs/developer/build-on-xlayer/network-information
- XLayer Testnet Explorer: https://www.oklink.com/x-layer-testnet
- XLayer Testnet RPC: https://testrpc.xlayer.tech/terigon

This change will help developers and users properly connect to XLayer Testnet through wallets and dApps that rely on the ethereum-lists chain registry.