### PR TITLE
Add Brevis ProverNet [Chain ID: 9973]

### DIFF
--- a/_data/chains/eip155-9973.json
+++ b/_data/chains/eip155-9973.json
@@ -1,0 +1,29 @@
+{
+  "name": "Brevis ProverNet",
+  "chain": "BREV",
+  "rpc": [
+    "https://evmrpc.brevis.network/"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://brevis.network",
+  "shortName": "brev",
+  "chainId": 9973,
+  "networkId": 9973,
+  "explorers": [
+    {
+    "name": "Breivs ProverNet Explorer",
+    "url": "https://provernet.brevis.network/",
+    "icon": "blockscout",
+    "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-1"
+  }
+}


### PR DESCRIPTION
Brevis Prover Network
Chain ID: 9973
https://brevis.network/