### PR TITLE
Add Cheese Blockchain (chainId 20250)

### DIFF
--- a/_data/chains/eip155-20250.json
+++ b/_data/chains/eip155-20250.json
@@ -1,0 +1,24 @@
+{
+  "name": "Cheese Blockchain",
+  "chain": "CHEESE",
+  "rpc": [
+    "https://cheese-blockchain-production.up.railway.app/rpc"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Native Cheesecoin",
+    "symbol": "NCH",
+    "decimals": 18
+  },
+  "infoURL": "https://cheese-blockchain.web.app",
+  "shortName": "nch",
+  "chainId": 20250,
+  "networkId": 20250,
+  "explorers": [
+    {
+      "name": "Cheese Explorer",
+      "url": "https://cheese-blockchain.web.app/explorer/",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add eip155-20250 chain metadata for Cheese Blockchain
- register canonical RPC, native currency (NCH), and explorer endpoint
- include unique short name 
ch and matching 
etworkId

## Validation
- verified JSON formatting and schema-compatible fields
- validated live RPC and explorer URLs from project deployment