### PR TITLE
Add LiterMark Chain (chainId: 5232)

### DIFF
--- a/_data/chains/eip155-5232.json
+++ b/_data/chains/eip155-5232.json
@@ -1,9 +1,7 @@
 {
   "name": "LiterMark Chain",
   "chain": "LMK",
-  "rpc": [
-    "https://litermark.org/rpc"
-  ],
+  "rpc": ["https://litermark.org/rpc"],
   "faucets": [],
   "nativeCurrency": {
     "name": "LiterMark",
@@ -14,12 +12,10 @@
   "shortName": "lmk",
   "chainId": 5232,
   "networkId": 5232,
-  "icon": "litermark",
   "explorers": [
     {
       "name": "LMKscan",
       "url": "https://litermark.org",
-      "icon": "litermark",
       "standard": "none"
     }
   ]

--- a/_data/chains/eip155-5232.json
+++ b/_data/chains/eip155-5232.json
@@ -8,10 +8,17 @@
     "symbol": "LMK",
     "decimals": 18
   },
+  "features": [
+    {
+      "name": "EIP155"
+    }
+  ],
   "infoURL": "https://litermark.com",
   "shortName": "lmk",
   "chainId": 5232,
   "networkId": 5232,
+  "slip44": 60,
+  "status": "active",
   "explorers": [
     {
       "name": "LMKscan",

--- a/_data/chains/eip155-5232.json
+++ b/_data/chains/eip155-5232.json
@@ -1,0 +1,26 @@
+{
+  "name": "LiterMark Chain",
+  "chain": "LMK",
+  "rpc": [
+    "https://litermark.org/rpc"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "LiterMark",
+    "symbol": "LMK",
+    "decimals": 18
+  },
+  "infoURL": "https://litermark.com",
+  "shortName": "lmk",
+  "chainId": 5232,
+  "networkId": 5232,
+  "icon": "litermark",
+  "explorers": [
+    {
+      "name": "LMKscan",
+      "url": "https://litermark.org",
+      "icon": "litermark",
+      "standard": "none"
+    }
+  ]
+}

--- a/_data/chains/eip155-5232.json
+++ b/_data/chains/eip155-5232.json
@@ -1,18 +1,15 @@
 {
   "name": "LiterMark Chain",
   "chain": "LMK",
+  "icon": "litermark",
   "rpc": ["https://litermark.org/rpc"],
+  "features": [{ "name": "EIP155" }],
   "faucets": [],
   "nativeCurrency": {
     "name": "LiterMark",
     "symbol": "LMK",
     "decimals": 18
   },
-  "features": [
-    {
-      "name": "EIP155"
-    }
-  ],
   "infoURL": "https://litermark.com",
   "shortName": "lmk",
   "chainId": 5232,

--- a/_data/icons/litermark.json
+++ b/_data/icons/litermark.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "ipfs://QmPLACEHOLDER",
+    "url": "ipfs://QmRscdcy6ebGXxZQeHsvEhFNmazgR7SuUDZd8NSYRaD5ux",
     "width": 256,
     "height": 256,
     "format": "png"

--- a/_data/icons/litermark.json
+++ b/_data/icons/litermark.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmPLACEHOLDER",
+    "width": 256,
+    "height": 256,
+    "format": "png"
+  }
+]

--- a/_data/icons/litermark.json
+++ b/_data/icons/litermark.json
@@ -1,8 +1,8 @@
 [
   {
     "url": "ipfs://QmRscdcy6ebGXxZQeHsvEhFNmazgR7SuUDZd8NSYRaD5ux",
-    "width": 256,
-    "height": 256,
+    "width": 1258,
+    "height": 1259,
     "format": "png"
   }
 ]


### PR DESCRIPTION
Add LiterMark Chain - a digital content authentication blockchain.

- Chain ID: 5232
- Native Currency: LMK
- Block Time: 5 seconds
- Consensus: DPoS (Clique PoA)
- Explorer: https://litermark.org
- Website: https://litermark.com