### PR TITLE
Add MYRX-MAINNET (Chain ID 8472)

### DIFF
--- a/_data/chains/eip155-8472.json
+++ b/_data/chains/eip155-8472.json
@@ -1,0 +1,22 @@
+{
+  "name": "MYRX-MAINNET",
+  "chain": "MYRX",
+  "rpc": ["https://rpc.myrxwallet.io"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "MyRx Token",
+    "symbol": "MRT",
+    "decimals": 18
+  },
+  "infoURL": "https://myrxwallet.io",
+  "shortName": "myrx",
+  "chainId": 8472,
+  "networkId": 8472,
+  "explorers": [
+    {
+      "name": "MyRx Explorer",
+      "url": "https://explorer.myrxwallet.io",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Adds MYRX-MAINNET, a sovereign EVM healthcare settlement rail operated by MyRxWallet North America Corporation.

**Chain details:**
- Chain ID: 8472
- Short name: myrx
- Native currency: MyRx Token (MRT), 18 decimals
- Mainnet live: 2026-05-07
- Public RPC: https://rpc.myrxwallet.io (eth_chainId verified: 0x2118)
- Explorer: https://explorer.myrxwallet.io (EIP-3091 compliant)
- Operator: MyRxWallet North America Corporation (Wyoming, USA)
- Platform: ONC-certified FHIR R4 EHR + health data marketplace

**Local validation:**
- `node tools/schemaCheck.js` — passed
- `npx prettier --check` — passed
- Single-file diff: `_data/chains/eip155-8472.json`