### PR TITLE
Update mainnet RPC URLs for Mezo (31612)

### DIFF
--- a/_data/chains/eip155-31612.json
+++ b/_data/chains/eip155-31612.json
@@ -4,8 +4,8 @@
   "rpc": [
     "https://rpc_evm-mezo.imperator.co",
     "wss://ws_evm-mezo.imperator.co",
-    "https://jsonrpc-mezo.boar.network",
-    "wss://jsonrpcws-mezo.boar.network",
+    "https://rpc-http.mezo.boar.network",
+    "wss://rpc-ws.mezo.boar.network",
     "https://mainnet.mezo.public.validationcloud.io",
     "wss://mainnet.mezo.public.validationcloud.io",
     "https://rpc-internal.mezo.org",


### PR DESCRIPTION
RPC URLs from Boar Network have been changed. This PR update them.