### PR TITLE
Add Intuition Mainnet (eip155-1155)

### DIFF
--- a/_data/chains/eip155-1155.json
+++ b/_data/chains/eip155-1155.json
@@ -1,0 +1,27 @@
+{
+  "name": "Intuition Mainnet",
+  "chain": "TRUST",
+  "icon": "intuition",
+  "rpc": ["https://rpc.intuition.systems"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "TRUST",
+    "symbol": "TRUST",
+    "decimals": 18
+  },
+  "infoURL": "https://intuition.systems",
+  "shortName": "intuition",
+  "chainId": 1155,
+  "networkId": 1155,
+  "explorers": [
+    {
+      "name": "Intuition Explorer",
+      "url": "https://explorer.intuition.systems",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-8453"
+  }
+}

--- a/_data/icons/intuition.json
+++ b/_data/icons/intuition.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmQNvmur1LyzcuYr6PhCd1d9K8qa5yzGiowUw4x38pz3Qv",
+    "width": 400,
+    "height": 400,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
## Summary

Add Intuition Mainnet to the EVM chains list.

- **Chain ID**: 1155 (0x483)
- **Chain file**: `_data/chains/eip155-1155.json`
- **Icon file**: `_data/icons/intuition.json`

## Chain details

- **Name**: Intuition Mainnet
- **Short name**: intuition
- **Native currency**: TRUST (18 decimals)
- **Architecture**: Layer 3 on Base (Arbitrum Orbit / AnyTrust DA)
- **RPC**: https://rpc.intuition.systems (verified — returns `0x483`)
- **Explorer**: https://explorer.intuition.systems (Blockscout, EIP3091)
- **Info URL**: https://intuition.systems
- **Icon**: IPFS CID `QmQNvmur1LyzcuYr6PhCd1d9K8qa5yzGiowUw4x38pz3Qv` (400×400 PNG, publicly resolvable)

## Checklist

- [x] `shortName` and `name` are unique in the repo
- [x] `chainId` 1155 is not taken by any other chain
- [x] Parent chain `eip155-8453` (Base) exists in the repo
- [x] Icon JSON present in `_data/icons/intuition.json`
- [x] IPFS CID retrievable via public gateway
- [x] RPC endpoint responds with correct chain ID
- [x] JSON formatted with Prettier (`npx prettier --check _data/*/*.json` passes)

Made with [Cursor](https://cursor.com)