### PR TITLE
Add Aurigraph Mainnet (8471) and Aurigraph Testnet (8472)

### DIFF
--- a/_data/chains/eip155-8471.json
+++ b/_data/chains/eip155-8471.json
@@ -1,0 +1,34 @@
+{
+  "name": "Aurigraph Mainnet",
+  "chain": "AUR",
+  "rpc": [
+    "https://rpc.aurigraph.io",
+    "wss://rpc.aurigraph.io/ws"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Aurigraph",
+    "symbol": "AUR",
+    "decimals": 18
+  },
+  "infoURL": "https://aurigraph.io",
+  "shortName": "aur",
+  "chainId": 8471,
+  "networkId": 8471,
+  "explorers": [
+    {
+      "name": "Aurigraph Explorer",
+      "url": "https://explorer.aurigraph.io",
+      "standard": "EIP3091"
+    }
+  ],
+  "status": "active",
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
+    }
+  ]
+}

--- a/_data/chains/eip155-8472.json
+++ b/_data/chains/eip155-8472.json
@@ -1,0 +1,36 @@
+{
+  "name": "Aurigraph Testnet",
+  "chain": "AUR",
+  "rpc": [
+    "https://testnet-rpc.aurigraph.io",
+    "wss://testnet-rpc.aurigraph.io/ws"
+  ],
+  "faucets": [
+    "https://faucet-testnet.aurigraph.io"
+  ],
+  "nativeCurrency": {
+    "name": "Aurigraph Testnet AUR",
+    "symbol": "tAUR",
+    "decimals": 18
+  },
+  "infoURL": "https://aurigraph.io",
+  "shortName": "aur-testnet",
+  "chainId": 8472,
+  "networkId": 8472,
+  "explorers": [
+    {
+      "name": "Aurigraph Testnet Explorer",
+      "url": "https://testnet-explorer.aurigraph.io",
+      "standard": "EIP3091"
+    }
+  ],
+  "status": "active",
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
+    }
+  ]
+}


### PR DESCRIPTION
Adds two new EIP-155 chain entries for the **Aurigraph DLT V12 EVM-compatibility layer**.

| Field | Aurigraph Mainnet | Aurigraph Testnet |
|---|---|---|
| `chainId` | 8471 | 8472 |
| `shortName` | aur | aur-testnet |
| Native | AUR | tAUR |
| RPC | `https://rpc.aurigraph.io` | `https://testnet-rpc.aurigraph.io` |
| Explorer | `https://explorer.aurigraph.io` | `https://testnet-explorer.aurigraph.io` |
| Faucet | — | `https://faucet-testnet.aurigraph.io` |

## About Aurigraph V12

Aurigraph is a Layer-1 distributed ledger built on HyperRAFT++ consensus with deterministic finality (~1.5s, 3 blocks). The EVM-compatibility layer is implemented via embedded `revm` inside Aurigraph nodes — Solidity bytecode executes on Aurigraph's own validators (not bridged to or anchored on Ethereum).

- Block time: ~500 ms
- Finality: deterministic after 3 blocks
- Features: `EIP155` (replay protection via chainId) + `EIP1559` (base-fee gas)
- Native AUR is a fresh token, not bridged from any other chain

## Verification

- Both chain IDs (8471, 8472) confirmed unregistered at `https://chainid.network` on 2026-04-30 (`curl https://chainid.network/chains.json | jq '[.[]|select(.chainId==8471 or .chainId==8472)]'` returned `[]`)
- Local build via this repo's processor passes: `./gradlew run` → `BUILD SUCCESSFUL` against the master branch as of `1984701 Add TurkChain (EIP155-1919)`
- Field set conforms to `model/src/main/kotlin/org/ethereum/lists/chains/model/Chain.kt`

## Checklist

- [x] One PR per chain ID? **No — two chains in one PR** (mainnet + testnet for the same project, paired commitments). Happy to split if maintainers prefer.
- [x] Chain ID is unique
- [x] RPC URLs use HTTPS
- [x] Explorer follows EIP-3091
- [x] No icon entries (skipping `_data/icons/` additions for this PR)

Thanks for maintaining the registry.