### PR TITLE
chore: Deprecate Status Network

### DIFF
--- a/_data/chains/eip155-373.json
+++ b/_data/chains/eip155-373.json
@@ -24,5 +24,5 @@
     ]
   },
   "explorers": [],
-  "status": "incubating"
+  "status": "deprecated"
 }

--- a/_data/chains/eip155-374.json
+++ b/_data/chains/eip155-374.json
@@ -24,5 +24,5 @@
     ]
   },
   "explorers": [],
-  "status": "incubating"
+  "status": "deprecated"
 }


### PR DESCRIPTION
Hello team!

There's been a larger change of direction of Status Network L2. It's getting merged with Linea and will no longer be operating a separate chain. Because of this, we'll need to deprecate or remove the currently reserved networks.
You can read more about that [here](https://status.network/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream).

Status Network Hoodi is a LIVE running network at id 374 that's soon to be wound down:
https://public.hoodi.rpc.status.network/
https://hoodiscan.status.network/
So, I'm changing it's status to deprecated

Now, I'm unsure about Status Network Mainnet (id 373).
This network wasn't ever ran in public, so not sure if deprecated state is correct option or simply removing its config file?
Please let me know what works better.

Many thanks,
the Status Network team