### PR TITLE
Add Vexidus Testnet (chainId 1618032)

### DIFF
--- a/_data/chains/eip155-1618032.json
+++ b/_data/chains/eip155-1618032.json
@@ -1,0 +1,24 @@
+{
+  "name": "Vexidus Testnet",
+  "chain": "VXS",
+  "rpc": ["https://testnet.vexidus.io"],
+  "faucets": ["https://vexswap.xyz"],
+  "nativeCurrency": {
+    "name": "Vexidus",
+    "symbol": "VXS",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://vexidus.io",
+  "shortName": "vxs-testnet",
+  "chainId": 1618032,
+  "networkId": 1618032,
+  "status": "active",
+  "explorers": [
+    {
+      "name": "VexScan",
+      "url": "https://vexscan.io",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Adds `_data/chains/eip155-1618032.json` for **Vexidus Testnet**.

Vexidus is a post-quantum L1 blockchain with EVM compatibility via an `eth_*` RPC adapter. The testnet has been live since Feb 26, 2026 with 5 validators across 4 continents (Europe, North America, Asia, India) and is currently at block 2.18M+.

### Chain summary

| Field | Value |
|---|---|
| Name | Vexidus Testnet |
| Chain ID | 1618032 (`0x18b070`) |
| Short name | vxs-testnet |
| Native currency | VXS (18 decimals via EVM adapter) |
| RPC | https://testnet.vexidus.io |
| Explorer | https://vexscan.io (EIP-3091 compatible) |
| Faucet | https://vexswap.xyz |
| Info URL | https://vexidus.io |

### RPC verification

```bash
$ curl -s -X POST https://testnet.vexidus.io \
    -H "Content-Type: application/json" \
    -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
{"jsonrpc":"2.0","result":"0x18b070","id":1}
```

### Notes

- Only `EIP155` is listed under `features`. Vexidus has chain-id replay protection but does not implement an EIP-1559 fee market, so claiming `EIP1559` would be misleading.
- No `multicall3` contract — Vexidus does not execute arbitrary EVM bytecode (the `eth_*` adapter translates to native protocol operations), so multicall3 is not deployable.
- No icon submitted in this PR (we will submit a separate icon PR with the IPFS-hosted asset once finalized).
- Mainnet (chainId 1618033) will be submitted as a separate PR once mainnet launches.
- `./gradlew run` passes locally (`BUILD SUCCESSFUL`).
- Prettier-formatted per `.prettierrc.json`.
- Checked: no chainId or shortName collisions in current registry.