### PR TITLE
Add Arxon chain (chainId 7171)

### DIFF
--- a/_data/eip155-7171.json
+++ b/_data/eip155-7171.json
@@ -1,0 +1,18 @@
+{
+  "name": "Arxon",
+  "chain": "ARX",
+  "rpc": [
+    "https://testnet.arxon.io:9944"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "ARX",
+    "symbol": "ARX",
+    "decimals": 18
+  },
+  "infoURL": "https://arxon.io",
+  "shortName": "arx",
+  "chainId": 7171,
+  "networkId": 7171,
+  "explorers": []
+}


### PR DESCRIPTION
Adding Arxon — a sovereign Layer-1 blockchain with selective privacy and EVM compatibility.

- Chain ID: 7171
- Token: ARX
- Website: https://arxon.io
- GitHub: https://github.com/Arxonchain/arxon-node