### PR TITLE
Add Oxin Chain (4457) with official icon

### DIFF
--- a/_data/chains/eip155-4457.json
+++ b/_data/chains/eip155-4457.json
@@ -1,0 +1,28 @@
+{
+  "name": "Oxin Chain",
+  "chain": "OXIN",
+  "rpc": [
+    "https://rpc.oxinchain.io",
+    "https://rpc1.oxinchain.io",
+    "https://rpc2.oxinchain.io"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Oxin",
+    "symbol": "OXIN",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://oxinchain.io",
+  "shortName": "oxin",
+  "chainId": 4457,
+  "networkId": 4457,
+  "icon": "oxin",
+  "explorers": [
+    {
+      "name": "oxinscan",
+      "url": "https://scan.oxinchain.io",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/icons/oxin.json
+++ b/_data/icons/oxin.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreibppuijktkbw75jrng6w5xbrvvh6w5ppd4msriiruibmpk25pndmi",
+    "width": 1500,
+    "height": 1500,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Adding Oxin Chain to the ethereum-lists/chains registry. Oxin Chain is a Proof-of-Authority (PoA) based EVM-compatible blockchain designed for high performance and low-cost transactions.

Chain Details
Name: Oxin Chain

Chain ID: 4457

Currency Symbol: OXIN

Network Type: Mainnet (PoA)

Official Links
Website: https://oxinchain.io/

Block Explorer: https://scan.oxinchain.io/

RPC Endpoints
These are the official public nodes maintained by the Oxin Foundation:

https://rpc.oxinchain.io/

https://rpc1.oxinchain.io/

https://rpc2.oxinchain.io/

Icon Information
The official logo has been uploaded to IPFS and the metadata is provided in the _data/icons folder.

IPFS CID: bafkreibppuijktkbw75jrng6w5xbrvvh6w5ppd4msriiruibmpk25pndmi

Compliance
[x] JSON files formatted via Prettier.

[x] Filename follows CAIP-2 standard (eip155-4457.json).

[x] Icon size is under 250KB and follows specified constraints.