### PR TITLE
Add POC  Testnet

### DIFF
--- a/_data/chains/eip155-484848.json
+++ b/_data/chains/eip155-484848.json
@@ -1,12 +1,8 @@
 {
   "name": "POC Testnet",
   "chain": "POC",
-  "rpc": [
-    "https://testnet-rpc.pochain.io"
-  ],
-  "faucets": [
-    "https://www.pochain.io/poc-faucet-testnet"
-  ],
+  "rpc": ["https://testnet-rpc.pochain.io"],
+  "faucets": ["https://www.pochain.io/poc-faucet-testnet"],
   "nativeCurrency": {
     "name": "POC Native Token",
     "symbol": "POC",

--- a/_data/icons/pochain.json
+++ b/_data/icons/pochain.json
@@ -1,6 +1,7 @@
 [
   {
-    "url": "ipfs://bafkreigxoer3jdv5hysomlo4lbpk4gibcmbhuwj4hkmbqcwiuxa26qy4je""width": 32,
+    "url": "ipfs://bafkreigxoer3jdv5hysomlo4lbpk4gibcmbhuwj4hkmbqcwiuxa26qy4je",
+    "width": 32,
     "height": 32,
     "format": "png"
   }


### PR DESCRIPTION
Added chain configurations for  POC Testnet (484848).

RPC endpoints are live and HTTPS enabled.

Explorer is running.

Icons are attached.

CI tests passed locally.