### PR TITLE
Deprecate Status Network Sepolia (1660990954)

### DIFF
--- a/_data/chains/eip155-1660990954.json
+++ b/_data/chains/eip155-1660990954.json
@@ -31,5 +31,5 @@
       "icon": "sn"
     }
   ],
-  "status": "active"
+  "status": "deprecated"
 }


### PR DESCRIPTION
Hello team!

Doing this PR to add deprecate our Sepolia testnet.

Status Network is a natively gasless and spam protected with RLN L2 built with the Linea stack anchored to Ethereum as the L1
You can find more info here: https://status.network/

We followed the guide and the maintainer checklist so hopefully all is good!

Many thanks,
the Status Network team