### PR TITLE
Fix Taiko explorer link and rename "Taiko Alethia" to "Taiko"

### DIFF
--- a/_data/chains/eip155-167000.json
+++ b/_data/chains/eip155-167000.json
@@ -1,5 +1,5 @@
 {
-  "name": "Taiko Alethia",
+  "name": "Taiko",
   "chain": "ETH",
   "status": "active",
   "icon": "taiko",

--- a/_data/chains/eip155-167000.json
+++ b/_data/chains/eip155-167000.json
@@ -23,11 +23,6 @@
       "name": "etherscan",
       "url": "https://taikoscan.io",
       "standard": "EIP3091"
-    },
-    {
-      "name": "Routescan",
-      "url": "https://taikoexplorer.com",
-      "standard": "EIP3091"
     }
   ]
 }


### PR DESCRIPTION
‘Alethia’ was added to distinguish the chain from the planned Gwyneth mainnet. We’ve now officially sunset Gwyneth.