### PR TITLE
Add explorer for Sei

### DIFF
--- a/_data/chains/eip155-1328.json
+++ b/_data/chains/eip155-1328.json
@@ -18,6 +18,11 @@
   "icon": "sei",
   "explorers": [
     {
+      "name": "SeiScan",
+      "url": "https://testnet.seiscan.io",
+      "standard": "EIP3091"
+    },
+    {
       "name": "Seitrace",
       "url": "https://seitrace.com",
       "standard": "EIP3091"

--- a/_data/chains/eip155-1329.json
+++ b/_data/chains/eip155-1329.json
@@ -16,6 +16,11 @@
   "icon": "seiv2",
   "explorers": [
     {
+      "name": "SeiScan",
+      "url": "https://seiscan.io",
+      "standard": "EIP3091"
+    },
+    {
       "name": "Seitrace",
       "url": "https://seitrace.com",
       "standard": "EIP3091"


### PR DESCRIPTION
This PR adds SeiScan as an explorer for Sei and Sei Testnet. 