### PR TITLE
Add TXCL Chain (eip155-47294)

### DIFF
--- a/_data/chains/eip155-47294.json
+++ b/_data/chains/eip155-47294.json
@@ -1,0 +1,25 @@
+{
+  "name": "TXCL Chain",
+  "chain": "TXCL",
+  "rpc": [
+    "https://rpc.txcl.tradexcele.com"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "TXCL",
+    "symbol": "TXCL",
+    "decimals": 18
+  },
+  "infoURL": "https://tradexcele.com/chain",
+  "shortName": "txcl",
+  "chainId": 47294,
+  "networkId": 47294,
+  "icon": "txcl",
+  "explorers": [
+    {
+      "name": "TXCL Explorer",
+      "url": "https://explorer.txcl.tradexcele.com",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
## TXCL Chain — Layer 1 EVM-compatible PoA blockchain

- **Chain name:** TXCL Chain
- **Chain ID:** 47294
- **Native token:** TXCL (18 decimals)
- **Consensus:** Clique PoA, 5-second blocks
- **Client:** go-ethereum (Geth v1.13.15-stable)
- **Operator:** TradeXcele (https://tradexcele.com)

### Verified RPC endpoint

Public RPC: `https://rpc.txcl.tradexcele.com`

Sample call:
```
POST / HTTP/1.1
Host: rpc.txcl.tradexcele.com
Content-Type: application/json

{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}

Response:
{"jsonrpc":"2.0","id":1,"result":"0xb8be"}
```

### Disclosure

TXCL Chain currently runs with a single validator in Clique PoA mode. This is publicly disclosed at https://tradexcele.com/chain along with the decentralization roadmap.

### Locked-down API

The public RPC is rate-limited (20 req/s per IP), serves CORS for browser wallets, and only exposes the safe namespaces (eth, net, web3, txpool, clique). Privileged namespaces (admin, personal, debug, miner) are blocked at the geth level.

Thank you for reviewing.