### PR TITLE
fix: update Tempo native currency decimals to 18 for EIP-3085 compatibility

### DIFF
--- a/_data/chains/eip155-42429.json
+++ b/_data/chains/eip155-42429.json
@@ -6,7 +6,7 @@
   "nativeCurrency": {
     "name": "No native currency",
     "symbol": "USD",
-    "decimals": 6
+    "decimals": 18
   },
   "infoURL": "https://tempo.xyz",
   "shortName": "tempo-andantino",

--- a/_data/chains/eip155-42431.json
+++ b/_data/chains/eip155-42431.json
@@ -6,7 +6,7 @@
   "nativeCurrency": {
     "name": "No native currency",
     "symbol": "USD",
-    "decimals": 6
+    "decimals": 18
   },
   "infoURL": "https://tempo.xyz",
   "shortName": "tempo-moderato",


### PR DESCRIPTION
## Summary

Updates Tempo chain configurations to use 18 decimals for native currency instead of 6.

## Changes

- `eip155-42429.json` (Tempo Testnet Andantino): decimals 6 → 18
- `eip155-42431.json` (Tempo Testnet Moderato): decimals 6 → 18

## Reason

MetaMask's EIP-3085 implementation [requires `nativeCurrency.decimals` to be exactly 18](https://github.com/MetaMask/metamask-extension/blob/main/app/scripts/lib/rpc-method-middleware/handlers/ethereum-chain-utils.js#L130). Using 6 decimals causes `wallet_addEthereumChain` requests to fail with an error.

This supersedes PR #8015 which originally added these chains with 6 decimals.