### PR TITLE
Add Nexus Mainnet (chain ID 3946)

### DIFF
--- a/_data/chains/eip155-3946.json
+++ b/_data/chains/eip155-3946.json
@@ -1,0 +1,25 @@
+{
+  "name": "Nexus Mainnet",
+  "chain": "NEX",
+  "icon": "nexus",
+  "rpc": [
+    "https://mainnet.rpc.nexus.xyz"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Nexus",
+    "symbol": "NEX",
+    "decimals": 18
+  },
+  "infoURL": "https://nexus.xyz",
+  "shortName": "nex",
+  "chainId": 3946,
+  "networkId": 3946,
+  "explorers": [
+    {
+      "name": "Nexus Explorer",
+      "url": "https://explorer.nexus.xyz",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/icons/nexus.json
+++ b/_data/icons/nexus.json
@@ -1,0 +1,6 @@
+{
+  "name": "nexus",
+  "description": "Nexus",
+  "url": "https://drive.google.com/uc?export=view&id=1-JcN3A-KXivWKtxP9LF7YKV5c0AMBrzg",
+  "format": "png"
+}


### PR DESCRIPTION
Adds Nexus Mainnet to the chains list.

| Field | Value |
|---|---|
| Name | Nexus Mainnet |
| Chain ID | 3946 |
| Network ID | 3946 |
| Native currency | NEX (18 decimals) |
| RPC | https://mainnet.rpc.nexus.xyz |
| Explorer | https://explorer.nexus.xyz (EIP-3091) |
| Info URL | https://nexus.xyz |

Icon added at `_data/icons/nexus.json`.