### PR TITLE
Add Robinhood Chain Testnet (46630)

### DIFF
--- a/_data/chains/eip155-46630.json
+++ b/_data/chains/eip155-46630.json
@@ -2,9 +2,7 @@
   "name": "Robinhood Chain Testnet",
   "title": "Robinhood Chain Testnet",
   "chain": "ETH",
-  "rpc": [
-    "https://rpc.testnet.chain.robinhood.com/rpc"
-  ],
+  "rpc": ["https://rpc.testnet.chain.robinhood.com/rpc"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Sepolia Ether",

--- a/_data/chains/eip155-46630.json
+++ b/_data/chains/eip155-46630.json
@@ -25,6 +25,6 @@
   "parent": {
     "type": "L2",
     "chain": "eip155-11155111",
-    "bridges": []
+    "bridges": [{ "url": "https://portal.arbitrum.io/bridge" }]
   }
 }

--- a/_data/chains/eip155-46630.json
+++ b/_data/chains/eip155-46630.json
@@ -1,0 +1,32 @@
+{
+  "name": "Robinhood Chain Testnet",
+  "title": "Robinhood Chain Testnet",
+  "chain": "ETH",
+  "rpc": [
+    "https://rpc.testnet.chain.robinhood.com/rpc"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Sepolia Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://docs.robinhood.com/chain/",
+  "shortName": "rh-testnet",
+  "chainId": 46630,
+  "networkId": 46630,
+  "slip44": 1,
+  "explorers": [
+    {
+      "name": "blockscout",
+      "url": "https://explorer.testnet.chain.robinhood.com",
+      "icon": "blockscout",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-11155111",
+    "bridges": []
+  }
+}


### PR DESCRIPTION
Adds metadata for **Robinhood Chain Testnet**, an Arbitrum L2 testnet chain settling on Ethereum Sepolia.

- **chainId:** 46630
- **shortName:** rh-testnet
- **Public RPC:** https://rpc.testnet.chain.robinhood.com/rpc
- **Explorer:** https://explorer.testnet.chain.robinhood.com (Blockscout, EIP-3091 compatible)
- **Parent:** Ethereum Sepolia (eip155-11155111)
- **Native currency:** ETH

Verified:
- `eth_chainId` -> `0xb626` (46630)
- Blockscout explorer responds 200 on `/block/{n}` and `/tx/{hash}` (EIP-3091 routes)
- No existing chainId 46630 or shortName `rh-testnet` collision in `_data/chains/`
- File validates against `tools/schema/chainSchema.json` (required fields, shortName pattern, types)