### PR TITLE
Reclaim chainId 69420 from defunct Condrieu testnet for CHEESE Blockchain

### DIFF
--- a/_data/chains/eip155-69420.json
+++ b/_data/chains/eip155-69420.json
@@ -1,24 +1,29 @@
 {
-  "name": "Condrieu",
-  "title": "Ethereum Verkle Testnet Condrieu",
-  "chain": "ETH",
-  "rpc": ["https://rpc.condrieu.ethdevops.io:8545"],
-  "faucets": ["https://faucet.condrieu.ethdevops.io"],
+  "name": "CHEESE Blockchain",
+  "chain": "CHEESE",
+  "rpc": [
+    "https://cheesescan.com/rpc",
+    "https://rpc1.cheesescan.com",
+    "https://rpc2.cheesescan.com"
+  ],
+  "faucets": [
+    "https://cheesescan.com/faucet"
+  ],
   "nativeCurrency": {
-    "name": "Condrieu Testnet Ether",
-    "symbol": "CTE",
+    "name": "CHEESE",
+    "symbol": "CHEESE",
     "decimals": 18
   },
-  "infoURL": "https://condrieu.ethdevops.io",
-  "shortName": "cndr",
+  "infoURL": "https://cheesescan.com",
+  "shortName": "cheese",
   "chainId": 69420,
   "networkId": 69420,
-  "slip44": 1,
+  "status": "incubating",
   "explorers": [
     {
-      "name": "Condrieu explorer",
-      "url": "https://explorer.condrieu.ethdevops.io",
-      "standard": "none"
+      "name": "CHEESE Explorer",
+      "url": "https://cheesescan.com",
+      "standard": "EIP3091"
     }
   ]
 }

--- a/_data/chains/eip155-69420.json
+++ b/_data/chains/eip155-69420.json
@@ -6,9 +6,7 @@
     "https://rpc1.cheesescan.com",
     "https://rpc2.cheesescan.com"
   ],
-  "faucets": [
-    "https://cheesescan.com/faucet"
-  ],
+  "faucets": ["https://cheesescan.com/faucet"],
   "nativeCurrency": {
     "name": "CHEESE",
     "symbol": "CHEESE",

--- a/_data/chains/eip155-69420.json
+++ b/_data/chains/eip155-69420.json
@@ -16,6 +16,7 @@
   "shortName": "cheese",
   "chainId": 69420,
   "networkId": 69420,
+  "redFlags": ["reusedChainId"],
   "status": "incubating",
   "explorers": [
     {


### PR DESCRIPTION
## Summary

Reclaim chainId 69420 from the **Condrieu** Ethereum Verkle Trees research testnet (2022–2023) for **CHEESE Blockchain**.

## Evidence that Condrieu is no longer in service

All four endpoints listed in the existing `_data/chains/eip155-69420.json` are unreachable as of 2026-05-14:

| Endpoint | Probe result |
|---|---|
| `https://rpc.condrieu.ethdevops.io:8545` | no response |
| `https://condrieu.ethdevops.io` | no response |
| `https://faucet.condrieu.ethdevops.io` | no response |
| `https://explorer.condrieu.ethdevops.io` | no response |

Condrieu was officially superseded by the Kaustinen Verkle testnet, which itself moved on to Kaustinen-7 and is now part of the broader Verkle/PeerDAS research stack. The 69420 chainId is no longer in use by the Ethereum Verkle effort.

## CHEESE Blockchain

- Independent EVM-compatible Layer-1 in **pre-testnet** status (hence `"status": "incubating"`).
- 6 validators in 5 countries (DE × 3, US × 2, SG, FI) on Hyperledger Besu 24.12.2 with QBFT consensus.
- 2-second block time, ~3 million blocks produced so far on chainId 69420.
- Smart contracts deployed: CheeseUsername, CheeseFaucet, CheeseNFT, CheeseTrustScoreV2, CheesePriceOracle, CheeseMultiSig v2, CheeseSubscription.
- Public RPC live (probe 2026-05-14):
  - `https://cheesescan.com/rpc` → `{"jsonrpc":"2.0","result":"0x10f2c","id":1}` (eth_chainId)
  - `https://rpc1.cheesescan.com` → same
  - `https://rpc2.cheesescan.com` → same
- Explorer at https://cheesescan.com supports EIP-3091 paths: `/address/{addr}`, `/tx/{hash}`, `/block/{number}` — all return 200.
- Faucet at https://cheesescan.com/faucet returns 200, Cloudflare Turnstile-protected, 10 CHEESE / 24 h cooldown.

## What this PR does

- Replaces the (defunct) Condrieu entry in `_data/chains/eip155-69420.json` with the CHEESE Blockchain entry.
- shortName `cheese` is free in the current registry.
- No icon JSON added in this PR (kept minimal); happy to follow up with one if useful.

## Verification commands

```bash
curl -sk -X POST https://cheesescan.com/rpc   -H 'Content-Type: application/json'   -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
# → {"jsonrpc":"2.0","result":"0x10f2c","id":1}

curl -sk -o /dev/null -w "%{http_code}
" https://cheesescan.com/address/0xC7A922Dcd2bE5FEd8a357D1C0E87a0814a235AA6
# → 200
```

Happy to address any review comments. Thanks!
