### PR TITLE
Add DogeOS Chikyū Testnet

### DIFF
--- a/_data/chains/eip155-6281971.json
+++ b/_data/chains/eip155-6281971.json
@@ -2,7 +2,7 @@
   "name": "DogeOS Chikyū Testnet",
   "chain": "DOGEOS",
   "rpc": ["https://rpc.testnet.dogeos.com"],
-  "faucets": [],
+  "faucets": ["https://faucet.testnet.dogeos.com/"],
   "nativeCurrency": {
     "name": "DOGE",
     "symbol": "DOGE",


### PR DESCRIPTION
## Summary
- add DogeOS Chikyū Testnet chain metadata
- add DogeOS testnet faucet

## Chain Details
| Field | Value |
| --- | --- |
| Chain ID | 6281971 |
| Name | DogeOS Chikyū Testnet |
| Native currency | DOGE (18) |
| RPC | https://rpc.testnet.dogeos.com |
| Explorer | https://blockscout.testnet.dogeos.com |
| Faucet | https://faucet.testnet.dogeos.com/ |
| Info URL | https://dogeos.com |
| Short name | dogeos-chikyu |