### PR TITLE
Add EBLA Network chains (mainnet 60186, testnet 60187, devnet 60188)

### DIFF
--- a/_data/chains/eip155-60186.json
+++ b/_data/chains/eip155-60186.json
@@ -1,0 +1,17 @@
+{
+  "name": "EBLA Mainnet",
+  "chain": "EBLA",
+  "icon": "ebla",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "EBLA",
+    "symbol": "EBLA",
+    "decimals": 18
+  },
+  "infoURL": "https://eblanetwork.com",
+  "shortName": "ebla",
+  "chainId": 60186,
+  "networkId": 60186,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-60187.json
+++ b/_data/chains/eip155-60187.json
@@ -1,0 +1,17 @@
+{
+  "name": "EBLA Testnet",
+  "chain": "EBLA",
+  "icon": "ebla",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "EBLA",
+    "symbol": "EBLA",
+    "decimals": 18
+  },
+  "infoURL": "https://eblanetwork.com",
+  "shortName": "tebla",
+  "chainId": 60187,
+  "networkId": 60187,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-60188.json
+++ b/_data/chains/eip155-60188.json
@@ -1,0 +1,17 @@
+{
+  "name": "EBLA Devnet",
+  "chain": "EBLA",
+  "icon": "ebla",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "EBLA",
+    "symbol": "EBLA",
+    "decimals": 18
+  },
+  "infoURL": "https://eblanetwork.com",
+  "shortName": "debla",
+  "chainId": 60188,
+  "networkId": 60188,
+  "status": "incubating"
+}

--- a/_data/icons/ebla.json
+++ b/_data/icons/ebla.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmVXSibomsMF5fE9j57TCcodvttxJxZm2tcBzhd5BJA73a",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
## Summary

Registers chain IDs for **EBLA Network** : a community-driven, EVM-compatible Layer 1 blockchain with Block DAG + PBFT consensus.

## What this PR adds

- `_data/chains/eip155-60186.json` — **EBLA Mainnet** (chainId 60186, shortName `ebla`)
- `_data/chains/eip155-60187.json` — **EBLA Testnet** (chainId 60187, shortName `tebla`)
- `_data/chains/eip155-60188.json` — **EBLA Devnet** (chainId 60188, shortName `debla`)
- `_data/icons/ebla.json` — Icon JSON pointing to IPFS CID `QmVXSibomsMF5fE9j57TCcodvttxJxZm2tcBzhd5BJA73a`

## Status

All three chains are submitted as `status: "incubating"` - mainnet has not yet launched. RPC and faucet arrays are intentionally empty for now; we will submit a follow-up PR with live RPC URLs once the public testnet is online.

## Verification

- [x] `./gradlew run` passes locally with `BUILD SUCCESSFUL`
- [x] `npx prettier --check` passes on all four files
- [x] Icon CID `QmVXSibomsMF5fE9j57TCcodvttxJxZm2tcBzhd5BJA73a` retrieved via raw `ipfs get` and SHA-256 verified
- [x] Icon is 512×512 PNG, 125 KB (well under the 250 KB limit)
- [x] All shortNames (`ebla`, `tebla`, `debla`) confirmed unique against existing chains
- [x] Branch is up to date with `ethereum-lists/chains` master

## Project info

- **Website:** https://eblanetwork.com
- **GitHub org:** https://github.com/EBLA-network
- **Mainnet RPC (placeholder):** https://rpc.eblanetwork.com (will serve eth_chainId once node is launched)
- **Mainnet explorer (placeholder):** https://explorer.eblanetwork.com

Thanks for maintaining this registry