### PR TITLE
Add Kairos Network (chainId: 7778)

### DIFF
--- a/_data/chains/eip155-7778.json
+++ b/_data/chains/eip155-7778.json
@@ -1,29 +1,36 @@
 {
-  "name": "Orenium Mainnet Protocol",
-  "chain": "ORE",
+  "name": "Kairos Network",
+  "chain": "KAIROS",
+  "icon": "kairos",
   "rpc": [
-    "https://validator-mainnet.orenium.org",
-    "https://rpc-oracle-mainnet.orenium.org",
-    "https://portalmainnet.orenium.org"
+    "https://rpc.kairos777.com"
+  ],
+  "faucets": [
+    "https://faucet.kairos777.com"
   ],
   "nativeCurrency": {
-    "name": "ORENIUM",
-    "symbol": "ORE",
+    "name": "KAIROS",
+    "symbol": "KAIROS",
     "decimals": 18
   },
-  "infoURL": "https://orenium.org",
-  "shortName": "ore",
+  "infoURL": "https://kairos777.com",
+  "shortName": "kairos",
   "chainId": 7778,
   "networkId": 7778,
-  "slip44": 1,
-  "icon": "ore",
-  "faucets": [],
+  "slip44": 7778,
   "explorers": [
     {
-      "name": "ORE Mainnet Explorer",
-      "icon": "ore",
-      "url": "https://oreniumscan.org",
-      "standard": "none"
+      "name": "Kairos Explorer",
+      "url": "https://scan.kairos777.com",
+      "standard": "EIP3091"
+    }
+  ],
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
     }
   ]
 }

--- a/_data/icons/kairos.json
+++ b/_data/icons/kairos.json
@@ -1,8 +1,9 @@
 [
   {
-    "url": "ipfs://QmPlaceholder",
+    "url": "ipfs://QmUQF8AENSaAPFw63hQ64qAYsYPzM2SwZK6j949RY1T6wK",
     "width": 256,
     "height": 256,
     "format": "png"
   }
 ]
+

--- a/_data/icons/kairos.json
+++ b/_data/icons/kairos.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmPlaceholder",
+    "width": 256,
+    "height": 256,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
## Add Kairos Network (chainId: 7778)

### Chain Details
| Field | Value |
|-------|-------|
| **Name** | Kairos Network |
| **Chain ID** | 7778 |
| **Currency** | KAIROS (18 decimals) |
| **Consensus** | KairosBFT (BFT-based, 21 validators) |
| **Block Time** | ~400ms |
| **Finality** | Instant |
| **TPS** | 10,000+ |
| **EVM Compatible** | Yes (EIP-155, EIP-1559) |

### Endpoints
- **RPC**: https://rpc.kairos777.com
- **Explorer**: https://scan.kairos777.com (EIP-3091 compliant)
- **Website**: https://kairos777.com
- **Faucet**: https://faucet.kairos777.com

### Cross-Chain
Connected to 5 chains via **KIP (Kairos Interoperability Protocol)**:
BSC, Ethereum, Polygon, Arbitrum, Base

### Verification
- Chain is live and producing blocks
- RPC endpoint returns valid responses
- Explorer is operational with EIP-3091 standard
- Native DEX (KairosSwap) with active liquidity pools

### Organization
**Kairos 777 Inc.** — https://kairos777.com