### PR TITLE
Add TradeXcele Chain (chainId 47294)

### DIFF
--- a/_data/chains/eip155-47294.json
+++ b/_data/chains/eip155-47294.json
@@ -1,0 +1,26 @@
+{
+    "name": "TradeXcele",
+    "chain": "TXCL",
+    "rpc": [
+          "https://tradexcele.cloud/rpc/"
+    ],
+    "faucets": [
+          "https://tradexcele.cloud/chain/faucet/"
+    ],
+    "nativeCurrency": {
+          "name": "TXCL",
+          "symbol": "TXCL",
+          "decimals": 18
+    },
+    "infoURL": "https://tradexcele.com/chain",
+    "shortName": "txcl",
+    "chainId": 47294,
+    "networkId": 47294,
+    "explorers": [
+          {
+                  "name": "TXCL Explorer",
+                  "url": "https://tradexcele.cloud/chain",
+                  "standard": "EIP3091"
+          }
+    ]
+}


### PR DESCRIPTION
Adds **TradeXcele Chain** — EVM-compatible Layer-1 by TradeXcele.

- **Chain ID**: 47294 (`0xb8be`)
- - **Native token**: TXCL (18 decimals)
- - **Consensus**: Clique PoA, 5-second blocks
- - **RPC**: https://tradexcele.cloud/rpc/  (verified `eth_chainId` returns `0xb8be`)
- - **Explorer**: https://tradexcele.cloud/chain  (EIP-3091 routes verified)
- - **Faucet**: https://tradexcele.cloud/chain/faucet/
- - **Info**: https://tradexcele.com/chain
Single-validator PoA, transparently disclosed; decentralization roadmap published on the info page.