### PR TITLE
Add Cheese Blockchain Mainnet (Chain ID 2025)

### DIFF
--- a/_data/chains/eip155-2025.json
+++ b/_data/chains/eip155-2025.json
@@ -1,24 +1,25 @@
 {
-  "name": "Rangers Protocol Mainnet",
-  "chain": "Rangers",
-  "icon": "rangers",
-  "rpc": ["https://mainnet.rangersprotocol.com/api/jsonrpc"],
-  "faucets": [],
-  "nativeCurrency": {
-    "name": "Rangers Protocol Gas",
-    "symbol": "RPG",
-    "decimals": 18
-  },
-  "infoURL": "https://rangersprotocol.com",
-  "shortName": "rpg",
-  "chainId": 2025,
-  "networkId": 2025,
-  "slip44": 1008,
-  "explorers": [
-    {
-      "name": "rangersscan",
-      "url": "https://scan.rangersprotocol.com",
-      "standard": "none"
-    }
-  ]
+    "name": "Cheese Blockchain",
+    "chain": "NCH",
+    "icon": "cheese",
+    "rpc": [
+          "https://cheese-blockchain-production.up.railway.app/rpc"
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+          "name": "Native Cheesecoin",
+          "symbol": "NCH",
+          "decimals": 18
+    },
+    "infoURL": "https://cheese-blockchain.web.app",
+    "shortName": "nch",
+    "chainId": 2025,
+    "networkId": 2025,
+    "explorers": [
+          {
+                  "name": "Cheese Blockchain Explorer",
+                  "url": "https://cheese-blockchain.web.app/explorer",
+                  "standard": "EIP3091"
+          }
+    ]
 }

--- a/_data/icons/cheese.json
+++ b/_data/icons/cheese.json
@@ -1,0 +1,8 @@
+[
+    {
+          "url": "ipfs://QmXttGpZcd4cTBMT39oLGWEKokyEgMOBnUB2rYdwWzCk91",
+          "width": 512,
+          "height": 512,
+          "format": "png"
+    }
+]


### PR DESCRIPTION
## Summary
Adding Cheese Blockchain Mainnet to the registry.

- Chain ID: 2025
- Symbol: NCH  
- RPC: https://cheese-blockchain-production.up.railway.app/rpc
- Explorer: https://cheese-blockchain.web.app/explorer
- Website: https://cheese-blockchain.web.app

## Checklist
- [x] The chain is publicly accessible
- [x] Chain ID 2025 is unique to this network
- [x] RPC endpoint is live and responding
- [x] Block explorer is operational