### PR TITLE
Add Ault Blockchain mainnet and testnet

### DIFF
--- a/_data/chains/eip155-10904.json
+++ b/_data/chains/eip155-10904.json
@@ -1,0 +1,18 @@
+{
+  "name": "Ault Blockchain Testnet",
+  "chain": "AULT",
+  "icon": "ault",
+  "rpc": [],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Testnet AULT Token",
+    "symbol": "AULT",
+    "decimals": 18
+  },
+  "infoURL": "https://aultblockchain.com",
+  "shortName": "ault-testnet",
+  "chainId": 10904,
+  "networkId": 10904,
+  "explorers": []
+}

--- a/_data/chains/eip155-904.json
+++ b/_data/chains/eip155-904.json
@@ -1,0 +1,18 @@
+{
+  "name": "Ault Blockchain Mainnet",
+  "chain": "AULT",
+  "icon": "ault",
+  "rpc": [],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "AULT Token",
+    "symbol": "AULT",
+    "decimals": 18
+  },
+  "infoURL": "https://aultblockchain.com",
+  "shortName": "ault",
+  "chainId": 904,
+  "networkId": 904,
+  "explorers": []
+}

--- a/_data/icons/ault.json
+++ b/_data/icons/ault.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmR65pFw3pgcCDeZJ5SHiXPKPjKyLEZZez2cEQZNssR2zd",
+    "width": 32,
+    "height": 32,
+    "format": "svg"
+  }
+]


### PR DESCRIPTION
This PR adds Ault Blockchain mainnet and testnet to ethereum-lists.

Chain IDs for Ault Blockchain:
- Mainnet: 904
- Testnet: 10904

Currently, RPC endpoints, explorers, and faucet information are left empty as they are TBD and will be added once officially available.
