### PR TITLE
Add AMA Mainnet (36969) and Testnet (36968)

### DIFF
--- a/_data/chains/eip155-36968.json
+++ b/_data/chains/eip155-36968.json
@@ -1,0 +1,29 @@
+{
+  "name": "AMA Testnet",
+  "chain": "AMA",
+  "rpc": ["https://testnet-rpc.ama.one"],
+  "faucets": ["https://mcp.ama.one/testnet-faucet"],
+  "nativeCurrency": {
+    "name": "AMA",
+    "symbol": "AMA",
+    "decimals": 9
+  },
+  "infoURL": "https://ama.one",
+  "shortName": "AMA-TESTNET",
+  "chainId": 36968,
+  "networkId": 36968,
+  "slip44": 1,
+  "status": "incubating",
+  "explorers": [
+    {
+      "name": "AMA Explorer Testnet",
+      "url": "https://testnet-ama.ddns.net",
+      "standard": "none"
+    },
+    {
+      "name": "AMA Explorer Testnet Alt",
+      "url": "https://testnet.explorer.ama.one",
+      "standard": "none"
+    }
+  ]
+}

--- a/_data/chains/eip155-36969.json
+++ b/_data/chains/eip155-36969.json
@@ -1,0 +1,29 @@
+{
+  "name": "AMA Mainnet",
+  "chain": "AMA",
+  "rpc": ["https://mainnet-rpc.ama.one"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "AMA",
+    "symbol": "AMA",
+    "decimals": 9
+  },
+  "infoURL": "https://ama.one",
+  "shortName": "AMA",
+  "chainId": 36969,
+  "networkId": 36969,
+  "slip44": 36969,
+  "status": "active",
+  "explorers": [
+    {
+      "name": "AMA Explorer Mainnet",
+      "url": "https://ama-explorer.ddns.net",
+      "standard": "none"
+    },
+    {
+      "name": "AMA Explorer Mainnet Alt",
+      "url": "https://explorer.ama.one",
+      "standard": "none"
+    }
+  ]
+}


### PR DESCRIPTION
Adding chain definitions for AMA Mainnet and AMA Testnet.

**Network Info:**
* **Mainnet:** ChainID 36969
* **Testnet:** ChainID 36968
* **Website:** https://ama.one

**Checks:**
* [x] RPC endpoints are public and accessible.
* [x] Chain IDs do not collide with existing entries.
* [x] Symbols and decimals are correct.
* [x] Explorers are active.

Thank you!