### PR TITLE
Add iTani Network Chain (Chain ID: 1229800785)

### DIFF
--- a/_data/chains/eip155-1229800785.json
+++ b/_data/chains/eip155-1229800785.json
@@ -1,0 +1,37 @@
+{
+  "name": "iTani Network Chain",
+  "chain": "ITN",
+  "rpc": [
+    {
+      "url": "https://node.itaninetworkchain.com/jsonrpc",
+      "tracking": "none"
+    },
+    {
+      "url": "https://relay.itaninetworkchain.com/jsonrpc",
+      "tracking": "none"
+    }
+  ],
+  "features": [
+    {
+      "name": "EIP155"
+    }
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "iTani",
+    "symbol": "ITANI",
+    "decimals": 18
+  },
+  "infoURL": "https://github.com/itanidreams-dev/iTani-Network-Chain",
+  "shortName": "itani",
+  "chainId": 1229800785,
+  "networkId": 1229800785,
+  "status": "active",
+  "explorers": [
+    {
+      "name": "iTani Explorer",
+      "url": "https://node.itaninetworkchain.com",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Add iTani Network Chain - Chain ID 1229800785 (0x494d4551). ITANI native token, 18 decimals. ISSP PoS consensus. EVM-compatible. RPC: https://node.itaninetworkchain.com/jsonrpc. Explorer: https://node.itaninetworkchain.com (EIP-3091). GitHub: https://github.com/itanidreams-dev/iTani-Network-Chain