### PR TITLE
Update Electroneum network name

### DIFF
--- a/_data/chains/eip155-52014.json
+++ b/_data/chains/eip155-52014.json
@@ -1,5 +1,5 @@
 {
-  "name": "Electroneum Mainnet",
+  "name": "Electroneum",
   "chain": "Electroneum",
   "rpc": ["https://rpc.electroneum.com", "https://rpc.ankr.com/electroneum"],
   "faucets": [],


### PR DESCRIPTION
Update Electroneum network name from `Electroneum Mainnet` to `Electroneum`.