### PR TITLE
feat: add NetX Mainnet (287) and NetX Testnet (587)

### DIFF
--- a/_data/chains/eip155-287.json
+++ b/_data/chains/eip155-287.json
@@ -1,0 +1,22 @@
+{
+  "name": "NetX Mainnet",
+  "chain": "NETX",
+  "rpc": ["https://rpc.tsccan.io"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "NETX",
+    "symbol": "NETX",
+    "decimals": 18
+  },
+  "infoURL": "https://tscscan.io",
+  "shortName": "netx",
+  "chainId": 287,
+  "networkId": 287,
+  "explorers": [
+    {
+      "name": "NetX Explorer",
+      "url": "https://tscscan.io",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-587.json
+++ b/_data/chains/eip155-587.json
@@ -1,0 +1,22 @@
+{
+  "name": "NetX Testnet",
+  "chain": "NETX",
+  "rpc": ["https://test-rpc.tsccan.io"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "NETX",
+    "symbol": "NETX",
+    "decimals": 18
+  },
+  "infoURL": "https://test.tscscan.io",
+  "shortName": "netx-testnet",
+  "chainId": 587,
+  "networkId": 587,
+  "explorers": [
+    {
+      "name": "NetX Testnet Explorer",
+      "url": "https://test.tscscan.io",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add chain definitions for the NetX network:

- **NetX Mainnet** — Chain ID `287`
  - RPC: `https://rpc.tsccan.io`
  - Explorer: `https://tscscan.io`
  - Native Currency: NETX (18 decimals)

- **NetX Testnet** — Chain ID `587`
  - RPC: `https://test-rpc.tsccan.io`
  - Explorer: `https://test.tscscan.io`
  - Native Currency: NETX (18 decimals)

## Checklist

- [x] Chain IDs 287 and 587 are not already taken
- [x] JSON files follow the repository schema
- [x] RPC endpoints are publicly accessible
- [x] Block explorers are accessible