### PR TITLE
Add QVTX DNA Mainnet (20232) and QVTX DNA Expression (42000)

### DIFF
--- a/_data/chains/eip155-20232.json
+++ b/_data/chains/eip155-20232.json
@@ -1,10 +1,10 @@
 {
-    "name": "QVTX DNA Expression",
+    "name": "QVTX DNA Mainnet",
     "chain": "QVTX",
     "rpc": [
-        "https://rpc.qvtx.io:8555",
-        "http://203.161.33.24:8555",
-        "http://162.0.222.112:8555"
+        "https://rpc.qvtx.io",
+        "http://104.207.66.161:8545",
+        "http://159.198.47.12:8545"
     ],
     "features": [
         {
@@ -18,9 +18,9 @@
         "decimals": 18
     },
     "infoURL": "https://qvtx.io",
-    "shortName": "qvtx-dna",
-    "chainId": 42000,
-    "networkId": 42000,
+    "shortName": "qvtx",
+    "chainId": 20232,
+    "networkId": 20232,
     "explorers": [
         {
             "name": "QVTX Explorer",


### PR DESCRIPTION
## Summary
- Add Chain 20232 (QVTX DNA Mainnet) — Clique PoA, live with 3 validator nodes
- Add Chain 42000 (QVTX DNA Expression) — DNA computation and storage chain

## Chain Details

### Chain 20232 — QVTX DNA Mainnet
- **Chain ID:** 20232 (0x4f08)
- **Network ID:** 20232
- **RPC:** https://rpc.qvtx.io
- **Explorer:** https://explorer.qvtx.io
- **Native Currency:** QVTX (18 decimals)
- **Consensus:** Clique PoA
- **Status:** Live, producing blocks

### Chain 42000 — QVTX DNA Expression
- **Chain ID:** 42000 (0xa410)
- **Network ID:** 42000
- **RPC:** http://203.161.33.24:8555
- **Explorer:** https://explorer.qvtx.io
- **Native Currency:** QVTX (18 decimals)
- **Status:** Live, 188K+ blocks

## Organization
- **Company:** Quantvestrix Inc.
- **Website:** https://qvtx.io
- **GitHub:** https://github.com/Quantvestrix-Official