### PR TITLE
Add Seven Chain mainnet (chainId: 70007)

### DIFF
--- a/_data/chains/eip155-70007.json
+++ b/_data/chains/eip155-70007.json
@@ -1,0 +1,29 @@
+{
+  "name": "Seven Chain",
+  "chain": "7chain",
+  "rpc": [
+    "https://theseven.meme/api/seven-chain/jsonrpc"
+  ],
+  "features": [
+    { "name": "EIP155" },
+    { "name": "EIP1559" }
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Seven",
+    "symbol": "SEVEN",
+    "decimals": 18
+  },
+  "infoURL": "https://theseven.meme",
+  "shortName": "7chain",
+  "chainId": 70007,
+  "networkId": 70007,
+  "slip44": 60,
+  "explorers": [
+    {
+      "name": "Seven Chain Explorer",
+      "url": "https://theseven.meme/blockchain/explorer",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
## Add Seven Chain (Chain ID: 70007)

**Seven Chain** is an EVM-compatible Layer-1 blockchain serving as the immutable settlement layer for [TheSeven.meme](https://theseven.meme) — a perpetual futures exchange with 100+ pairs and up to 2001× leverage.

### Chain Details
- **Chain ID:** 70007 (0x11177)
- **Native Currency:** SEVEN (18 decimals)
- **Consensus:** Parlia (BSC-based)
- **Public RPC:** https://theseven.meme/api/seven-chain/jsonrpc
- **Explorer:** https://theseven.meme/blockchain/explorer

### Verification
- RPC is live and responds to `eth_chainId` with `0x11177`
- Chain ID matches Chainlist listing at chainlist.org/chain/70007