### PR TITLE
Add ILITY Mainnet (chainId 4370) and ILITY Testnet (chainId 69923)

### DIFF
--- a/_data/chains/eip155-4370.json
+++ b/_data/chains/eip155-4370.json
@@ -1,0 +1,23 @@
+{
+  "name": "ILITY Mainnet",
+  "chain": "ILY",
+  "rpc": ["https://rpc.ility.xyz"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "ILITY",
+    "symbol": "ILY",
+    "decimals": 18
+  },
+  "infoURL": "https://ility.xyz",
+  "shortName": "ily",
+  "chainId": 4370,
+  "networkId": 4370,
+  "icon": "ility",
+  "explorers": [
+    {
+      "name": "ILITY Mainnet Explorer",
+      "url": "https://scan.ility.xyz",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-69923.json
+++ b/_data/chains/eip155-69923.json
@@ -1,0 +1,23 @@
+{
+  "name": "ILITY Testnet",
+  "chain": "ILY",
+  "rpc": ["https://rpc.testnet.ility.xyz"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "ILITY Token",
+    "symbol": "ILYt",
+    "decimals": 18
+  },
+  "infoURL": "https://ility.xyz",
+  "shortName": "ilyt",
+  "chainId": 69923,
+  "networkId": 69923,
+  "icon": "ility",
+  "explorers": [
+    {
+      "name": "ILITY Testnet Explorer",
+      "url": "https://scan.testnet.ility.xyz",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/icons/ility.json
+++ b/_data/icons/ility.json
@@ -1,0 +1,14 @@
+[
+  {
+    "url": "ipfs://bafkreiadvg2ds5rbmhfdxhnugojk4tlm6ujpzs7vocfqdszrwqvs2nmbfm",
+    "width": 320,
+    "height": 320,
+    "format": "svg"
+  },
+  {
+    "url": "ipfs://bafkreiaevsz2i5ljfqahubwpz4rc54e4lenotuihvszttoed24at46euom",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
## Summary
- Add ILITY Mainnet (chainId 4370, shortName `ily`)
- Add ILITY Testnet (chainId 69923, shortName `ilyt`)
- Add `ility` icon (svg + png variants)

## Test plan
- [x] `./gradlew run` — BUILD SUCCESSFUL
- [x] `npx prettier --check` — files match the repo style
- [x] No chainId / shortName / name collisions
- [x] Icon JSON shape matches existing chains
- [x] Explorer URLs are EIP3091-compliant and have no trailing slash