### PR TITLE
feat(chain): Add Nebula (Chain ID: 73285)

### DIFF
--- a/_data/chains/eip155-73285.json
+++ b/_data/chains/eip155-73285.json
@@ -1,0 +1,23 @@
+{
+  "name": "Nebula",
+  "chain": "NEBULA",
+  "icon": "nebula",
+  "rpc": ["https://nebula-chain.com/rpc"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Nebula Cash",
+    "symbol": "NEBX",
+    "decimals": 18
+  },
+  "infoURL": "https://nebula-chain.com",
+  "shortName": "nebula",
+  "chainId": 73285,
+  "networkId": 73285,
+  "explorers": [
+    {
+      "name": "Nebula Explorer",
+      "url": "https://nebxscan.nebula-chain.com",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds the Nebula blockchain (v2) to the Ethereum-based chains list.

**Overview:**  
Nebula is a next-generation, public, and permissionless EVM-compatible blockchain built for autonomous agents and AI-driven economies. Powered by Proof-of-Work (PoW), it ensures decentralization, computational fairness, and full Solidity support. Its native token, Nebula Cash (NEBX), is mined and used for transactions, smart contracts, and governance.

**Nebula enables artificial intelligences to:**  
- Deploy and manage smart contracts  
- Transact data, services, and digital assets  
- Perform autonomous financial operations  
- Secure the network through mining

**Key Technical Specs:**  
- Consensus: Proof-of-Work (Ethash)  
- Block time: 10 seconds  
- Gas limit: 10 million  
- Chain ID: 73285  
- Token: NEBX (mined only)

**Endpoints:**  
- RPC: https://nebula-chain.com/rpc  
- Explorer: https://nebxscan.nebula-chain.com  

All endpoints are operational and synced with the mainnet.

**Compatibility:**  
Fully EVM-compatible; works seamlessly with Metamask, Remix, Hardhat, and other Ethereum tooling.

**Additional Info:**  
The Nebula mainnet is live and stable. Bridges, exchanges, and liquidity infrastructure are being expanded.

This PR replaces the previous stale PR (#7491). JSON is validated, Prettier formatted, and CI checks are passing.

Closes #7491
