### PR TITLE
Add Datachain Rope icon (Chain ID: 271828)

### DIFF
--- a/_data/icons/datachain.json
+++ b/_data/icons/datachain.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreiharclrqazm62svqlm4sxm4pv6nrw543mnjyv4qchtr7225iftdfq",
+    "width": 1563,
+    "height": 1563,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
## Summary

This PR adds the icon for **Datachain Rope** (Chain ID: 271828).

### Icon Details

| Property | Value |
|----------|-------|
| Chain ID | 271828 |
| Format | PNG |
| Dimensions | 1563x1563 |
| IPFS CID | `bafkreiharclrqazm62svqlm4sxm4pv6nrw543mnjyv4qchtr7225iftdfq` |

### IPFS Verification

The icon is accessible via IPFS:
- `ipfs://bafkreiharclrqazm62svqlm4sxm4pv6nrw543mnjyv4qchtr7225iftdfq`
- Gateway: https://bafkreiharclrqazm62svqlm4sxm4pv6nrw543mnjyv4qchtr7225iftdfq.ipfs.dweb.link/

### Related

This icon is referenced by the chain definition in ChainList:
- ChainList PR: https://github.com/DefiLlama/chainlist/pull/2449

### Website

https://datachain.network

Made with [Cursor](https://cursor.com)