### PR TITLE
Add Tempo Moderato (42431) and deprecate Andantino (42429) testnets

### DIFF
--- a/_data/chains/eip155-42429.json
+++ b/_data/chains/eip155-42429.json
@@ -1,5 +1,5 @@
 {
-  "name": "Tempo Testnet (Deprecated)",
+  "name": "Tempo Testnet Andantino (Deprecated)",
   "chain": "ETH",
   "rpc": ["https://rpc.testnet.tempo.xyz"],
   "faucets": [],
@@ -9,7 +9,7 @@
     "decimals": 6
   },
   "infoURL": "https://tempo.xyz",
-  "shortName": "andantino",
+  "shortName": "tempo-andantino",
   "chainId": 42429,
   "networkId": 42429,
   "icon": "tempo",

--- a/_data/chains/eip155-42431.json
+++ b/_data/chains/eip155-42431.json
@@ -1,5 +1,5 @@
 {
-  "name": "Tempo Testnet",
+  "name": "Tempo Testnet Moderato",
   "chain": "ETH",
   "rpc": ["https://rpc.moderato.tempo.xyz", "wss://rpc.moderato.tempo.xyz"],
   "faucets": [],
@@ -9,7 +9,7 @@
     "decimals": 6
   },
   "infoURL": "https://tempo.xyz",
-  "shortName": "moderato",
+  "shortName": "tempo-moderato",
   "chainId": 42431,
   "networkId": 42431,
   "icon": "tempo",


### PR DESCRIPTION
## Summary

This PR adds the new Tempo Moderato testnet and marks the old Andantino testnet as deprecated.

### Changes

**New chain: eip155-42431 (Tempo Moderato)**
- Chain ID: 42431
- RPC: `https://rpc.moderato.tempo.xyz`
- WebSocket: `wss://rpc.moderato.tempo.xyz`
- Explorer: https://explore.tempo.xyz
- Short name: `tempo-moderato`

**Updated chain: eip155-42429 (Tempo Andantino)**
- Added `status: deprecated`
- Updated name to "Tempo Testnet (Deprecated)"
- Updated explorer to legacy URL: https://explore.andantino.tempo.xyz
- Short name: `tempo-andantino`

### Context

Tempo launched a new testnet (Moderato) on January 8th, 2025 to replace the original Andantino testnet, which is being deprecated on March 8th, 2025.

See: https://docs.tempo.xyz/#testnet-migration

### Checklist

- [x] `./gradlew run` passes
- [x] Prettier formatting applied
- [x] Chain IDs are unique
- [x] Short names are unique