### PR TITLE
Add chain.love

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ npx prettier --write _data/*/*.json
  * [networks.vercel.app](https://networks.vercel.app)
  * [Wagmi compatible chain configurations](https://spenhouet.com/chains)
  * [chainlist.simplr.sh - Info packaged single pager](https://chainlist.simplr.sh)
+ * [Chain.Love - Web3 services discovery](https://chain.love)
 
 ### Other
  * [FaucETH](https://github.com/komputing/FaucETH)


### PR DESCRIPTION
Chain.Love is a one-stop hub to discover, compare, and access Web3 services seamlessly. We provide curated Web3 services lists  where developers can discover all available solutions on particular network and compare service providers side-by-side.

Chain.Love’s mission is to make blockchain services accessible, transparent, and reliable. We empower ecosystems to grow faster by reducing fragmentation, increasing trust, and enabling fair competition among providers.

@ligi we've tried to contact you for listing purposes, but didn't succeed.