### PR TITLE
Add icon for TXCL Chain (eip155-47294)

### DIFF
--- a/_data/icons/txcl.json
+++ b/_data/icons/txcl.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "https://tradexcele.com/txc/txcl-icon.png",
+    "width": 256,
+    "height": 256,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
## Icon for TXCL Chain

Companion to PR #8311 which adds the TXCL Chain entry (chainId 47294).

The chain JSON references `"icon": "txcl"`, so this PR adds `_data/icons/txcl.json` pointing to a 256x256 PNG hosted on the project domain.

### Icon details

- **URL:** https://tradexcele.com/txc/txcl-icon.png
- **Dimensions:** 256x256
- **Format:** PNG
- **Verified accessible:** HTTP 200, Content-Type: image/png