### PR TITLE
Add Sentrix Chain mainnet (chainId 7119) and testnet (chainId 7120)

### DIFF
--- a/_data/chains/eip155-7119.json
+++ b/_data/chains/eip155-7119.json
@@ -2,7 +2,7 @@
   "name": "Sentrix Mainnet",
   "chain": "Sentrix",
   "rpc": [
-    "https://sentrix-rpc.sentriscloud.com/rpc"
+    "https://rpc.sentrixchain.com/rpc"
   ],
   "faucets": [],
   "nativeCurrency": {
@@ -17,7 +17,8 @@
   "explorers": [
     {
       "name": "Sentrixscan",
-      "url": "https://sentrixscan.sentriscloud.com"
+      "url": "https://scan.sentrixchain.com",
+      "standard": "none"
     }
   ]
 }

--- a/_data/chains/eip155-7119.json
+++ b/_data/chains/eip155-7119.json
@@ -1,0 +1,23 @@
+{
+  "name": "Sentrix Mainnet",
+  "chain": "Sentrix",
+  "rpc": [
+    "https://sentrix-rpc.sentriscloud.com/rpc"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Sentrix",
+    "symbol": "SRX",
+    "decimals": 18
+  },
+  "infoURL": "https://sentrixchain.com",
+  "shortName": "srx",
+  "chainId": 7119,
+  "networkId": 7119,
+  "explorers": [
+    {
+      "name": "Sentrixscan",
+      "url": "https://sentrixscan.sentriscloud.com"
+    }
+  ]
+}

--- a/_data/chains/eip155-7120.json
+++ b/_data/chains/eip155-7120.json
@@ -1,0 +1,25 @@
+{
+  "name": "Sentrix Testnet",
+  "chain": "Sentrix",
+  "rpc": [
+    "https://testnet-rpc.sentriscloud.com/rpc"
+  ],
+  "faucets": [
+    "https://faucet.sentrixchain.com"
+  ],
+  "nativeCurrency": {
+    "name": "Sentrix",
+    "symbol": "SRX",
+    "decimals": 18
+  },
+  "infoURL": "https://sentrixchain.com",
+  "shortName": "srx-testnet",
+  "chainId": 7120,
+  "networkId": 7120,
+  "explorers": [
+    {
+      "name": "Sentrixscan",
+      "url": "https://sentrixscan.sentriscloud.com"
+    }
+  ]
+}

--- a/_data/chains/eip155-7120.json
+++ b/_data/chains/eip155-7120.json
@@ -2,7 +2,7 @@
   "name": "Sentrix Testnet",
   "chain": "Sentrix",
   "rpc": [
-    "https://testnet-rpc.sentriscloud.com/rpc"
+    "https://testnet-rpc.sentrixchain.com/rpc"
   ],
   "faucets": [
     "https://faucet.sentrixchain.com"
@@ -19,7 +19,8 @@
   "explorers": [
     {
       "name": "Sentrixscan",
-      "url": "https://sentrixscan.sentriscloud.com"
+      "url": "https://scan.sentrixchain.com",
+      "standard": "none"
     }
   ]
 }


### PR DESCRIPTION
This PR adds Sentrix Chain to the registry.

## Sentrix Mainnet (chainId 7119)
- RPC: https://sentrix-rpc.sentriscloud.com/rpc
- Explorer: https://sentrixscan.sentriscloud.com
- Native token: SRX (18 decimals)
- Consensus: Voyager DPoS+BFT
- EVM-compatible (revm 37) — Solidity contracts deploy natively
- Live in production since April 2026

## Sentrix Testnet (chainId 7120)
- RPC: https://testnet-rpc.sentriscloud.com/rpc
- Explorer: https://sentrixscan.sentriscloud.com (toggle to Testnet)
- Faucet: https://faucet.sentrixchain.com
- Same consensus + EVM tooling as mainnet

## Verification

- Mainnet `eth_chainId` returns `0x1bcf` (= 7119) ✓
- Testnet `eth_chainId` returns `0x1bd0` (= 7120) ✓
- `./gradlew run` passes locally ✓
- Both JSONs validated via `jq empty` ✓

## About Sentrix Chain

Sentrix is a Layer-1 blockchain built in Rust, combining Bitcoin's monetary discipline (fixed 315M supply, 4-year halving) with Ethereum's programmability (EVM-native, Solidity-ready). Production-ready as of April 2026 with sub-second finality via DPoS+BFT consensus.

- Website: https://sentrixchain.com
- GitHub: https://github.com/sentrix-labs/sentrix
- Whitepaper: https://github.com/sentrix-labs/sentrix/blob/main/WHITEPAPER.md

## Notes

- `explorers[].standard` set to `none` for now — sentrixscan partial EIP-3091 support; will upgrade to `EIP3091` in a follow-up PR after explorer UX hardens
- Icon will be added in a follow-up PR (logo asset upload)
- `slip44` not yet registered with SLIP-44; will add later for hardware wallet support