### PR TITLE
Update nativeCurrency of Stable Mainnet

### DIFF
--- a/_data/chains/eip155-988.json
+++ b/_data/chains/eip155-988.json
@@ -5,8 +5,8 @@
   "faucets": [],
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "nativeCurrency": {
-    "name": "gUSDT",
-    "symbol": "gUSDT",
+    "name": "USDT0",
+    "symbol": "USDT0",
     "decimals": 18
   },
   "infoURL": "https://stable.xyz",


### PR DESCRIPTION
With Stable v1.2.0 upgrade on Stable Mainnet, the native currency has changed to USDT0 from gUSDT.

Ref: https://docs.stable.xyz/en/developers/mainnet/mainnet-information