### PR TITLE
Activate Status Network Hoodi, Deprecate Status Network Sepolia

### DIFF
--- a/_data/chains/eip155-1660990954.json
+++ b/_data/chains/eip155-1660990954.json
@@ -2,8 +2,8 @@
   "name": "Status Network Sepolia",
   "title": "Status Network Sepolia",
   "chain": "ETH",
-  "rpc": ["https://public.sepolia.rpc.status.network"],
-  "faucets": ["https://faucet.status.network/"],
+  "rpc": [],
+  "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
     "symbol": "ETH",
@@ -17,19 +17,8 @@
   "parent": {
     "type": "L2",
     "chain": "eip155-11155111",
-    "bridges": [
-      {
-        "url": "https://bridge.status.network"
-      }
-    ]
+    "bridges": []
   },
-  "explorers": [
-    {
-      "name": "Blockscout",
-      "url": "https://sepoliascan.status.network",
-      "standard": "EIP3091",
-      "icon": "sn"
-    }
-  ],
-  "status": "active"
+  "explorers": [],
+  "status": "deprecated"
 }

--- a/_data/chains/eip155-374.json
+++ b/_data/chains/eip155-374.json
@@ -2,8 +2,8 @@
   "name": "Status Network Hoodi",
   "title": "Status Network Hoodi",
   "chain": "ETH",
-  "rpc": [],
-  "faucets": [],
+  "rpc": ["https://public.hoodi.rpc.status.network"],
+  "faucets": ["https://eth.faucet.status.network/"],
   "nativeCurrency": {
     "name": "Ether",
     "symbol": "ETH",
@@ -23,6 +23,13 @@
       }
     ]
   },
-  "explorers": [],
-  "status": "incubating"
+  "explorers": [
+    {
+      "name": "Blockscout",
+      "url": "https://hoodiscan.status.network",
+      "standard": "EIP3091",
+      "icon": "snt"
+    }
+  ],
+  "status": "active"
 }


### PR DESCRIPTION
Hello team!

Doing this PR to add replace our Sepolia testnet with Hoodi testnet.

Status Network is a natively gasless and spam protected with RLN L2 built with the Linea stack anchored to Ethereum as the L1
You can find more info here: https://status.network/

We followed the guide and the maintainer checklist so hopefully all is good!

Many thanks,
the Status Network team