### PR TITLE
Add Aeru Network (chainId: 192)

### DIFF
--- a/_data/chains/eip155-192.json
+++ b/_data/chains/eip155-192.json
@@ -1,0 +1,24 @@
+{
+  "name": "Aeru",
+  "chain": "ARU",
+  "icon": "aru",
+  "rpc": ["https://rpc.aruscan.com", "wss://wss.aruscan.com"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Aeru",
+    "symbol": "ARU",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://atheru.org/",
+  "shortName": "aru",
+  "chainId": 192,
+  "networkId": 192,
+  "explorers": [
+    {
+      "name": "aruscan",
+      "url": "https://aruscan.com",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/icons/aru.json
+++ b/_data/icons/aru.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreihwgtuhhd7twd73f4lw42vlz5la47s5t5maotlvf5b26xxlmmbq7m",
+    "width": 4501,
+    "height": 4501,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
- Add chain definition for Aeru (ARU) network
- Add Aeru icon with IPFS CID
- RPC endpoints: https://rpc.aruscan.com, wss://wss.aruscan.com
- Explorer: https://aruscan.com