### PR TITLE
Add Kalichain configuration file

### DIFF
--- a/_data/chains/eip155-6533.json
+++ b/_data/chains/eip155-6533.json
@@ -1,0 +1,34 @@
+{
+  "name": "Kalichain",
+  "chain": "Kalichain",
+  "rpc": [
+    "https://subnets.avax.network/kalichain/mainnet/rpc"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Kalis",
+    "symbol": "KALIS",
+    "decimals": 18
+  },
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
+    }
+  ],
+  "infoURL": "https://kalichain.com",
+  "shortName": "kalis",
+  "chainId": 6533,
+  "networkId": 6533,
+  "icon": "kalichain",
+  "explorers": [
+    {
+      "name": "Kalichain Explorer",
+      "url": "https://scan.kalichain.com",
+      "icon": "kalichain",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Migrating Kalichain to new ChainID 6533 (Avalanche Subnet).

- Added eip155-6533.json
- Deleted eip155-654.json (Deprecated)
- Reusing existing icon "kalichain"