### PR TITLE
Add Camp Network Mainnet

### DIFF
--- a/_data/chains/eip155-484.json
+++ b/_data/chains/eip155-484.json
@@ -1,0 +1,22 @@
+{
+  "name": "Camp Network Mainnet",
+  "chain": "CAMP",
+  "rpc": ["https://rpc.camp.raas.gelato.cloud"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Camp",
+    "symbol": "CAMP",
+    "decimals": 18
+  },
+  "infoURL": "https://campnetwork.xyz",
+  "shortName": "Camp",
+  "chainId": 484,
+  "networkId": 484,
+  "explorers": [
+    {
+      "name": "blockscout",
+      "url": "https://camp.cloud.blockscout.com",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds Camp Network Mainnet (Chain ID 484) to the chains registry.

**Chain Details**

- **Chain ID**: 484 (0x1e4)
- **Name**: Camp Network Mainnet
- **Symbol**: CAMP
- **Public RPC Endpoint**: [https://rpc.camp.raas.gelato.cloud](https://rpc.camp.raas.gelato.cloud)
- **Explorer**: [https://camp.cloud.blockscout.com](https://camp.cloud.blockscout.com) 
- **Website**: [https://campnetwork.xyz](https://campnetwork.xyz)