### PR TITLE
Fix missing explorer metadata for BSC

### DIFF
--- a/137
+++ b/137
@@ -1,0 +1,7 @@
+"explorers": [
+  {
+    "name": "BscScan",
+    "url": "https://bscscan.com",
+    "standard": "EIP3091"
+  }
+]


### PR DESCRIPTION
This PR adds missing explorer metadata for the BSC chain.
No breaking changes.