### PR TITLE
Add eGLOBLE Chain (chainId: 224488)

### DIFF
--- a/_data/chains/eip155-224488.json
+++ b/_data/chains/eip155-224488.json
@@ -1,0 +1,24 @@
+{
+  "name": "eGLOBLE Chain",
+  "chain": "eGBL",
+  "rpc": [
+    "https://rpc.egloble.site"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "eGBL",
+    "symbol": "eGBL",
+    "decimals": 18
+  },
+  "infoURL": "https://egloble.site",
+  "shortName": "egbl",
+  "chainId": 224488,
+  "networkId": 224488,
+  "explorers": [
+    {
+      "name": "eGLOBLE Explorer",
+      "url": "https://explorer.egloble.site",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
## Add eGLOBLE Chain

- Chain Name: eGLOBLE Chain
- Chain ID: 224488
- Native Currency: eGBL
- RPC: https://rpc.egloble.site
- Explorer: https://explorer.egloble.site
- Website: https://egloble.site