### PR TITLE
Add LXP Network Support ( ChainID : 1122 )

### DIFF
--- a/_data/chains/eip155-1122.json
+++ b/_data/chains/eip155-1122.json
@@ -1,0 +1,29 @@
+{
+  "name": "LuxePorts",
+  "chain": "LXP",
+  "rpc": [
+    "https://rpc.luxeports.com",
+    "https://erpc.luxeports.com",
+    "wss://rpc.luxeports.com/ws",
+    "wss://erpc.luxeports.com/ws"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "LuxePorts",
+    "symbol": "LXP",
+    "decimals": 18
+  },
+  "infoURL": "luxeports.com",
+  "shortName": "lxp",
+  "chainId": 1122,
+  "networkId": 1122,
+  "icon": "lxp",
+  "explorers": [
+    {
+      "name": "lxpscan",
+      "url": "https://lxpscan.com",
+      "icon": "lxpscan",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/icons/lxp.json
+++ b/_data/icons/lxp.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmZRg6LmyU4jJie3VPd7xacBf6qwkbsnHDgCgRkr7iwgKP",
+    "width": 1450,
+    "height": 1450,
+    "format": "png"
+  }
+]

--- a/_data/icons/lxpscan.json
+++ b/_data/icons/lxpscan.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmZRg6LmyU4jJie3VPd7xacBf6qwkbsnHDgCgRkr7iwgKP",
+    "width": 1450,
+    "height": 1450,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Hi Ethereum Lists Team,

We’ve added support for the LXP Network in this PR. This includes all necessary configuration and metadata to integrate LXP seamlessly into the chains list.

We believe adding LXP will benefit the ecosystem by improving interoperability and visibility for users of this network.

We’d really appreciate it if you could review and consider merging this PR. Happy to make any adjustments if needed!

Thanks for your time and consideration.

— LXP Team