### PR TITLE
Add Intuition Testnet (eip155-13579)

### DIFF
--- a/_data/chains/eip155-13579.json
+++ b/_data/chains/eip155-13579.json
@@ -1,0 +1,27 @@
+{
+  "name": "Intuition Testnet",
+  "chain": "TRUST",
+  "icon": "intuition",
+  "rpc": ["https://testnet.rpc.intuition.systems"],
+  "faucets": ["https://intuition-testnet.hub.caldera.xyz"],
+  "nativeCurrency": {
+    "name": "Testnet TRUST",
+    "symbol": "tTRUST",
+    "decimals": 18
+  },
+  "infoURL": "https://intuition.systems",
+  "shortName": "intuition-testnet",
+  "chainId": 13579,
+  "networkId": 13579,
+  "explorers": [
+    {
+      "name": "Intuition Testnet Explorer",
+      "url": "https://testnet.explorer.intuition.systems",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-84532"
+  }
+}


### PR DESCRIPTION
## Summary

Add Intuition Testnet to the EVM chains list.

- **Chain ID**: 13579 (0x350B)
- **Chain file**: `_data/chains/eip155-13579.json`
- **Icon file**: reuses existing `_data/icons/intuition.json`

## Chain details

- **Name**: Intuition Testnet
- **Short name**: intuition-testnet
- **Native currency**: tTRUST (18 decimals)
- **Architecture**: Layer 3 on Base Sepolia (Arbitrum Orbit / AnyTrust DA)
- **RPC**: https://testnet.rpc.intuition.systems (verified — returns `0x350b`)
- **Faucet**: https://intuition-testnet.hub.caldera.xyz
- **Explorer**: https://testnet.explorer.intuition.systems (Blockscout, EIP3091)
- **Info URL**: https://intuition.systems
- **Icon**: reuses `intuition` icon — IPFS CID `QmQNvmur1LyzcuYr6PhCd1d9K8qa5yzGiowUw4x38pz3Qv`

## Checklist

- [x] `shortName` and `name` are unique in the repo
- [x] `chainId` 13579 is not taken by any other chain
- [x] Parent chain `eip155-84532` (Base Sepolia) exists in the repo
- [x] Icon JSON present in `_data/icons/intuition.json`
- [x] RPC endpoint responds with correct chain ID
- [x] JSON formatted with Prettier (`npx prettier --check` passes)

## Related

Companion to #8273 (Intuition Mainnet, eip155-1155)

Made with [Cursor](https://cursor.com)