### PR TITLE
Add BM Chain (chainId: 6800) and BM Chain Testnet (chainId: 6801)

### DIFF
--- a/_data/chains/eip155-6800.json
+++ b/_data/chains/eip155-6800.json
@@ -1,0 +1,17 @@
+{
+  "name": "BM Chain",
+  "chain": "BMX",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "BMX",
+    "symbol": "BMX",
+    "decimals": 18
+  },
+  "infoURL": "https://bm.xyz",
+  "shortName": "bmx",
+  "chainId": 6800,
+  "networkId": 6800,
+  "explorers": [],
+  "status": "incubating"
+}

--- a/_data/chains/eip155-6801.json
+++ b/_data/chains/eip155-6801.json
@@ -1,0 +1,18 @@
+{
+  "name": "BM Chain Testnet",
+  "chain": "BMX",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "BMX",
+    "symbol": "BMX",
+    "decimals": 18
+  },
+  "infoURL": "https://bm.xyz",
+  "shortName": "bmx-testnet",
+  "chainId": 6801,
+  "networkId": 6801,
+  "slip44": 1,
+  "explorers": [],
+  "status": "incubating"
+}


### PR DESCRIPTION
## Summary

Add BM Chain mainnet (chainId: 6800) and BM Chain Testnet (chainId: 6801) to the
chain registry.

BM Chain is an EVM-compatible Layer 1 blockchain purpose-built for perpetual futures
trading (Perp DEX). It features a dual-engine architecture with a high-performance
order matching engine (Core Engine) alongside a standard EVM engine, unified under
HotStuff BFT consensus with DPoS staking. The native token is BMX.

## Chain Details

| Property | Mainnet | Testnet |
|----------|---------|---------|
| Name | BM Chain | BM Chain Testnet |
| Chain ID | 6800 | 6801 |
| Network ID | 6800 | 6801 |
| Native Currency | BMX (18 decimals) | BMX (18 decimals) |
| Short Name | bmx | bmx-testnet |
| Info URL | https://bm.xyz | https://bm.xyz |
| Status | incubating | incubating |

## Notes

- RPC endpoints and block explorer URLs will be added in a follow-up PR once
  infrastructure is deployed (testnet & mainnet target: Q2 ~ Q3 2026).
- Both chain IDs (6800, 6801) have been verified as unregistered in this repository.