### PR TITLE
Add rpcfree.com RPC to Polygon (chainId 137)

### DIFF
--- a/_data/chains/eip155-137.json
+++ b/_data/chains/eip155-137.json
@@ -10,7 +10,8 @@
     "wss://polygon-bor-rpc.publicnode.com",
     "https://polygon.gateway.tenderly.co",
     "wss://polygon.gateway.tenderly.co",
-    "https://rpc.satelink.network/rpc/polygon"
+    "https://rpc.satelink.network/rpc/polygon",
+    "https://rpcfree.com/polygon-rpc"
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
Adds rpcfree.com public RPC endpoint to Polygon (chainId 137).

- URL: https://rpcfree.com
- Operated by Etox / PAPRIKASOFT SRL (Romania)
- No signup, no API key required
- Privacy: https://rpcfree.com/privacy

### Verification

```
$ curl -X POST https://rpcfree.com/polygon-rpc -H "Content-Type: application/json" \
    -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
{"jsonrpc":"2.0","id":1,"result":"0x89"}
```

CORS is configured (OPTIONS returns 204 with `Access-Control-Allow-Origin: *`).

### Scope note

This PR originally included Ethereum (1), Base (8453), and Arbitrum (42161) as well. I dropped those three because `singleChainCheck` against any of those files currently fails with `java.net.ProtocolException: Too many follow-up requests: 21` from okhttp — reproducible locally with no rpcfree.com changes present.

Root cause: each of those files lists a `*.dex.guru` URL as an explorer, and those URLs now return an infinite 308 self-redirect:

```
$ curl -I https://ethereum.dex.guru
HTTP/2 308
location: https://ethereum.dex.guru
```

Same pattern for `base.dex.guru` and `arbitrum.dex.guru`. Polygon's file doesn't reference dex.guru and validates cleanly. I'll open a separate PR removing the broken explorer entries so Ethereum/Base/Arbitrum RPC submissions can land afterward.