### PR TITLE
Add Nanch Network (chainId 24258392)

### DIFF
--- a/_data/chains/24258392.json
+++ b/_data/chains/24258392.json
@@ -1,0 +1,23 @@
+{
+  "name": "Nanch Network",
+  "chain": "NANCH",
+  "rpc": ["https://rpc.nanch.network"],
+  "faucets": ["https://faucets.nanch.network"],
+  "nativeCurrency": {
+    "name": "Nanch",
+    "symbol": "NACH",
+    "decimals": 18
+  },
+  "infoURL": "https://nanch.network",
+  "shortName": "nanch",
+  "chainId": 24258392,
+  "networkId": 24258392,
+  "icon": "nanch",
+  "explorers": [
+    {
+      "name": "NanchScan",
+      "url": "https://nanchscan.com",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Added new EVM chain "Nanch Network"
RPC: https://rpc.nanch.network
Explorer: https://nanchscan.com
Token: NACH
