### PR TITLE
Add Intuition Mainnet (ID: 1155)

### DIFF
--- a/_data/chains/eip155-1155.json
+++ b/_data/chains/eip155-1155.json
@@ -1,0 +1,27 @@
+{
+  "name": "Intuition Mainnet",
+  "chain": "TRUST",
+  "icon": "intuition",
+  "rpc": ["https://rpc.intuition.systems"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "TRUST",
+    "symbol": "TRUST",
+    "decimals": 18
+  },
+  "infoURL": "https://intuition.systems",
+  "shortName": "intuition",
+  "chainId": 1155,
+  "networkId": 1155,
+  "explorers": [
+    {
+      "name": "Intuition Explorer",
+      "url": "https://explorer.intuition.systems",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-8453"
+  }
+}

--- a/_data/icons/intuition.json
+++ b/_data/icons/intuition.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmQNvmur1LyzcuYr6PhCd1d9K8qa5yzGiowUw4x38pz3Qv",
+    "width": 400,
+    "height": 400,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
## Summary

- Add Intuition Mainnet chain definition (chainId: 1155)
- Intuition is an Arbitrum Orbit L3 built on top of Base, dedicated to Information Finance (InfoFi)

## Chain details

| Field | Value |
|-------|-------|
| **Name** | Intuition Mainnet |
| **Chain ID** | 1155 (`0x483`) |
| **Native Currency** | TRUST (18 decimals) |
| **RPC** | `https://rpc.intuition.systems` |
| **Explorer** | `https://explorer.intuition.systems` (EIP3091) |
| **Parent** | Base (eip155-8453) |
| **Info** | https://intuition.systems |

## Verification

- Chain ID confirmed via `eth_chainId` RPC call: `0x483` = 1155
- Network ID confirmed via `net_version`: `1155`
- RPC is live, current block height ~2,990,071
- Explorer returns HTTP 200, Blockscout-based, EIP3091 compliant
- Multicall3 deployed at standard address `0xcA11bde05977b3631167028862bE2a173976CA11`
- `shortName` "intuition" is unique in the registry
- JSON formatted with Prettier per repo guidelines