### PR TITLE
Add PlasticHero (chainId 250210)

### DIFF
--- a/_data/chains/eip155-250210.json
+++ b/_data/chains/eip155-250210.json
@@ -1,0 +1,24 @@
+{
+  "name": "PlasticHero",
+  "shortName": "pth",
+  "chain": "PTH",
+  "chainId": 250210,
+  "networkId": 250210,
+  "rpc": ["https://rpc.plasticherokorea.com"],
+  "faucets": [],
+  "infoURL": "https://www.plasticherocoin.com",
+  "icon": "plastichero",
+  "nativeCurrency": {
+    "name": "PlasticHero",
+    "symbol": "PTH",
+    "decimals": 18
+  },
+  "explorers": [
+    {
+      "name": "PlasticHero Explorer",
+      "url": "https://explorer.plasticherokorea.com",
+      "standard": "EIP3091"
+    }
+  ],
+  "status": "active"
+}

--- a/_data/icons/plastichero.json
+++ b/_data/icons/plastichero.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmVShDPGLX1C6SrHGsnHrvNL1DmSaXAtXHwYDYSrrMomeL",
+    "width": 250,
+    "height": 250,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
## Chain Info
- Name: PlasticHero
- Chain ID: 250210
- Symbol: PTH
- RPC: https://rpc.plasticherokorea.com
- Explorer: https://explorer.plasticherokorea.com
- Website: https://www.plasticherocoin.com
- Status: Mainnet (active)
- Icon: IPFS (Filebase pinned)