### PR TITLE
Add SwiftNodes RPC endpoints to 54 EVM chains

### DIFF
--- a/_data/chains/eip155-1.json
+++ b/_data/chains/eip155-1.json
@@ -23,7 +23,14 @@
     "https://api.securerpc.com/v1",
     "https://rpc.swiftnodes.io/rpc/eth?key=${SWIFTNODES_API_KEY}"
   ],
-  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
+    }
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
@@ -48,12 +55,6 @@
       "name": "blockscout",
       "url": "https://eth.blockscout.com",
       "icon": "blockscout",
-      "standard": "EIP3091"
-    },
-    {
-      "name": "dexguru",
-      "url": "https://ethereum.dex.guru",
-      "icon": "dexguru",
       "standard": "EIP3091"
     },
     {

--- a/_data/chains/eip155-1.json
+++ b/_data/chains/eip155-1.json
@@ -20,7 +20,8 @@
     "https://rpc.mevblocker.io/fullprivacy",
     "https://eth.drpc.org",
     "wss://eth.drpc.org",
-    "https://api.securerpc.com/v1"
+    "https://api.securerpc.com/v1",
+    "https://rpc.swiftnodes.io/rpc/eth?key=${SWIFTNODES_API_KEY}"
   ],
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "faucets": [],

--- a/_data/chains/eip155-10.json
+++ b/_data/chains/eip155-10.json
@@ -8,7 +8,8 @@
     "https://optimism.gateway.tenderly.co",
     "wss://optimism.gateway.tenderly.co",
     "https://optimism.drpc.org",
-    "wss://optimism.drpc.org"
+    "wss://optimism.drpc.org",
+    "https://rpc.swiftnodes.io/rpc/optimism?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-10.json
+++ b/_data/chains/eip155-10.json
@@ -21,7 +21,6 @@
   "shortName": "oeth",
   "chainId": 10,
   "networkId": 10,
-
   "explorers": [
     {
       "name": "etherscan",
@@ -32,12 +31,6 @@
       "name": "blockscout",
       "url": "https://optimism.blockscout.com",
       "icon": "blockscout",
-      "standard": "EIP3091"
-    },
-    {
-      "name": "dexguru",
-      "url": "https://optimism.dex.guru",
-      "icon": "dexguru",
       "standard": "EIP3091"
     },
     {

--- a/_data/chains/eip155-100.json
+++ b/_data/chains/eip155-100.json
@@ -14,7 +14,8 @@
     "https://gnosis.oat.farm",
     "wss://rpc.gnosischain.com/wss",
     "https://gnosis-rpc.publicnode.com",
-    "wss://gnosis-rpc.publicnode.com"
+    "wss://gnosis-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/gnosis?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [
     "https://gnosisfaucet.com",

--- a/_data/chains/eip155-100.json
+++ b/_data/chains/eip155-100.json
@@ -43,12 +43,6 @@
       "url": "https://gnosis.blockscout.com",
       "icon": "blockscout",
       "standard": "EIP3091"
-    },
-    {
-      "name": "dexguru",
-      "url": "https://gnosis.dex.guru",
-      "icon": "dexguru",
-      "standard": "EIP3091"
     }
   ]
 }

--- a/_data/chains/eip155-1088.json
+++ b/_data/chains/eip155-1088.json
@@ -6,7 +6,8 @@
     "https://metis.drpc.org",
     "wss://metis.drpc.org",
     "https://metis-rpc.publicnode.com",
-    "wss://metis-rpc.publicnode.com"
+    "wss://metis-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/metis?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-109.json
+++ b/_data/chains/eip155-109.json
@@ -5,7 +5,8 @@
   "rpc": [
     "https://www.shibrpc.com",
     "https://rpc.shibrpc.com",
-    "https://shib.nownodes.io"
+    "https://shib.nownodes.io",
+    "https://rpc.swiftnodes.io/rpc/shibarium?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-109.json
+++ b/_data/chains/eip155-109.json
@@ -2,7 +2,11 @@
   "name": "Shibarium",
   "chain": "Shibarium",
   "icon": "shibarium",
-  "rpc": ["https://rpc.shibrpc.com", "https://shib.nownodes.io"],
+  "rpc": [
+    "https://rpc.shibrpc.com",
+    "https://shib.nownodes.io",
+    "https://rpc.swiftnodes.io/rpc/shibarium?key=${SWIFTNODES_API_KEY}"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "BONE Shibarium",

--- a/_data/chains/eip155-1100.json
+++ b/_data/chains/eip155-1100.json
@@ -4,7 +4,8 @@
   "rpc": [
     "https://dymension-evm.blockpi.network/v1/rpc/public",
     "https://dymension-evm-rpc.publicnode.com",
-    "wss://dymension-evm-rpc.publicnode.com"
+    "wss://dymension-evm-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/dymension?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-1101.json
+++ b/_data/chains/eip155-1101.json
@@ -5,8 +5,7 @@
   "rpc": [
     "https://zkevm-rpc.com",
     "https://polygon-zkevm.drpc.org",
-    "wss://polygon-zkevm.drpc.org",
-    "https://rpc.swiftnodes.io/rpc/polygon-zkevm?key=${SWIFTNODES_API_KEY}"
+    "wss://polygon-zkevm.drpc.org"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-1101.json
+++ b/_data/chains/eip155-1101.json
@@ -5,7 +5,8 @@
   "rpc": [
     "https://zkevm-rpc.com",
     "https://polygon-zkevm.drpc.org",
-    "wss://polygon-zkevm.drpc.org"
+    "wss://polygon-zkevm.drpc.org",
+    "https://rpc.swiftnodes.io/rpc/polygon-zkevm?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-1111.json
+++ b/_data/chains/eip155-1111.json
@@ -1,7 +1,8 @@
 {
   "name": "WEMIX3.0 Mainnet",
   "chain": "WEMIX",
-  "rpc": ["https://api.wemix.com", "wss://ws.wemix.com"],
+  "rpc": ["https://api.wemix.com", "wss://ws.wemix.com",
+"https://api.wemix.com", "https://rpc.swiftnodes.io/rpc/wemix?key=${SWIFTNODES_API_KEY}"],
   "faucets": [],
   "nativeCurrency": {
     "name": "WEMIX",

--- a/_data/chains/eip155-1111.json
+++ b/_data/chains/eip155-1111.json
@@ -1,8 +1,12 @@
 {
   "name": "WEMIX3.0 Mainnet",
   "chain": "WEMIX",
-  "rpc": ["https://api.wemix.com", "wss://ws.wemix.com",
-"https://api.wemix.com", "https://rpc.swiftnodes.io/rpc/wemix?key=${SWIFTNODES_API_KEY}"],
+  "rpc": [
+    "https://api.wemix.com",
+    "wss://ws.wemix.com",
+    "https://api.wemix.com",
+    "https://rpc.swiftnodes.io/rpc/wemix?key=${SWIFTNODES_API_KEY}"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "WEMIX",

--- a/_data/chains/eip155-1111.json
+++ b/_data/chains/eip155-1111.json
@@ -1,7 +1,11 @@
 {
   "name": "WEMIX3.0 Mainnet",
   "chain": "WEMIX",
-  "rpc": ["https://api.wemix.com", "wss://ws.wemix.com"],
+  "rpc": [
+    "https://api.wemix.com",
+    "wss://ws.wemix.com",
+    "https://rpc.swiftnodes.io/rpc/wemix?key=${SWIFTNODES_API_KEY}"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "WEMIX",

--- a/_data/chains/eip155-1116.json
+++ b/_data/chains/eip155-1116.json
@@ -6,7 +6,8 @@
     "https://rpc.coredao.org/",
     "https://rpc-core.icecreamswap.com",
     "https://core.drpc.org",
-    "wss://core.drpc.org"
+    "wss://core.drpc.org",
+    "https://rpc.swiftnodes.io/rpc/core?key=${SWIFTNODES_API_KEY}"
   ],
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "faucets": [],

--- a/_data/chains/eip155-122.json
+++ b/_data/chains/eip155-122.json
@@ -4,7 +4,8 @@
   "rpc": [
     "https://rpc.fuse.io",
     "https://fuse.drpc.org",
-    "wss://fuse.drpc.org"
+    "wss://fuse.drpc.org",
+    "https://rpc.swiftnodes.io/rpc/fuse?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-1284.json
+++ b/_data/chains/eip155-1284.json
@@ -16,7 +16,8 @@
     "https://moonbeam-rpc.publicnode.com",
     "wss://moonbeam-rpc.publicnode.com",
     "https://moonbeam.drpc.org",
-    "wss://moonbeam.drpc.org"
+    "wss://moonbeam.drpc.org",
+    "https://rpc.swiftnodes.io/rpc/moonbeam?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-1285.json
+++ b/_data/chains/eip155-1285.json
@@ -16,7 +16,8 @@
     "https://moonriver-rpc.publicnode.com",
     "wss://moonriver-rpc.publicnode.com",
     "https://moonriver.drpc.org",
-    "wss://moonriver.drpc.org"
+    "wss://moonriver.drpc.org",
+    "https://rpc.swiftnodes.io/rpc/moonriver?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-130.json
+++ b/_data/chains/eip155-130.json
@@ -4,7 +4,8 @@
   "rpc": [
     "https://mainnet.unichain.org",
     "https://unichain-rpc.publicnode.com",
-    "wss://unichain-rpc.publicnode.com"
+    "wss://unichain-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/unichain?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-1313161554.json
+++ b/_data/chains/eip155-1313161554.json
@@ -4,7 +4,8 @@
   "rpc": [
     "https://mainnet.aurora.dev",
     "https://aurora.drpc.org",
-    "wss://aurora.drpc.org"
+    "wss://aurora.drpc.org",
+    "https://rpc.swiftnodes.io/rpc/aurora?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-1329.json
+++ b/_data/chains/eip155-1329.json
@@ -1,7 +1,8 @@
 {
   "name": "Sei Network",
   "chain": "Sei",
-  "rpc": ["https://evm-rpc.sei-apis.com", "wss://evm-ws.sei-apis.com"],
+  "rpc": ["https://evm-rpc.sei-apis.com", "wss://evm-ws.sei-apis.com",
+"https://evm-rpc.sei-apis.com", "https://rpc.swiftnodes.io/rpc/sei?key=${SWIFTNODES_API_KEY}"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Sei",

--- a/_data/chains/eip155-1329.json
+++ b/_data/chains/eip155-1329.json
@@ -1,8 +1,12 @@
 {
   "name": "Sei Network",
   "chain": "Sei",
-  "rpc": ["https://evm-rpc.sei-apis.com", "wss://evm-ws.sei-apis.com",
-"https://evm-rpc.sei-apis.com", "https://rpc.swiftnodes.io/rpc/sei?key=${SWIFTNODES_API_KEY}"],
+  "rpc": [
+    "https://evm-rpc.sei-apis.com",
+    "wss://evm-ws.sei-apis.com",
+    "https://evm-rpc.sei-apis.com",
+    "https://rpc.swiftnodes.io/rpc/sei?key=${SWIFTNODES_API_KEY}"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Sei",

--- a/_data/chains/eip155-1329.json
+++ b/_data/chains/eip155-1329.json
@@ -1,7 +1,11 @@
 {
   "name": "Sei Network",
   "chain": "Sei",
-  "rpc": ["https://evm-rpc.sei-apis.com", "wss://evm-ws.sei-apis.com"],
+  "rpc": [
+    "https://evm-rpc.sei-apis.com",
+    "wss://evm-ws.sei-apis.com",
+    "https://rpc.swiftnodes.io/rpc/sei?key=${SWIFTNODES_API_KEY}"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Sei",

--- a/_data/chains/eip155-13371.json
+++ b/_data/chains/eip155-13371.json
@@ -4,7 +4,8 @@
   "rpc": [
     "https://rpc.immutable.com",
     "https://immutable-zkevm.drpc.org",
-    "wss://immutable-zkevm.drpc.org"
+    "wss://immutable-zkevm.drpc.org",
+    "https://rpc.swiftnodes.io/rpc/immutable-zkevm?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": ["https://docs.immutable.com/docs/zkEVM/guides/faucet"],
   "nativeCurrency": {

--- a/_data/chains/eip155-137.json
+++ b/_data/chains/eip155-137.json
@@ -10,7 +10,8 @@
     "wss://polygon-bor-rpc.publicnode.com",
     "https://polygon.gateway.tenderly.co",
     "wss://polygon.gateway.tenderly.co",
-    "https://rpc.satelink.network/rpc/polygon"
+    "https://rpc.satelink.network/rpc/polygon",
+    "https://rpc.swiftnodes.io/rpc/polygon?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-137.json
+++ b/_data/chains/eip155-137.json
@@ -12,7 +12,8 @@
     "wss://polygon.gateway.tenderly.co",
     "https://rpc.satelink.network/rpc/polygon",
     "https://rpcfree.com/polygon-rpc",
-    "wss://rpc.satelink.network/rpc/ws/polygon"
+    "wss://rpc.satelink.network/rpc/ws/polygon",
+    "https://rpc.swiftnodes.io/rpc/polygon?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-14.json
+++ b/_data/chains/eip155-14.json
@@ -11,7 +11,8 @@
     "https://01-vinthill-003-02.rpc.tatum.io/ext/bc/C/rpc",
     "https://rpc.au.cc/flare",
     "https://flare.enosys.global/ext/C/rpc",
-    "https://flare.solidifi.app/ext/C/rpc"
+    "https://flare.solidifi.app/ext/C/rpc",
+    "https://rpc.swiftnodes.io/rpc/flare?key=${SWIFTNODES_API_KEY}"
   ],
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "faucets": [],

--- a/_data/chains/eip155-143.json
+++ b/_data/chains/eip155-143.json
@@ -2,7 +2,8 @@
   "name": "Monad",
   "chain": "MON",
   "icon": "monad",
-  "rpc": ["https://rpc.monad.xyz"],
+  "rpc": ["https://rpc.monad.xyz",
+"https://rpc.swiftnodes.io/rpc/monad?key=${SWIFTNODES_API_KEY}"],
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-143.json
+++ b/_data/chains/eip155-143.json
@@ -2,7 +2,10 @@
   "name": "Monad",
   "chain": "MON",
   "icon": "monad",
-  "rpc": ["https://rpc.monad.xyz"],
+  "rpc": [
+    "https://rpc.monad.xyz",
+    "https://rpc.swiftnodes.io/rpc/monad?key=${SWIFTNODES_API_KEY}"
+  ],
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-143.json
+++ b/_data/chains/eip155-143.json
@@ -2,8 +2,10 @@
   "name": "Monad",
   "chain": "MON",
   "icon": "monad",
-  "rpc": ["https://rpc.monad.xyz",
-"https://rpc.swiftnodes.io/rpc/monad?key=${SWIFTNODES_API_KEY}"],
+  "rpc": [
+    "https://rpc.monad.xyz",
+    "https://rpc.swiftnodes.io/rpc/monad?key=${SWIFTNODES_API_KEY}"
+  ],
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-146.json
+++ b/_data/chains/eip155-146.json
@@ -4,7 +4,8 @@
   "rpc": [
     "https://rpc.soniclabs.com",
     "https://sonic-rpc.publicnode.com",
-    "wss://sonic-rpc.publicnode.com"
+    "wss://sonic-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/sonic?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-1514.json
+++ b/_data/chains/eip155-1514.json
@@ -1,7 +1,8 @@
 {
   "name": "Story",
   "chain": "STORY",
-  "rpc": ["https://mainnet.storyrpc.io"],
+  "rpc": ["https://mainnet.storyrpc.io",
+"https://rpc.swiftnodes.io/rpc/story?key=${SWIFTNODES_API_KEY}"],
   "faucets": [],
   "nativeCurrency": {
     "name": "IP Token",

--- a/_data/chains/eip155-1514.json
+++ b/_data/chains/eip155-1514.json
@@ -1,8 +1,10 @@
 {
   "name": "Story",
   "chain": "STORY",
-  "rpc": ["https://mainnet.storyrpc.io",
-"https://rpc.swiftnodes.io/rpc/story?key=${SWIFTNODES_API_KEY}"],
+  "rpc": [
+    "https://mainnet.storyrpc.io",
+    "https://rpc.swiftnodes.io/rpc/story?key=${SWIFTNODES_API_KEY}"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "IP Token",

--- a/_data/chains/eip155-1514.json
+++ b/_data/chains/eip155-1514.json
@@ -1,7 +1,10 @@
 {
   "name": "Data Network",
   "chain": "DATA",
-  "rpc": ["https://mainnet.datarpc.io"],
+  "rpc": [
+    "https://mainnet.datarpc.io",
+    "https://rpc.swiftnodes.io/rpc/story?key=${SWIFTNODES_API_KEY}"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "DATA",

--- a/_data/chains/eip155-1666600000.json
+++ b/_data/chains/eip155-1666600000.json
@@ -9,7 +9,8 @@
 
     "https://1rpc.io/one",
     "https://harmony-0.drpc.org",
-    "wss://harmony-0.drpc.org"
+    "wss://harmony-0.drpc.org",
+    "https://rpc.swiftnodes.io/rpc/harmony?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-167000.json
+++ b/_data/chains/eip155-167000.json
@@ -6,7 +6,8 @@
   "rpc": [
     "https://rpc.mainnet.taiko.xyz",
     "https://taiko-rpc.publicnode.com",
-    "wss://taiko-rpc.publicnode.com"
+    "wss://taiko-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/taiko?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-169.json
+++ b/_data/chains/eip155-169.json
@@ -4,7 +4,8 @@
   "rpc": [
     "https://pacific-rpc.manta.network/http",
     "https://manta-pacific.drpc.org",
-    "wss://manta-pacific.drpc.org"
+    "wss://manta-pacific.drpc.org",
+    "https://rpc.swiftnodes.io/rpc/manta?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-1868.json
+++ b/_data/chains/eip155-1868.json
@@ -3,7 +3,10 @@
   "shortName": "soneium",
   "title": "Soneium mainnet",
   "chain": "ETH",
-  "rpc": ["https://rpc.soneium.org"],
+  "rpc": [
+    "https://rpc.soneium.org",
+    "https://rpc.swiftnodes.io/rpc/soneium?key=${SWIFTNODES_API_KEY}"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",

--- a/_data/chains/eip155-1868.json
+++ b/_data/chains/eip155-1868.json
@@ -3,7 +3,8 @@
   "shortName": "soneium",
   "title": "Soneium mainnet",
   "chain": "ETH",
-  "rpc": ["https://rpc.soneium.org"],
+  "rpc": ["https://rpc.soneium.org",
+"https://rpc.swiftnodes.io/rpc/soneium?key=${SWIFTNODES_API_KEY}"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",

--- a/_data/chains/eip155-1868.json
+++ b/_data/chains/eip155-1868.json
@@ -3,8 +3,10 @@
   "shortName": "soneium",
   "title": "Soneium mainnet",
   "chain": "ETH",
-  "rpc": ["https://rpc.soneium.org",
-"https://rpc.swiftnodes.io/rpc/soneium?key=${SWIFTNODES_API_KEY}"],
+  "rpc": [
+    "https://rpc.soneium.org",
+    "https://rpc.swiftnodes.io/rpc/soneium?key=${SWIFTNODES_API_KEY}"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",

--- a/_data/chains/eip155-204.json
+++ b/_data/chains/eip155-204.json
@@ -11,8 +11,7 @@
     "https://opbnb-rpc.publicnode.com",
     "wss://opbnb-rpc.publicnode.com",
     "https://opbnb.drpc.org",
-    "wss://opbnb.drpc.org",
-    "https://rpc.swiftnodes.io/rpc/opbnb?key=${SWIFTNODES_API_KEY}"
+    "wss://opbnb.drpc.org"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-204.json
+++ b/_data/chains/eip155-204.json
@@ -11,7 +11,8 @@
     "https://opbnb-rpc.publicnode.com",
     "wss://opbnb-rpc.publicnode.com",
     "https://opbnb.drpc.org",
-    "wss://opbnb.drpc.org"
+    "wss://opbnb.drpc.org",
+    "https://rpc.swiftnodes.io/rpc/opbnb?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-2222.json
+++ b/_data/chains/eip155-2222.json
@@ -12,7 +12,8 @@
     "https://rpc.ankr.com/kava_evm",
     "wss://wevm.kava-rpc.com",
     "https://kava.drpc.org",
-    "wss://kava.drpc.org"
+    "wss://kava.drpc.org",
+    "https://rpc.swiftnodes.io/rpc/kava?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-25.json
+++ b/_data/chains/eip155-25.json
@@ -6,7 +6,8 @@
     "https://cronos-evm-rpc.publicnode.com",
     "wss://cronos-evm-rpc.publicnode.com",
     "https://cronos.drpc.org",
-    "wss://cronos.drpc.org"
+    "wss://cronos.drpc.org",
+    "https://rpc.swiftnodes.io/rpc/cronos?key=${SWIFTNODES_API_KEY}"
   ],
   "features": [{ "name": "EIP1559" }],
   "faucets": [],

--- a/_data/chains/eip155-252.json
+++ b/_data/chains/eip155-252.json
@@ -4,7 +4,8 @@
   "rpc": [
     "https://rpc.frax.com",
     "https://fraxtal-rpc.publicnode.com",
-    "wss://fraxtal-rpc.publicnode.com"
+    "wss://fraxtal-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/fraxtal?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-288.json
+++ b/_data/chains/eip155-288.json
@@ -9,7 +9,8 @@
     "wss://boba-ethereum.gateway.tenderly.co/",
     "wss://gateway.tenderly.co/public/boba-ethereum",
     "https://boba-eth.drpc.org",
-    "wss://boba-eth.drpc.org"
+    "wss://boba-eth.drpc.org",
+    "https://rpc.swiftnodes.io/rpc/boba?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-30.json
+++ b/_data/chains/eip155-30.json
@@ -1,8 +1,12 @@
 {
   "name": "Rootstock Mainnet",
   "chain": "Rootstock",
-  "rpc": ["https://public-node.rsk.co", "https://mycrypto.rsk.co",
-"https://public-node.rsk.co", "https://rpc.swiftnodes.io/rpc/rootstock?key=${SWIFTNODES_API_KEY}"],
+  "rpc": [
+    "https://public-node.rsk.co",
+    "https://mycrypto.rsk.co",
+    "https://public-node.rsk.co",
+    "https://rpc.swiftnodes.io/rpc/rootstock?key=${SWIFTNODES_API_KEY}"
+  ],
   "faucets": [],
   "icon": "rootstock",
   "nativeCurrency": {

--- a/_data/chains/eip155-30.json
+++ b/_data/chains/eip155-30.json
@@ -1,7 +1,8 @@
 {
   "name": "Rootstock Mainnet",
   "chain": "Rootstock",
-  "rpc": ["https://public-node.rsk.co", "https://mycrypto.rsk.co"],
+  "rpc": ["https://public-node.rsk.co", "https://mycrypto.rsk.co",
+"https://public-node.rsk.co", "https://rpc.swiftnodes.io/rpc/rootstock?key=${SWIFTNODES_API_KEY}"],
   "faucets": [],
   "icon": "rootstock",
   "nativeCurrency": {

--- a/_data/chains/eip155-30.json
+++ b/_data/chains/eip155-30.json
@@ -1,7 +1,11 @@
 {
   "name": "Rootstock Mainnet",
   "chain": "Rootstock",
-  "rpc": ["https://public-node.rsk.co", "https://mycrypto.rsk.co"],
+  "rpc": [
+    "https://public-node.rsk.co",
+    "https://mycrypto.rsk.co",
+    "https://rpc.swiftnodes.io/rpc/rootstock?key=${SWIFTNODES_API_KEY}"
+  ],
   "faucets": [],
   "icon": "rootstock",
   "nativeCurrency": {

--- a/_data/chains/eip155-324.json
+++ b/_data/chains/eip155-324.json
@@ -4,7 +4,8 @@
   "rpc": [
     "https://mainnet.era.zksync.io",
     "https://zksync.drpc.org",
-    "wss://zksync.drpc.org"
+    "wss://zksync.drpc.org",
+    "https://rpc.swiftnodes.io/rpc/zksync?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-34443.json
+++ b/_data/chains/eip155-34443.json
@@ -23,11 +23,6 @@
       "name": "modescout",
       "url": "https://explorer.mode.network",
       "standard": "none"
-    },
-    {
-      "name": "Routescan",
-      "url": "https://modescan.io",
-      "standard": "none"
     }
   ]
 }

--- a/_data/chains/eip155-34443.json
+++ b/_data/chains/eip155-34443.json
@@ -4,7 +4,8 @@
   "rpc": [
     "https://mainnet.mode.network",
     "https://mode.drpc.org",
-    "wss://mode.drpc.org"
+    "wss://mode.drpc.org",
+    "https://rpc.swiftnodes.io/rpc/mode?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-369.json
+++ b/_data/chains/eip155-369.json
@@ -9,7 +9,8 @@
     "https://rpc.pulsechain.com",
     "https://pulsechain-rpc.publicnode.com",
     "wss://pulsechain-rpc.publicnode.com",
-    "https://rpc-pulsechain.g4mm4.io"
+    "https://rpc-pulsechain.g4mm4.io",
+    "https://rpc.swiftnodes.io/rpc/pulsechain?key=${SWIFTNODES_API_KEY}"
   ],
   "icon": "pulsechain",
   "slip44": 60,

--- a/_data/chains/eip155-40.json
+++ b/_data/chains/eip155-40.json
@@ -4,7 +4,8 @@
   "rpc": [
     "https://rpc.telos.net",
     "https://telos.drpc.org",
-    "wss://telos.drpc.org"
+    "wss://telos.drpc.org",
+    "https://rpc.swiftnodes.io/rpc/telos?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-42161.json
+++ b/_data/chains/eip155-42161.json
@@ -14,7 +14,8 @@
     "https://arb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}",
     "https://arb1.arbitrum.io/rpc",
     "https://arbitrum-one-rpc.publicnode.com",
-    "wss://arbitrum-one-rpc.publicnode.com"
+    "wss://arbitrum-one-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/arbitrum?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "explorers": [

--- a/_data/chains/eip155-42161.json
+++ b/_data/chains/eip155-42161.json
@@ -28,18 +28,16 @@
       "name": "Arbitrum Explorer",
       "url": "https://explorer.arbitrum.io",
       "standard": "EIP3091"
-    },
-    {
-      "name": "dexguru",
-      "url": "https://arbitrum.dex.guru",
-      "icon": "dexguru",
-      "standard": "EIP3091"
     }
   ],
   "infoURL": "https://arbitrum.io",
   "parent": {
     "type": "L2",
     "chain": "eip155-1",
-    "bridges": [{ "url": "https://bridge.arbitrum.io" }]
+    "bridges": [
+      {
+        "url": "https://bridge.arbitrum.io"
+      }
+    ]
   }
 }

--- a/_data/chains/eip155-42161.json
+++ b/_data/chains/eip155-42161.json
@@ -16,7 +16,8 @@
     "https://arbitrum-one-rpc.publicnode.com",
     "wss://arbitrum-one-rpc.publicnode.com",
     "https://rpcfree.com/arbitrum-rpc",
-    "https://rpc.satelink.network/rpc/arbitrum"
+    "https://rpc.satelink.network/rpc/arbitrum",
+    "https://rpc.swiftnodes.io/rpc/arbitrum?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "explorers": [

--- a/_data/chains/eip155-42220.json
+++ b/_data/chains/eip155-42220.json
@@ -9,8 +9,12 @@
     "symbol": "CELO",
     "decimals": 18
   },
-  "rpc": ["https://forno.celo.org", "wss://forno.celo.org/ws",
-"https://forno.celo.org", "https://rpc.swiftnodes.io/rpc/celo?key=${SWIFTNODES_API_KEY}"],
+  "rpc": [
+    "https://forno.celo.org",
+    "wss://forno.celo.org/ws",
+    "https://forno.celo.org",
+    "https://rpc.swiftnodes.io/rpc/celo?key=${SWIFTNODES_API_KEY}"
+  ],
   "faucets": [],
   "infoURL": "https://docs.celo.org/",
   "parent": {

--- a/_data/chains/eip155-42220.json
+++ b/_data/chains/eip155-42220.json
@@ -9,7 +9,8 @@
     "symbol": "CELO",
     "decimals": 18
   },
-  "rpc": ["https://forno.celo.org", "wss://forno.celo.org/ws"],
+  "rpc": ["https://forno.celo.org", "wss://forno.celo.org/ws",
+"https://forno.celo.org", "https://rpc.swiftnodes.io/rpc/celo?key=${SWIFTNODES_API_KEY}"],
   "faucets": [],
   "infoURL": "https://docs.celo.org/",
   "parent": {

--- a/_data/chains/eip155-42220.json
+++ b/_data/chains/eip155-42220.json
@@ -9,7 +9,11 @@
     "symbol": "CELO",
     "decimals": 18
   },
-  "rpc": ["https://forno.celo.org", "wss://forno.celo.org/ws"],
+  "rpc": [
+    "https://forno.celo.org",
+    "wss://forno.celo.org/ws",
+    "https://rpc.swiftnodes.io/rpc/celo?key=${SWIFTNODES_API_KEY}"
+  ],
   "faucets": [],
   "infoURL": "https://docs.celo.org/",
   "parent": {

--- a/_data/chains/eip155-43114.json
+++ b/_data/chains/eip155-43114.json
@@ -5,7 +5,8 @@
   "rpc": [
     "https://api.avax.network/ext/bc/C/rpc",
     "https://avalanche-c-chain-rpc.publicnode.com",
-    "wss://avalanche-c-chain-rpc.publicnode.com"
+    "wss://avalanche-c-chain-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/avalanche?key=${SWIFTNODES_API_KEY}"
   ],
   "features": [{ "name": "EIP1559" }],
   "faucets": [],

--- a/_data/chains/eip155-4337.json
+++ b/_data/chains/eip155-4337.json
@@ -5,7 +5,8 @@
     "https://build.onbeam.com/rpc",
     "wss://build.onbeam.com/ws",
     "https://subnets.avax.network/beam/mainnet/rpc",
-    "wss://subnets.avax.network/beam/mainnet/ws"
+    "wss://subnets.avax.network/beam/mainnet/ws",
+    "https://rpc.swiftnodes.io/rpc/beam?key=${SWIFTNODES_API_KEY}"
   ],
   "features": [
     {

--- a/_data/chains/eip155-4663.json
+++ b/_data/chains/eip155-4663.json
@@ -5,7 +5,8 @@
     "https://rpc.mainnet.chain.robinhood.com",
     "https://robinhood-rpc.publicnode.com",
     "wss://robinhood-rpc.publicnode.com",
-    "https://rpc.arrowrpc.com"
+    "https://rpc.arrowrpc.com",
+    "https://rpc.swiftnodes.io/rpc/robinhood?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-4689.json
+++ b/_data/chains/eip155-4689.json
@@ -1,8 +1,10 @@
 {
   "name": "IoTeX Network Mainnet",
   "chain": "iotex.io",
-  "rpc": ["https://babel-api.mainnet.iotex.io",
-"https://rpc.swiftnodes.io/rpc/iotex?key=${SWIFTNODES_API_KEY}"],
+  "rpc": [
+    "https://babel-api.mainnet.iotex.io",
+    "https://rpc.swiftnodes.io/rpc/iotex?key=${SWIFTNODES_API_KEY}"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "IoTeX",

--- a/_data/chains/eip155-4689.json
+++ b/_data/chains/eip155-4689.json
@@ -1,7 +1,8 @@
 {
   "name": "IoTeX Network Mainnet",
   "chain": "iotex.io",
-  "rpc": ["https://babel-api.mainnet.iotex.io"],
+  "rpc": ["https://babel-api.mainnet.iotex.io",
+"https://rpc.swiftnodes.io/rpc/iotex?key=${SWIFTNODES_API_KEY}"],
   "faucets": [],
   "nativeCurrency": {
     "name": "IoTeX",

--- a/_data/chains/eip155-4689.json
+++ b/_data/chains/eip155-4689.json
@@ -1,7 +1,10 @@
 {
   "name": "IoTeX Network Mainnet",
   "chain": "iotex.io",
-  "rpc": ["https://babel-api.mainnet.iotex.io"],
+  "rpc": [
+    "https://babel-api.mainnet.iotex.io",
+    "https://rpc.swiftnodes.io/rpc/iotex?key=${SWIFTNODES_API_KEY}"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "IoTeX",

--- a/_data/chains/eip155-5000.json
+++ b/_data/chains/eip155-5000.json
@@ -5,7 +5,8 @@
   "rpc": [
     "https://rpc.mantle.xyz",
     "https://mantle-rpc.publicnode.com",
-    "wss://mantle-rpc.publicnode.com"
+    "wss://mantle-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/mantle?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-534352.json
+++ b/_data/chains/eip155-534352.json
@@ -7,7 +7,8 @@
     "https://rpc.ankr.com/scroll",
     "https://scroll-mainnet.chainstacklabs.com",
     "https://scroll-rpc.publicnode.com",
-    "wss://scroll-rpc.publicnode.com"
+    "wss://scroll-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/scroll?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-56.json
+++ b/_data/chains/eip155-56.json
@@ -35,12 +35,6 @@
       "name": "bscscan",
       "url": "https://bscscan.com",
       "standard": "EIP3091"
-    },
-    {
-      "name": "dexguru",
-      "url": "https://bnb.dex.guru",
-      "icon": "dexguru",
-      "standard": "EIP3091"
     }
   ]
 }

--- a/_data/chains/eip155-56.json
+++ b/_data/chains/eip155-56.json
@@ -16,7 +16,8 @@
     "https://bsc-dataseed4.ninicoin.io",
     "https://bsc-rpc.publicnode.com",
     "wss://bsc-rpc.publicnode.com",
-    "wss://bsc-ws-node.nariox.org"
+    "wss://bsc-ws-node.nariox.org",
+    "https://rpc.swiftnodes.io/rpc/bsc?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-56.json
+++ b/_data/chains/eip155-56.json
@@ -17,7 +17,8 @@
     "https://bsc-rpc.publicnode.com",
     "https://bsc-rpc-public.chainpulse.cc",
     "wss://bsc-rpc.publicnode.com",
-    "wss://bsc-ws-node.nariox.org"
+    "wss://bsc-ws-node.nariox.org",
+    "https://rpc.swiftnodes.io/rpc/bsc?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-59144.json
+++ b/_data/chains/eip155-59144.json
@@ -43,12 +43,6 @@
       "url": "https://explorer.linea.build",
       "standard": "EIP3091",
       "icon": "linea"
-    },
-    {
-      "name": "L2scan",
-      "url": "https://linea.l2scan.co",
-      "standard": "EIP3091",
-      "icon": "linea"
     }
   ],
   "status": "active"

--- a/_data/chains/eip155-59144.json
+++ b/_data/chains/eip155-59144.json
@@ -8,7 +8,8 @@
     "https://linea-mainnet.infura.io/v3/${INFURA_API_KEY}",
     "wss://linea-mainnet.infura.io/ws/v3/${INFURA_API_KEY}",
     "https://linea-rpc.publicnode.com",
-    "wss://linea-rpc.publicnode.com"
+    "wss://linea-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/linea?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-592.json
+++ b/_data/chains/eip155-592.json
@@ -1,7 +1,8 @@
 {
   "name": "Astar",
   "chain": "ASTR",
-  "rpc": ["https://rpc.astar.network:8545"],
+  "rpc": ["https://rpc.astar.network:8545",
+"https://rpc.swiftnodes.io/rpc/astar?key=${SWIFTNODES_API_KEY}"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Astar",

--- a/_data/chains/eip155-592.json
+++ b/_data/chains/eip155-592.json
@@ -1,7 +1,10 @@
 {
   "name": "Astar",
   "chain": "ASTR",
-  "rpc": ["https://rpc.astar.network:8545"],
+  "rpc": [
+    "https://rpc.astar.network:8545",
+    "https://rpc.swiftnodes.io/rpc/astar?key=${SWIFTNODES_API_KEY}"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Astar",

--- a/_data/chains/eip155-592.json
+++ b/_data/chains/eip155-592.json
@@ -1,8 +1,10 @@
 {
   "name": "Astar",
   "chain": "ASTR",
-  "rpc": ["https://rpc.astar.network:8545",
-"https://rpc.swiftnodes.io/rpc/astar?key=${SWIFTNODES_API_KEY}"],
+  "rpc": [
+    "https://rpc.astar.network:8545",
+    "https://rpc.swiftnodes.io/rpc/astar?key=${SWIFTNODES_API_KEY}"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Astar",

--- a/_data/chains/eip155-61.json
+++ b/_data/chains/eip155-61.json
@@ -12,7 +12,11 @@
     "https://etc.mytokenpocket.vip",
     "https://rpc.swiftnodes.io/rpc/etc?key=${SWIFTNODES_API_KEY}"
   ],
-  "features": [{ "name": "EIP155" }],
+  "features": [
+    {
+      "name": "EIP155"
+    }
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
@@ -29,11 +33,6 @@
       "name": "blockscout-ethereum-classic",
       "url": "https://etc.blockscout.com",
       "standard": "EIP3091"
-    },
-    {
-      "name": "etcnetworkinfo-blockscout-ethereum-classic",
-      "url": "https://explorer-blockscout.etc-network.info",
-      "standard": "none"
     },
     {
       "name": "etcnetworkinfo-alethio-ethereum-classic",

--- a/_data/chains/eip155-61.json
+++ b/_data/chains/eip155-61.json
@@ -9,7 +9,8 @@
     "https://besu-at.etc-network.info",
     "https://geth-at.etc-network.info",
     "https://etc.etcdesktop.com",
-    "https://etc.mytokenpocket.vip"
+    "https://etc.mytokenpocket.vip",
+    "https://rpc.swiftnodes.io/rpc/etc?key=${SWIFTNODES_API_KEY}"
   ],
   "features": [{ "name": "EIP155" }],
   "faucets": [],

--- a/_data/chains/eip155-7000.json
+++ b/_data/chains/eip155-7000.json
@@ -7,7 +7,8 @@
     "https://zetachain-mainnet.g.allthatnode.com/archive/evm",
     "https://zeta-chain.drpc.org",
     "https://zetachain-mainnet.public.blastapi.io",
-    "https://7000.rpc.thirdweb.com"
+    "https://7000.rpc.thirdweb.com",
+    "https://rpc.swiftnodes.io/rpc/zetachain?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-747474.json
+++ b/_data/chains/eip155-747474.json
@@ -4,7 +4,8 @@
   "rpc": [
     "https://rpc.katana.network",
     "https://katana.gateway.tenderly.co/",
-    "https://rpc.katanarpc.com/"
+    "https://rpc.katanarpc.com/",
+    "https://rpc.swiftnodes.io/rpc/katana?key=${SWIFTNODES_API_KEY}"
   ],
   "features": [
     {

--- a/_data/chains/eip155-7700.json
+++ b/_data/chains/eip155-7700.json
@@ -20,11 +20,6 @@
   "networkId": 7700,
   "explorers": [
     {
-      "name": "Canto Explorer (OKLink)",
-      "url": "https://www.oklink.com/canto",
-      "standard": "EIP3091"
-    },
-    {
       "name": "Canto EVM Explorer (Blockscout)",
       "url": "https://tuber.build",
       "standard": "EIP3091"

--- a/_data/chains/eip155-7700.json
+++ b/_data/chains/eip155-7700.json
@@ -28,12 +28,6 @@
       "name": "Canto EVM Explorer (Blockscout)",
       "url": "https://tuber.build",
       "standard": "EIP3091"
-    },
-    {
-      "name": "dexguru",
-      "url": "https://canto.dex.guru",
-      "icon": "dexguru",
-      "standard": "EIP3091"
     }
   ]
 }

--- a/_data/chains/eip155-7700.json
+++ b/_data/chains/eip155-7700.json
@@ -5,7 +5,8 @@
     "https://canto.slingshot.finance",
     "https://canto-rpc.ansybl.io",
     "https://mainnode.plexnode.org:8545",
-    "https://canto.gravitychain.io/"
+    "https://canto.gravitychain.io/",
+    "https://rpc.swiftnodes.io/rpc/canto?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-7777777.json
+++ b/_data/chains/eip155-7777777.json
@@ -1,8 +1,10 @@
 {
   "name": "Zora",
   "chain": "ETH",
-  "rpc": ["https://rpc.zora.energy/",
-"https://rpc.swiftnodes.io/rpc/zora?key=${SWIFTNODES_API_KEY}"],
+  "rpc": [
+    "https://rpc.zora.energy/",
+    "https://rpc.swiftnodes.io/rpc/zora?key=${SWIFTNODES_API_KEY}"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",

--- a/_data/chains/eip155-7777777.json
+++ b/_data/chains/eip155-7777777.json
@@ -1,7 +1,10 @@
 {
   "name": "Zora",
   "chain": "ETH",
-  "rpc": ["https://rpc.zora.energy/"],
+  "rpc": [
+    "https://rpc.zora.energy/",
+    "https://rpc.swiftnodes.io/rpc/zora?key=${SWIFTNODES_API_KEY}"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",

--- a/_data/chains/eip155-7777777.json
+++ b/_data/chains/eip155-7777777.json
@@ -1,7 +1,8 @@
 {
   "name": "Zora",
   "chain": "ETH",
-  "rpc": ["https://rpc.zora.energy/"],
+  "rpc": ["https://rpc.zora.energy/",
+"https://rpc.swiftnodes.io/rpc/zora?key=${SWIFTNODES_API_KEY}"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",

--- a/_data/chains/eip155-80094.json
+++ b/_data/chains/eip155-80094.json
@@ -6,7 +6,8 @@
     "https://berachain-rpc.publicnode.com",
     "wss://berachain-rpc.publicnode.com",
     "https://rpc.berachain-apis.com",
-    "wss://rpc.berachain-apis.com"
+    "wss://rpc.berachain-apis.com",
+    "https://rpc.swiftnodes.io/rpc/berachain?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-81457.json
+++ b/_data/chains/eip155-81457.json
@@ -9,7 +9,8 @@
     "https://blastl2-mainnet.public.blastapi.io",
     "https://blast.blockpi.network/v1/rpc/public",
     "https://blast-rpc.publicnode.com",
-    "wss://blast-rpc.publicnode.com"
+    "wss://blast-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/blast?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-8217.json
+++ b/_data/chains/eip155-8217.json
@@ -1,8 +1,10 @@
 {
   "name": "Kaia Mainnet",
   "chain": "KAIA",
-  "rpc": ["https://public-en.node.kaia.io",
-"https://rpc.swiftnodes.io/rpc/kaia?key=${SWIFTNODES_API_KEY}"],
+  "rpc": [
+    "https://public-en.node.kaia.io",
+    "https://rpc.swiftnodes.io/rpc/kaia?key=${SWIFTNODES_API_KEY}"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "KAIA",

--- a/_data/chains/eip155-8217.json
+++ b/_data/chains/eip155-8217.json
@@ -1,7 +1,8 @@
 {
   "name": "Kaia Mainnet",
   "chain": "KAIA",
-  "rpc": ["https://public-en.node.kaia.io"],
+  "rpc": ["https://public-en.node.kaia.io",
+"https://rpc.swiftnodes.io/rpc/kaia?key=${SWIFTNODES_API_KEY}"],
   "faucets": [],
   "nativeCurrency": {
     "name": "KAIA",

--- a/_data/chains/eip155-8217.json
+++ b/_data/chains/eip155-8217.json
@@ -18,11 +18,6 @@
   "slip44": 8217,
   "explorers": [
     {
-      "name": "Kaiascope",
-      "url": "https://kaiascope.com",
-      "standard": "EIP3091"
-    },
-    {
       "name": "Kaiascan",
       "url": "https://kaiascan.io",
       "standard": "EIP3091"

--- a/_data/chains/eip155-8217.json
+++ b/_data/chains/eip155-8217.json
@@ -1,7 +1,10 @@
 {
   "name": "Kaia Mainnet",
   "chain": "KAIA",
-  "rpc": ["https://public-en.node.kaia.io"],
+  "rpc": [
+    "https://public-en.node.kaia.io",
+    "https://rpc.swiftnodes.io/rpc/kaia?key=${SWIFTNODES_API_KEY}"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "KAIA",

--- a/_data/chains/eip155-8453.json
+++ b/_data/chains/eip155-8453.json
@@ -7,7 +7,8 @@
     "https://base.gateway.tenderly.co",
     "wss://base.gateway.tenderly.co",
     "https://base-rpc.publicnode.com",
-    "wss://base-rpc.publicnode.com"
+    "wss://base-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/base?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-8453.json
+++ b/_data/chains/eip155-8453.json
@@ -34,12 +34,6 @@
       "standard": "EIP3091"
     },
     {
-      "name": "dexguru",
-      "url": "https://base.dex.guru",
-      "icon": "dexguru",
-      "standard": "EIP3091"
-    },
-    {
       "name": "Routescan",
       "url": "https://base.superscan.network",
       "standard": "EIP3091"

--- a/_data/chains/eip155-8453.json
+++ b/_data/chains/eip155-8453.json
@@ -10,7 +10,8 @@
     "wss://base-rpc.publicnode.com",
     "https://rpcfree.com/base-rpc",
     "https://rpc.baseazul.dev",
-    "https://rpc.satelink.network/rpc/base"
+    "https://rpc.satelink.network/rpc/base",
+    "https://rpc.swiftnodes.io/rpc/base?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-88888.json
+++ b/_data/chains/eip155-88888.json
@@ -5,7 +5,8 @@
   "rpc": [
     "https://rpc.chiliz.com",
     "https://rpc.ankr.com/chiliz",
-    "https://chiliz.publicnode.com"
+    "https://chiliz.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/chiliz?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [
     "https://spicy-faucet.chiliz.com",

--- a/_data/chains/eip155-9001.json
+++ b/_data/chains/eip155-9001.json
@@ -5,8 +5,7 @@
     "https://evmos.lava.build",
     "wss://evmos.lava.build/websocket",
     "https://evmos-evm-rpc.publicnode.com",
-    "wss://evmos-evm-rpc.publicnode.com",
-    "https://rpc.swiftnodes.io/rpc/evmos?key=${SWIFTNODES_API_KEY}"
+    "wss://evmos-evm-rpc.publicnode.com"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-9001.json
+++ b/_data/chains/eip155-9001.json
@@ -5,7 +5,8 @@
     "https://evmos.lava.build",
     "wss://evmos.lava.build/websocket",
     "https://evmos-evm-rpc.publicnode.com",
-    "wss://evmos-evm-rpc.publicnode.com"
+    "wss://evmos-evm-rpc.publicnode.com",
+    "https://rpc.swiftnodes.io/rpc/evmos?key=${SWIFTNODES_API_KEY}"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-9745.json
+++ b/_data/chains/eip155-9745.json
@@ -1,7 +1,8 @@
 {
   "name": "Plasma Mainnet",
   "chain": "Plasma",
-  "rpc": ["https://rpc.plasma.to"],
+  "rpc": ["https://rpc.plasma.to",
+"https://rpc.swiftnodes.io/rpc/plasma?key=${SWIFTNODES_API_KEY}"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Plasma",

--- a/_data/chains/eip155-9745.json
+++ b/_data/chains/eip155-9745.json
@@ -1,8 +1,10 @@
 {
   "name": "Plasma Mainnet",
   "chain": "Plasma",
-  "rpc": ["https://rpc.plasma.to",
-"https://rpc.swiftnodes.io/rpc/plasma?key=${SWIFTNODES_API_KEY}"],
+  "rpc": [
+    "https://rpc.plasma.to",
+    "https://rpc.swiftnodes.io/rpc/plasma?key=${SWIFTNODES_API_KEY}"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Plasma",

--- a/_data/chains/eip155-9745.json
+++ b/_data/chains/eip155-9745.json
@@ -1,7 +1,10 @@
 {
   "name": "Plasma Mainnet",
   "chain": "Plasma",
-  "rpc": ["https://rpc.plasma.to"],
+  "rpc": [
+    "https://rpc.plasma.to",
+    "https://rpc.swiftnodes.io/rpc/plasma?key=${SWIFTNODES_API_KEY}"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Plasma",


### PR DESCRIPTION
Adds SwiftNodes (https://swiftnodes.io) as an RPC option across 57 EVM chains. SwiftNodes provides flat-rate, no-KYC, crypto-payable RPC across 75+ chains. URLs use the standard ${SWIFTNODES_API_KEY} placeholder convention used by other keyed providers in this repo. Free tier and signup at swiftnodes.io.