### PR TITLE
Add Taiko Hoodi testnet

### DIFF
--- a/_data/chains/eip155-167012.json
+++ b/_data/chains/eip155-167012.json
@@ -1,0 +1,26 @@
+{
+  "name": "Taiko Hoodi",
+  "chain": "ETH",
+  "status": "active",
+  "icon": "taiko",
+  "rpc": [
+    "https://rpc.hoodi.taiko.xyz"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://taiko.xyz",
+  "shortName": "tko-hoodi",
+  "chainId": 167012,
+  "networkId": 167012,
+  "explorers": [
+    {
+      "name": "Blockscout",
+      "url": "https://blockscout.hoodi.taiko.xyz",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
As Holesky is sunsetting, we are also sunsetting the Taiko Hekla testnet and setting up a Taiko Hoodi testnet in it's place.