### PR TITLE
Add SwiftNodes RPC endpoints for 35 EVM chains

### DIFF
--- a/_data/chains/eip155-1.json
+++ b/_data/chains/eip155-1.json
@@ -20,9 +20,17 @@
     "https://rpc.mevblocker.io/fullprivacy",
     "https://eth.drpc.org",
     "wss://eth.drpc.org",
-    "https://api.securerpc.com/v1"
+    "https://api.securerpc.com/v1",
+    "https://rpc.swiftnodes.io/rpc/eth"
   ],
-  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
+    }
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",

--- a/_data/chains/eip155-10.json
+++ b/_data/chains/eip155-10.json
@@ -8,7 +8,8 @@
     "https://optimism.gateway.tenderly.co",
     "wss://optimism.gateway.tenderly.co",
     "https://optimism.drpc.org",
-    "wss://optimism.drpc.org"
+    "wss://optimism.drpc.org",
+    "https://rpc.swiftnodes.io/rpc/optimism"
   ],
   "faucets": [],
   "nativeCurrency": {
@@ -20,7 +21,6 @@
   "shortName": "oeth",
   "chainId": 10,
   "networkId": 10,
-
   "explorers": [
     {
       "name": "etherscan",

--- a/_data/chains/eip155-100.json
+++ b/_data/chains/eip155-100.json
@@ -14,7 +14,8 @@
     "https://gnosis.oat.farm",
     "wss://rpc.gnosischain.com/wss",
     "https://gnosis-rpc.publicnode.com",
-    "wss://gnosis-rpc.publicnode.com"
+    "wss://gnosis-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/gnosis"
   ],
   "faucets": [
     "https://gnosisfaucet.com",

--- a/_data/chains/eip155-1088.json
+++ b/_data/chains/eip155-1088.json
@@ -6,7 +6,8 @@
     "https://metis.drpc.org",
     "wss://metis.drpc.org",
     "https://metis-rpc.publicnode.com",
-    "wss://metis-rpc.publicnode.com"
+    "wss://metis-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/metis"
   ],
   "faucets": [],
   "nativeCurrency": {
@@ -28,6 +29,10 @@
   "parent": {
     "type": "L2",
     "chain": "eip155-1",
-    "bridges": [{ "url": "https://bridge.metis.io" }]
+    "bridges": [
+      {
+        "url": "https://bridge.metis.io"
+      }
+    ]
   }
 }

--- a/_data/chains/eip155-1100.json
+++ b/_data/chains/eip155-1100.json
@@ -4,7 +4,8 @@
   "rpc": [
     "https://dymension-evm.blockpi.network/v1/rpc/public",
     "https://dymension-evm-rpc.publicnode.com",
-    "wss://dymension-evm-rpc.publicnode.com"
+    "wss://dymension-evm-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/dymension"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-1284.json
+++ b/_data/chains/eip155-1284.json
@@ -16,7 +16,8 @@
     "https://moonbeam-rpc.publicnode.com",
     "wss://moonbeam-rpc.publicnode.com",
     "https://moonbeam.drpc.org",
-    "wss://moonbeam.drpc.org"
+    "wss://moonbeam.drpc.org",
+    "https://rpc.swiftnodes.io/rpc/moonbeam"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-1285.json
+++ b/_data/chains/eip155-1285.json
@@ -16,7 +16,8 @@
     "https://moonriver-rpc.publicnode.com",
     "wss://moonriver-rpc.publicnode.com",
     "https://moonriver.drpc.org",
-    "wss://moonriver.drpc.org"
+    "wss://moonriver.drpc.org",
+    "https://rpc.swiftnodes.io/rpc/moonriver"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-130.json
+++ b/_data/chains/eip155-130.json
@@ -4,7 +4,8 @@
   "rpc": [
     "https://mainnet.unichain.org",
     "https://unichain-rpc.publicnode.com",
-    "wss://unichain-rpc.publicnode.com"
+    "wss://unichain-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/unichain"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-1329.json
+++ b/_data/chains/eip155-1329.json
@@ -1,7 +1,11 @@
 {
   "name": "Sei Network",
   "chain": "Sei",
-  "rpc": ["https://evm-rpc.sei-apis.com", "wss://evm-ws.sei-apis.com"],
+  "rpc": [
+    "https://evm-rpc.sei-apis.com",
+    "wss://evm-ws.sei-apis.com",
+    "https://rpc.swiftnodes.io/rpc/sei"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Sei",

--- a/_data/chains/eip155-137.json
+++ b/_data/chains/eip155-137.json
@@ -9,7 +9,8 @@
     "https://polygon-bor-rpc.publicnode.com",
     "wss://polygon-bor-rpc.publicnode.com",
     "https://polygon.gateway.tenderly.co",
-    "wss://polygon.gateway.tenderly.co"
+    "wss://polygon.gateway.tenderly.co",
+    "https://rpc.swiftnodes.io/rpc/polygon"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-143.json
+++ b/_data/chains/eip155-143.json
@@ -2,8 +2,18 @@
   "name": "Monad",
   "chain": "MON",
   "icon": "monad",
-  "rpc": ["https://rpc.monad.xyz"],
-  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "rpc": [
+    "https://rpc.monad.xyz",
+    "https://rpc.swiftnodes.io/rpc/monad"
+  ],
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
+    }
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Monad",

--- a/_data/chains/eip155-146.json
+++ b/_data/chains/eip155-146.json
@@ -4,7 +4,8 @@
   "rpc": [
     "https://rpc.soniclabs.com",
     "https://sonic-rpc.publicnode.com",
-    "wss://sonic-rpc.publicnode.com"
+    "wss://sonic-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/sonic"
   ],
   "faucets": [],
   "nativeCurrency": {
@@ -12,7 +13,11 @@
     "symbol": "S",
     "decimals": 18
   },
-  "features": [{ "name": "EIP155" }],
+  "features": [
+    {
+      "name": "EIP155"
+    }
+  ],
   "infoURL": "https://soniclabs.com",
   "shortName": "sonic",
   "chainId": 146,

--- a/_data/chains/eip155-1514.json
+++ b/_data/chains/eip155-1514.json
@@ -1,7 +1,10 @@
 {
   "name": "Story",
   "chain": "STORY",
-  "rpc": ["https://mainnet.storyrpc.io"],
+  "rpc": [
+    "https://mainnet.storyrpc.io",
+    "https://rpc.swiftnodes.io/rpc/story"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "IP Token",

--- a/_data/chains/eip155-167000.json
+++ b/_data/chains/eip155-167000.json
@@ -6,7 +6,8 @@
   "rpc": [
     "https://rpc.mainnet.taiko.xyz",
     "https://taiko-rpc.publicnode.com",
-    "wss://taiko-rpc.publicnode.com"
+    "wss://taiko-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/taiko"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-1868.json
+++ b/_data/chains/eip155-1868.json
@@ -3,7 +3,10 @@
   "shortName": "soneium",
   "title": "Soneium mainnet",
   "chain": "ETH",
-  "rpc": ["https://rpc.soneium.org"],
+  "rpc": [
+    "https://rpc.soneium.org",
+    "https://rpc.swiftnodes.io/rpc/soneium"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
@@ -35,6 +38,10 @@
   "parent": {
     "type": "L2",
     "chain": "eip155-1",
-    "bridges": [{ "url": "https://superbridge.app/soneium" }]
+    "bridges": [
+      {
+        "url": "https://superbridge.app/soneium"
+      }
+    ]
   }
 }

--- a/_data/chains/eip155-204.json
+++ b/_data/chains/eip155-204.json
@@ -11,7 +11,8 @@
     "https://opbnb-rpc.publicnode.com",
     "wss://opbnb-rpc.publicnode.com",
     "https://opbnb.drpc.org",
-    "wss://opbnb.drpc.org"
+    "wss://opbnb.drpc.org",
+    "https://rpc.swiftnodes.io/rpc/opbnb"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-2222.json
+++ b/_data/chains/eip155-2222.json
@@ -12,7 +12,8 @@
     "https://rpc.ankr.com/kava_evm",
     "wss://wevm.kava-rpc.com",
     "https://kava.drpc.org",
-    "wss://kava.drpc.org"
+    "wss://kava.drpc.org",
+    "https://rpc.swiftnodes.io/rpc/kava"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-25.json
+++ b/_data/chains/eip155-25.json
@@ -6,9 +6,14 @@
     "https://cronos-evm-rpc.publicnode.com",
     "wss://cronos-evm-rpc.publicnode.com",
     "https://cronos.drpc.org",
-    "wss://cronos.drpc.org"
+    "wss://cronos.drpc.org",
+    "https://rpc.swiftnodes.io/rpc/cronos"
   ],
-  "features": [{ "name": "EIP1559" }],
+  "features": [
+    {
+      "name": "EIP1559"
+    }
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Cronos",

--- a/_data/chains/eip155-252.json
+++ b/_data/chains/eip155-252.json
@@ -4,7 +4,8 @@
   "rpc": [
     "https://rpc.frax.com",
     "https://fraxtal-rpc.publicnode.com",
-    "wss://fraxtal-rpc.publicnode.com"
+    "wss://fraxtal-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/fraxtal"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-369.json
+++ b/_data/chains/eip155-369.json
@@ -9,11 +9,19 @@
     "https://rpc.pulsechain.com",
     "https://pulsechain-rpc.publicnode.com",
     "wss://pulsechain-rpc.publicnode.com",
-    "https://rpc-pulsechain.g4mm4.io"
+    "https://rpc-pulsechain.g4mm4.io",
+    "https://rpc.swiftnodes.io/rpc/pulsechain"
   ],
   "icon": "pulsechain",
   "slip44": 60,
-  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
+    }
+  ],
   "faucets": [],
   "ens": {
     "registry": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e"

--- a/_data/chains/eip155-42161.json
+++ b/_data/chains/eip155-42161.json
@@ -14,7 +14,8 @@
     "https://arb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}",
     "https://arb1.arbitrum.io/rpc",
     "https://arbitrum-one-rpc.publicnode.com",
-    "wss://arbitrum-one-rpc.publicnode.com"
+    "wss://arbitrum-one-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/arbitrum"
   ],
   "faucets": [],
   "explorers": [
@@ -39,6 +40,10 @@
   "parent": {
     "type": "L2",
     "chain": "eip155-1",
-    "bridges": [{ "url": "https://bridge.arbitrum.io" }]
+    "bridges": [
+      {
+        "url": "https://bridge.arbitrum.io"
+      }
+    ]
   }
 }

--- a/_data/chains/eip155-42220.json
+++ b/_data/chains/eip155-42220.json
@@ -9,13 +9,21 @@
     "symbol": "CELO",
     "decimals": 18
   },
-  "rpc": ["https://forno.celo.org", "wss://forno.celo.org/ws"],
+  "rpc": [
+    "https://forno.celo.org",
+    "wss://forno.celo.org/ws",
+    "https://rpc.swiftnodes.io/rpc/celo"
+  ],
   "faucets": [],
   "infoURL": "https://docs.celo.org/",
   "parent": {
     "type": "L2",
     "chain": "eip155-1",
-    "bridges": [{ "url": "https://superbridge.app/celo" }]
+    "bridges": [
+      {
+        "url": "https://superbridge.app/celo"
+      }
+    ]
   },
   "explorers": [
     {

--- a/_data/chains/eip155-43114.json
+++ b/_data/chains/eip155-43114.json
@@ -5,9 +5,14 @@
   "rpc": [
     "https://api.avax.network/ext/bc/C/rpc",
     "https://avalanche-c-chain-rpc.publicnode.com",
-    "wss://avalanche-c-chain-rpc.publicnode.com"
+    "wss://avalanche-c-chain-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/avalanche"
   ],
-  "features": [{ "name": "EIP1559" }],
+  "features": [
+    {
+      "name": "EIP1559"
+    }
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Avalanche",
@@ -30,6 +35,10 @@
       "url": "https://snowtrace.io",
       "standard": "EIP3091"
     },
-    { "name": "Avascan", "url": "https://avascan.info", "standard": "EIP3091" }
+    {
+      "name": "Avascan",
+      "url": "https://avascan.info",
+      "standard": "EIP3091"
+    }
   ]
 }

--- a/_data/chains/eip155-5000.json
+++ b/_data/chains/eip155-5000.json
@@ -5,7 +5,8 @@
   "rpc": [
     "https://rpc.mantle.xyz",
     "https://mantle-rpc.publicnode.com",
-    "wss://mantle-rpc.publicnode.com"
+    "wss://mantle-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/mantle"
   ],
   "faucets": [],
   "nativeCurrency": {
@@ -32,6 +33,10 @@
   "parent": {
     "type": "L2",
     "chain": "eip155-1",
-    "bridges": [{ "url": "https://bridge.mantle.xyz" }]
+    "bridges": [
+      {
+        "url": "https://bridge.mantle.xyz"
+      }
+    ]
   }
 }

--- a/_data/chains/eip155-534352.json
+++ b/_data/chains/eip155-534352.json
@@ -7,7 +7,8 @@
     "https://rpc.ankr.com/scroll",
     "https://scroll-mainnet.chainstacklabs.com",
     "https://scroll-rpc.publicnode.com",
-    "wss://scroll-rpc.publicnode.com"
+    "wss://scroll-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/scroll"
   ],
   "faucets": [],
   "nativeCurrency": {
@@ -29,6 +30,10 @@
   "parent": {
     "type": "L2",
     "chain": "eip155-1",
-    "bridges": [{ "url": "https://scroll.io/bridge" }]
+    "bridges": [
+      {
+        "url": "https://scroll.io/bridge"
+      }
+    ]
   }
 }

--- a/_data/chains/eip155-56.json
+++ b/_data/chains/eip155-56.json
@@ -16,7 +16,8 @@
     "https://bsc-dataseed4.ninicoin.io",
     "https://bsc-rpc.publicnode.com",
     "wss://bsc-rpc.publicnode.com",
-    "wss://bsc-ws-node.nariox.org"
+    "wss://bsc-ws-node.nariox.org",
+    "https://rpc.swiftnodes.io/rpc/bsc"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-59144.json
+++ b/_data/chains/eip155-59144.json
@@ -8,7 +8,8 @@
     "https://linea-mainnet.infura.io/v3/${INFURA_API_KEY}",
     "wss://linea-mainnet.infura.io/ws/v3/${INFURA_API_KEY}",
     "https://linea-rpc.publicnode.com",
-    "wss://linea-rpc.publicnode.com"
+    "wss://linea-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/linea"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-61.json
+++ b/_data/chains/eip155-61.json
@@ -9,9 +9,14 @@
     "https://besu-at.etc-network.info",
     "https://geth-at.etc-network.info",
     "https://etc.etcdesktop.com",
-    "https://etc.mytokenpocket.vip"
+    "https://etc.mytokenpocket.vip",
+    "https://rpc.swiftnodes.io/rpc/etc"
   ],
-  "features": [{ "name": "EIP155" }],
+  "features": [
+    {
+      "name": "EIP155"
+    }
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",

--- a/_data/chains/eip155-747474.json
+++ b/_data/chains/eip155-747474.json
@@ -4,7 +4,8 @@
   "rpc": [
     "https://rpc.katana.network",
     "https://katana.gateway.tenderly.co/",
-    "https://rpc.katanarpc.com/"
+    "https://rpc.katanarpc.com/",
+    "https://rpc.swiftnodes.io/rpc/katana"
   ],
   "features": [
     {

--- a/_data/chains/eip155-80094.json
+++ b/_data/chains/eip155-80094.json
@@ -6,7 +6,8 @@
     "https://berachain-rpc.publicnode.com",
     "wss://berachain-rpc.publicnode.com",
     "https://rpc.berachain-apis.com",
-    "wss://rpc.berachain-apis.com"
+    "wss://rpc.berachain-apis.com",
+    "https://rpc.swiftnodes.io/rpc/berachain"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-81457.json
+++ b/_data/chains/eip155-81457.json
@@ -9,7 +9,8 @@
     "https://blastl2-mainnet.public.blastapi.io",
     "https://blast.blockpi.network/v1/rpc/public",
     "https://blast-rpc.publicnode.com",
-    "wss://blast-rpc.publicnode.com"
+    "wss://blast-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/blast"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-8453.json
+++ b/_data/chains/eip155-8453.json
@@ -7,7 +7,8 @@
     "https://base.gateway.tenderly.co",
     "wss://base.gateway.tenderly.co",
     "https://base-rpc.publicnode.com",
-    "wss://base-rpc.publicnode.com"
+    "wss://base-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/base"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-88888.json
+++ b/_data/chains/eip155-88888.json
@@ -5,7 +5,8 @@
   "rpc": [
     "https://rpc.chiliz.com",
     "https://rpc.ankr.com/chiliz",
-    "https://chiliz.publicnode.com"
+    "https://chiliz.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/chiliz"
   ],
   "faucets": [
     "https://spicy-faucet.chiliz.com",
@@ -20,7 +21,9 @@
   "shortName": "chzmainnet",
   "chainId": 88888,
   "networkId": 88888,
-  "redFlags": ["reusedChainId"],
+  "redFlags": [
+    "reusedChainId"
+  ],
   "explorers": [
     {
       "name": "chiliscan",

--- a/_data/chains/eip155-9001.json
+++ b/_data/chains/eip155-9001.json
@@ -5,7 +5,8 @@
     "https://evmos.lava.build",
     "wss://evmos.lava.build/websocket",
     "https://evmos-evm-rpc.publicnode.com",
-    "wss://evmos-evm-rpc.publicnode.com"
+    "wss://evmos-evm-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/evmos"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-9745.json
+++ b/_data/chains/eip155-9745.json
@@ -1,7 +1,10 @@
 {
   "name": "Plasma Mainnet",
   "chain": "Plasma",
-  "rpc": ["https://rpc.plasma.to"],
+  "rpc": [
+    "https://rpc.plasma.to",
+    "https://rpc.swiftnodes.io/rpc/plasma"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Plasma",


### PR DESCRIPTION
## Summary

Adds [SwiftNodes](https://swiftnodes.io) RPC endpoints for 35 EVM chains.

### About SwiftNodes

- Multi-chain RPC provider supporting 53+ chains (EVM and non-EVM)
- Load-balanced across 500+ upstream nodes with health checking and automatic failover
- Free tier available — no KYC or credit card required
- Flat-rate monthly pricing (no per-request fees)
- HTTP and WebSocket endpoints

### Links

- Website: https://swiftnodes.io
- Documentation: https://swiftnodes.io/docs
- Privacy Policy: https://swiftnodes.io/docs/privacy-policy
- Status: https://swiftnodes.io (status tab)
- Support: https://t.me/SwiftNodesBot

### Chains Added

Ethereum (1), BSC (56), Base (8453), Arbitrum (42161), Polygon (137), Optimism (10), Avalanche (43114), Sonic (146), PulseChain (369), Cronos (25), Sei (1329), Linea (59144), Scroll (534352), Blast (81457), Gnosis (100), Berachain (80094), Moonbeam (1284), Mantle (5000), Celo (42220), opBNB (204), Unichain (130), Metis (1088), Taiko (167000), Fraxtal (252), Moonriver (1285), Kava (2222), Evmos (9001), Chiliz (88888), Soneium (1868), Story (1514), Dymension (1100), Ethereum Classic (61), Monad (143), Plasma (9745), Katana (747474)