### PR TITLE
Add support for Danny Mainnet (Chain ID 5069)

### DIFF
--- a/_data/chains/eip155-5069.json
+++ b/_data/chains/eip155-5069.json
@@ -1,0 +1,27 @@
+{
+  "name": "Danny",
+  "title": "Danny",
+  "chain": "DAN",
+  "rpc": [
+    "https://rpc.dannyscan.com"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Danny",
+    "symbol": "DAN",
+    "decimals": 18
+  },
+  "infoURL": "https://dannychain.com",
+  "shortName": "dan",
+  "chainId": 5069,
+  "networkId": 5069,
+  "icon": "danny",
+  "explorers": [
+    {
+      "name": "Dannyscan",
+      "url": "https://dannyscan.com",
+      "icon": "danny",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-5069.json
+++ b/_data/chains/eip155-5069.json
@@ -2,9 +2,7 @@
   "name": "Danny",
   "title": "Danny",
   "chain": "DAN",
-  "rpc": [
-    "https://rpc.dannyscan.com"
-  ],
+  "rpc": ["https://rpc.dannyscan.com"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Danny",

--- a/_data/icons/danny.json
+++ b/_data/icons/danny.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreiagefsqnkwmuksiftyg7idhnuvun7r3bnf2zbnf2dmrpzcmijvcla",
+    "width": 200,
+    "height": 200,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
**Add support for Danny Mainnet (Chain ID 5069).**

Files Added
constants/additionalChainRegistry/chainid-5069.js — Danny Mainnet

Network Name: Danny Mainnet
Chain ID: 5069 (hex 0x13cd)
RPC Endpoint: https://rpc.dannyscan.com/
Native Currency: DAN (18 decimals)
Block Explorer: https://dannyscan.com/ (EIP-3091 compliant)
Features: EIP155, EIP1559