### PR TITLE
Deprecate old Memento Testnet

### DIFF
--- a/_data/chains/eip155-12052024.json
+++ b/_data/chains/eip155-12052024.json
@@ -1,8 +1,9 @@
 {
-  "name": "Memento Testnet",
+  "name": "Memento Testnet (deprecated)",
   "chain": "Memento",
-  "rpc": ["https://test-rpc.mementoblockchain.com/IRkghvI3FfEArEJMr4zC/rpc"],
+  "rpc": [],
   "faucets": [],
+  "status": "deprecated",
   "nativeCurrency": {
     "name": "Ether",
     "symbol": "ETH",
@@ -12,11 +13,5 @@
   "shortName": "memento-test",
   "chainId": 12052024,
   "networkId": 12052024,
-  "explorers": [
-    {
-      "name": "Tracehawk",
-      "url": "https://test-explorer.mementoblockchain.com",
-      "standard": "none"
-    }
-  ]
+  "explorers": []
 }


### PR DESCRIPTION
With Memento Testnet now being added to the ZKsync ecosystem has deprecated this old testnet which was running outside the ecosystem.