### PR TITLE
Change AtlantisChain native token symbol to PYR

### DIFF
--- a/_data/chains/eip155-1338.json
+++ b/_data/chains/eip155-1338.json
@@ -5,8 +5,8 @@
   "rpc": ["https://rpc.atlantischain.network"],
   "faucets": ["https://faucet.atlantischain.network"],
   "nativeCurrency": {
-    "name": "ELY",
-    "symbol": "ELY",
+    "name": "PYR",
+    "symbol": "PYR",
     "decimals": 18
   },
   "infoURL": "https://elysiumchain.tech",


### PR DESCRIPTION
I have updated the native currency symbol from `ELY` to `PYR`.
The symbol has also been updated on the Substrate chain metadata.

RPC verification:

```bash
curl -X POST https://rpc.atlantischain.network \
  -H "Content-Type: application/json" \
  --data '{"jsonrpc":"2.0","method":"system_properties","params":[],"id":1}'
```

Response:

```json
{
  "jsonrpc":"2.0",
  "result":{
    "ss58Format":42,
    "tokenDecimals":18,
    "tokenSymbol":"PYR"
  },
  "id":1
}
```