### PR TITLE
Add CoinAfrica chain (chainId 35147)

### DIFF
--- a/_data/chains/eip155-35147.json
+++ b/_data/chains/eip155-35147.json
@@ -1,0 +1,24 @@
+{
+  "name": "CoinAfrica",
+  "chain": "CoinAfrica",
+  "rpc": [
+    "https://rpc.coinafrica.tech"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "COINA",
+    "symbol": "COINA",
+    "decimals": 18
+  },
+  "infoURL": "https://coinafrica.tech",
+  "shortName": "coina",
+  "chainId": 35147,
+  "networkId": 35147,
+  "explorers": [
+    {
+      "name": "CoinA-Scan",
+      "url": "https://coinascan.com",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the CoinAfrica EVM chain (chainId 35147).

- Native currency: COINA (18 decimals)
- RPC: https://rpc.coinafrica.tech (verified returning 0x894b)
- Explorer: https://coinascan.com (Blockscout, EIP-3091 compliant)
- Info: https://coinafrica.tech

Icon will be added in a follow-up once pinned to IPFS.