### PR TITLE
New Shib RPC endpoint to the following chain configuration files

### DIFF
--- a/_data/chains/eip155-109.json
+++ b/_data/chains/eip155-109.json
@@ -5,6 +5,8 @@
   "rpc": [
     "https://rpc.shibarium.shib.io",
     "https://shibarium.drpc.org",
+    "https://www.shibrpc.com",
+    "https://rpc.shibrpc.com",
     "https://shib.nownodes.io"
   ],
   "faucets": [],

--- a/_data/chains/eip155-157.json
+++ b/_data/chains/eip155-157.json
@@ -2,7 +2,10 @@
   "name": "Puppynet",
   "chain": "Puppynet",
   "icon": "shibarium",
-  "rpc": ["https://rpc.puppynet.shib.io"],
+  "rpc": [
+    "https://rpc.puppynet.shib.io",
+    "https://puppynet.shibrpc.com"
+  ],
   "faucets": ["https://shibarium.shib.io/faucet"],
   "nativeCurrency": {
     "name": "BONE",


### PR DESCRIPTION
This pull request adds the new Shib RPC endpoint to the following chain configuration files:

* `_data/chains/eip155-109.json`
* `_data/chains/eip155-157.json`

#### **Changes Included**

* Added the new Shib RPC URL to both chain files.
* Updated the RPC list to ensure users receive the new RPC endpoint when interacting with these networks.