### PR TITLE
Add MAKI Chain (chainId 8000008)

### DIFF
--- a/_data/chains/eip155-8000008.json
+++ b/_data/chains/eip155-8000008.json
@@ -1,9 +1,7 @@
 {
   "name": "MAKI Chain",
   "chain": "MAKI",
-  "rpc": [
-    "https://rpc.makiai.app"
-  ],
+  "rpc": ["https://rpc.makiai.app"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
@@ -13,12 +11,5 @@
   "infoURL": "https://makiai.app",
   "shortName": "maki",
   "chainId": 8000008,
-  "networkId": 8000008,
-  "explorers": [
-    {
-      "name": "MAKI Explorer",
-      "url": "https://explorer.makiai.app",
-      "standard": "EIP3091"
-    }
-  ]
+  "networkId": 8000008
 }

--- a/_data/chains/eip155-8000008.json
+++ b/_data/chains/eip155-8000008.json
@@ -1,0 +1,24 @@
+{
+  "name": "MAKI Chain",
+  "chain": "MAKI",
+  "rpc": [
+    "https://rpc.makiai.app"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://makiai.app",
+  "shortName": "maki",
+  "chainId": 8000008,
+  "networkId": 8000008,
+  "explorers": [
+    {
+      "name": "MAKI Explorer",
+      "url": "https://explorer.makiai.app",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Adding MAKI Chain to the registry.

Chain ID: 8000008
Network: MAKI Chain (EVM-compatible L2)
RPC: https://rpc.makiai.app
Explorer: https://explorer.makiai.app
Info: https://makiai.app
