### PR TITLE
Add RPC URL for Liquichain (chainId 1662)

### DIFF
--- a/_data/chains/eip155-1662.json
+++ b/_data/chains/eip155-1662.json
@@ -2,7 +2,9 @@
   "name": "Liquichain",
   "shortName": "Liquichain",
   "chain": "LQC",
-  "rpc": [],
+  "rpc": [
+    "https://mainnet.liquichain.io/rpc"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Licoin",

--- a/_data/chains/eip155-1662.json
+++ b/_data/chains/eip155-1662.json
@@ -2,9 +2,7 @@
   "name": "Liquichain",
   "shortName": "Liquichain",
   "chain": "LQC",
-  "rpc": [
-    "https://mainnet.liquichain.io/rpc"
-  ],
+  "rpc": ["https://mainnet.liquichain.io/rpc"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Licoin",


### PR DESCRIPTION
Adds the public JSON-RPC endpoint for **Liquichain** (chainId 1662). The chain has been registered here for several years; this PR fills in the previously empty `rpc` array so wallets and aggregators (chainlist.org, etc.) can auto-configure the network.

## Changes
- `_data/chains/eip155-1662.json`: add `https://mainnet.liquichain.io/rpc` to the `rpc` array.

## Verification
The endpoint is live and responds to standard EVM JSON-RPC:

```bash
$ curl -s -X POST https://mainnet.liquichain.io/rpc \
    -H 'Content-Type: application/json' \
    -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
{"jsonrpc":"2.0","id":1,"result":"0x67e"}
```

`0x67e` = 1662, matching the registered `chainId`.

No other fields are modified.