### PR TITLE
update on edeXa Testnet

### DIFF
--- a/_data/chains/eip155-1995.json
+++ b/_data/chains/eip155-1995.json
@@ -1,8 +1,8 @@
 {
   "name": "edeXa Testnet",
   "chain": "edeXa",
-  "rpc": ["https://rpc.testnet.edexa.network", "https://rpc.testnet.edexa.com"],
-  "faucets": ["https://faucet.edexa.com/"],
+  "rpc": [],
+  "faucets": [],
   "nativeCurrency": {
     "name": "edeXa",
     "symbol": "tEDX",
@@ -14,11 +14,5 @@
   "networkId": 1995,
   "slip44": 1,
   "icon": "edexa",
-  "explorers": [
-    {
-      "name": "edexa-testnet-explorer",
-      "url": "https://explorer.testnet.edexa.network",
-      "standard": "EIP3091"
-    }
-  ]
+  "explorers": []
 }


### PR DESCRIPTION
We’re restructuring parts of the network infrastructure, including new RPC endpoints and a refreshed testnet architecture. To avoid pointing developers to an unstable environment, we’ve temporarily removed it from Chainlist. The new testnet will be re-added once validation and monitoring are complete.