### PR TITLE
Add Access Network (chainId: 22888)

### DIFF
--- a/_data/chains/eip155-22888.json
+++ b/_data/chains/eip155-22888.json
@@ -1,0 +1,25 @@
+{
+  "name": "Access Network",
+  "chain": "ACCESS",
+  "icon": "access",
+  "chainId": 22888,
+  "shortName": "access",
+  "networkId": 22888,
+  "nativeCurrency": {
+    "name": "Access Coin",
+    "symbol": "ACCESS",
+    "decimals": 18
+  },
+  "rpc": ["https://accesschain.org/rpc"],
+  "faucets": [],
+  "infoURL": "https://accesschain.org",
+  "explorers": [
+    {
+      "name": "Access Network Explorer",
+      "url": "https://accesschain.org/explorer",
+      "standard": "EIP3091",
+      "icon": "access"
+    }
+  ],
+  "status": "active"
+}

--- a/_data/icons/access.json
+++ b/_data/icons/access.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreifwuwf43ceqgb6hoavb4igpea5txc26dafm4pmuykdvrer5z6ess4",
+    "width": 1024,
+    "height": 1024,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Add Access Network mainnet chain.

- Chain ID: 22888
- RPC: https://accesschain.org/rpc (returns 0x5968 ✓)
- Explorer: https://accesschain.org/explorer (EIP-3091 compliant ✓)
- Currency: ACCESS
- Files: `_data/chains/eip155-22888.json`, `_data/icons/access.json`