### PR TITLE
Add CYBERIA-MAINNET (Chain ID 49406)

### DIFF
--- a/_data/chains/eip155-49406.json
+++ b/_data/chains/eip155-49406.json
@@ -1,0 +1,18 @@
+{
+  "name": "Cyberia Mainnet",
+  "chain": "cyberia-mainnet",
+  "rpc": ["https://rpc.cyberia.church"],
+  "icon": "cyberia",
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Cyber",
+    "symbol": "CYBER",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://cyberia.church",
+  "shortName": "CYBER",
+  "chainId": 49406,
+  "networkId": 49406,
+  "explorers": []
+}


### PR DESCRIPTION
Adds CYBERIA-MAINNET, a sovereign EVM healthcare settlement rail operated by MyRxWallet North America Corporation.

Chain details:

    Chain ID: 49406
    Short name: cyberia
    Native currency: Cyber (CYBER), 18 decimals
    Mainnet live: 2026-01-30  
    Public RPC: https://rpc.cyberia.church/ (eth_chainId verified: 0xC0FE)
    Explorer: https://explorer.cyberia.church/
    Platform: polygon-edge

    Single-file diff: _data/chains/eip155-49406.json