### PR TITLE
Retire Autonity Piccadilly 04

### DIFF
--- a/_data/chains/eip155-65100004.json
+++ b/_data/chains/eip155-65100004.json
@@ -1,13 +1,8 @@
 {
   "name": "Autonity Piccadilly (Tiber) Testnet",
+  "status": "deprecated",
   "chain": "AUT",
-  "rpc": [
-    "https://autonity.rpc.web3cdn.network/testnet",
-    "wss://autonity.rpc.web3cdn.network/testnet/ws",
-    "https://autonity-piccadilly.rpc.subquery.network/public",
-    "https://piccadilly.autonity-apis.com",
-    "wss://piccadilly-ws.autonity-apis.com"
-  ],
+  "rpc": [],
   "faucets": [],
   "nativeCurrency": {
     "name": "Piccadilly Auton",


### PR DESCRIPTION
This PR retires the Autonity Piccadilly (Tiber) Testnet.

Please merge at the earliest convenience.