### PR TITLE
Add VALYGO chains (7771777, 7773777)

### DIFF
--- a/_data/chains/eip155-7771777.json
+++ b/_data/chains/eip155-7771777.json
@@ -1,0 +1,32 @@
+{
+  "name": "VALYGO Smart Contract",
+  "chain": "VYO",
+  "rpc": [
+    "https://rpc-gw-1.vyoscan.com/ext/bc/2t51dXsuxUvd9teY9TKEJmgxmxMk3CRF88UYTA4HQgjeYZqzSX/rpc"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "VYO",
+    "symbol": "VYO",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://vyochain.com",
+  "shortName": "vyo",
+  "chainId": 7771777,
+  "networkId": 7771777,
+  "icon": "valygo",
+  "explorers": [
+    {
+      "name": "VYOScan",
+      "url": "https://vyoscan.com",
+      "icon": "valygo",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-43114",
+    "bridges": []
+  }
+}

--- a/_data/chains/eip155-7773777.json
+++ b/_data/chains/eip155-7773777.json
@@ -1,0 +1,32 @@
+{
+  "name": "VALYGO NFT",
+  "chain": "VYO",
+  "rpc": [
+    "https://rpc-gw-1.vyoscan.com/ext/bc/2RyzsmGypNQZPby1miwMMV8spTvhgd9qd2peNRzU1mErUQqSSw/rpc"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "VYO",
+    "symbol": "VYO",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://vyochain.com",
+  "shortName": "vyonft",
+  "chainId": 7773777,
+  "networkId": 7773777,
+  "icon": "valygo",
+  "explorers": [
+    {
+      "name": "VYOScan NFT",
+      "url": "https://nft.vyoscan.com",
+      "icon": "valygo",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-43114",
+    "bridges": []
+  }
+}

--- a/_data/icons/valygo.json
+++ b/_data/icons/valygo.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreiaavltvvqtjcwi3flzechwoygtlujvpb7k6jczmx64iw5bjc6e7vm",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Adds two VALYGO Avalanche L1 chains:

- **VALYGO Smart Contract (7771777)** — primary application chain
- **VALYGO NFT (7773777)** — NFT chain

Details:
- **RPC Gateway:** rpc-gw-1.vyoscan.com (per-chain BID routing)
- **Explorers:** vyoscan.com / nft.vyoscan.com (Blockscout, EIP-3091)
- **Native token:** VYO (18 decimals)
- **Website:** https://vyochain.com
- **Parent:** Avalanche (eip155-43114)
- **Icon:** IPFS-pinned PNG (512x512, 179KB)