### PR TITLE
Update valygo.json

### DIFF
--- a/_data/icons/valygo.json
+++ b/_data/icons/valygo.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "ipfs://bafkreiaavltvvqtjcwi3flzechwoygtlujvpb7k6jczmx64iw5bjc6e7vm",
+    "url": "ipfs://Qmc93z2XScvpPfVGpUNhFsKXPV5RVkf48RAFQNcwdYQdWs",
     "width": 512,
     "height": 512,
     "format": "png"


### PR DESCRIPTION
Previous CID (bafkrei...) was unreachable on public IPFS network. Re-uploaded correct 512x512 PNG logo with new pinned CID.