### PR TITLE
feat: add MYRX-MAINNET (chain ID 8472)

### DIFF
--- a/_data/chains/eip155-8472.json
+++ b/_data/chains/eip155-8472.json
@@ -1,0 +1,24 @@
+{
+  "name": "MYRX-MAINNET",
+  "chain": "MYRX",
+  "rpc": [
+    "https://rpc.myrxwallet.io"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "MyRx Token",
+    "symbol": "MRT",
+    "decimals": 18
+  },
+  "infoURL": "https://myrxwallet.io",
+  "shortName": "myrx",
+  "chainId": 8472,
+  "networkId": 8472,
+  "explorers": [
+    {
+      "name": "MyRx Explorer",
+      "url": "https://explorer.myrxwallet.io",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-8472.json
+++ b/_data/chains/eip155-8472.json
@@ -1,6 +1,7 @@
 {
   "name": "MYRX-MAINNET",
   "chain": "MYRX",
+  "icon": "myrx",
   "rpc": [
     "https://rpc.myrxwallet.io"
   ],
@@ -14,11 +15,20 @@
   "shortName": "myrx",
   "chainId": 8472,
   "networkId": 8472,
+  "slip44": 60,
   "explorers": [
     {
       "name": "MyRx Explorer",
       "url": "https://explorer.myrxwallet.io",
       "standard": "EIP3091"
+    }
+  ],
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
     }
   ]
 }

--- a/_data/icons/myrx.json
+++ b/_data/icons/myrx.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmPDMhjTgZuFwN44NsQkKHcPQuuQJCMHeruuLzoKbNQAxw",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]

--- a/_data/icons/myrx.json
+++ b/_data/icons/myrx.json
@@ -1,8 +1,8 @@
-[
-  {
-    "url": "ipfs://QmPDMhjTgZuFwN44NsQkKHcPQuuQJCMHeruuLzoKbNQAxw",
-    "width": 512,
-    "height": 512,
-    "format": "png"
+{
+  "name": "myrx",
+  "description": "MYRX-MAINNET",
+  "website": "https://myrxwallet.io",
+  "logo": {
+    "ipfs": "QmPDMhjTgZuFwN44NsQkKHcPQuuQJCMHeruuLzoKbNQAxw"
   }
-]
+}


### PR DESCRIPTION
## MYRX-MAINNET -- Chain ID 8472

Sovereign EVM blockchain operated by MyRxWallet North America Corporation. Mainnet live since 2026-05-07.

### Verification
```
cast chain-id --rpc-url https://rpc.myrxwallet.io
# Returns: 8472
```
- Repository: https://github.com/MyRxWallet/mainnet
- Explorer: https://explorer.myrxwallet.io (EIP-3091)
- Treasury: 0x7636345D9d3C375Ac9aF0d98EB2eEd588d7A61d7

### Use case
Healthcare data and payments infrastructure. HIPAA-aligned data flows, provider settlement, patient-controlled data licensing.

### Contact
developer@myrxwallet.io | https://myrxwallet.io

**Changes:** Add `_data/chains/eip155-8472.json`