### PR TITLE
Add Websocket support to ENI Mainnet

### DIFF
--- a/_data/chains/eip155-173.json
+++ b/_data/chains/eip155-173.json
@@ -1,7 +1,7 @@
 {
   "name": "ENI Mainnet",
   "chain": "ENI",
-  "rpc": ["https://rpc.eniac.network"],
+  "rpc": ["https://rpc.eniac.network", "wss://rpc.eniac.network/ws/"],
   "faucets": [],
   "nativeCurrency": {
     "name": "EGAS",


### PR DESCRIPTION
This PR adds support for the WebSocket RPC URL for the ENI Mainnet.