### PR TITLE
chains: add Sentrix Mainnet (7119) and Sentrix Testnet (7120)

### DIFF
--- a/_data/chains/eip155-7119.json
+++ b/_data/chains/eip155-7119.json
@@ -1,0 +1,29 @@
+{
+  "name": "Sentrix Mainnet",
+  "chain": "SRX",
+  "rpc": [
+    "https://rpc.sentrixchain.com"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Sentrix",
+    "symbol": "SRX",
+    "decimals": 18
+  },
+  "infoURL": "https://sentrixchain.com",
+  "shortName": "srx",
+  "chainId": 7119,
+  "networkId": 7119,
+  "explorers": [
+    {
+      "name": "Sentrix Scan",
+      "url": "https://scan.sentrixchain.com",
+      "standard": "EIP3091"
+    },
+    {
+      "name": "Blockscout",
+      "url": "https://blockscout.sentrixchain.com",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-7120.json
+++ b/_data/chains/eip155-7120.json
@@ -1,0 +1,26 @@
+{
+  "name": "Sentrix Testnet",
+  "chain": "SRX",
+  "rpc": [
+    "https://testnet-rpc.sentrixchain.com"
+  ],
+  "faucets": [
+    "https://faucet.sentrixchain.com"
+  ],
+  "nativeCurrency": {
+    "name": "Sentrix Testnet",
+    "symbol": "tSRX",
+    "decimals": 18
+  },
+  "infoURL": "https://sentrixchain.com",
+  "shortName": "srx-testnet",
+  "chainId": 7120,
+  "networkId": 7120,
+  "explorers": [
+    {
+      "name": "Sentrix Scan Testnet",
+      "url": "https://scan.sentrixchain.com",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Adds two new chain definitions:

- **Sentrix Mainnet** (chain ID 7119, ticker SRX) — production EVM-compatible Layer-1, live since 2026-04-25 with revm 38 embedded execution and Voyager DPoS+BFT consensus.
- **Sentrix Testnet** (chain ID 7120, ticker tSRX) — public testnet with faucet at faucet.sentrixchain.com.

Both networks expose:
- Standard EVM JSON-RPC at the listed endpoints (HTTP + WebSocket on \`/ws\`)
- EIP-3091-compatible block explorers (custom Sentrix Scan + Blockscout sidecar on mainnet)
- 18-decimal nativeCurrency for EVM tooling compatibility (the underlying ledger is 8-decimal native, but \`eth_getBalance\` returns 18-decimal wei-scaled values for MetaMask / ethers / viem)

Source code: https://github.com/sentrix-labs/sentrix
Brand assets: https://github.com/sentrix-labs/brand-kit
Public RPC + endpoint inventory: https://sentrixchain.com