### PR TITLE
Add MyrxWallet Network (Chain 8472) — EIP155/EIP1559, MRT native token

### DIFF
--- a/_data/chains/eip155-8472.json
+++ b/_data/chains/eip155-8472.json
@@ -1,11 +1,15 @@
 {
   "name": "MyrxWallet Network",
   "chain": "MYRX",
-  "icon": "myrxwallet",
-  "rpc": [
-    "https://rpc.myrxwallet.io"
+  "rpc": ["https://rpc.myrxwallet.io"],
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
+    }
   ],
-  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "faucets": [],
   "nativeCurrency": {
     "name": "MRT",

--- a/_data/chains/eip155-8472.json
+++ b/_data/chains/eip155-8472.json
@@ -1,10 +1,14 @@
 {
-  "name": "MYRX-MAINNET",
+  "name": "MyrxWallet Network",
   "chain": "MYRX",
-  "rpc": ["https://rpc.myrxwallet.io"],
+  "icon": "myrxwallet",
+  "rpc": [
+    "https://rpc.myrxwallet.io"
+  ],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "faucets": [],
   "nativeCurrency": {
-    "name": "MyRx Token",
+    "name": "MRT",
     "symbol": "MRT",
     "decimals": 18
   },
@@ -14,7 +18,7 @@
   "networkId": 8472,
   "explorers": [
     {
-      "name": "MyRx Explorer",
+      "name": "MyrxWallet Explorer",
       "url": "https://explorer.myrxwallet.io",
       "standard": "EIP3091"
     }


### PR DESCRIPTION
## Summary

Adds MyrxWallet Network (Chain ID 8472) to chainlist.org.

**Chain details:**
- Chain ID: 8472
- Native currency: MRT (MyrxWallet Token), 18 decimals
- RPC: https://rpc.myrxwallet.io
- Explorer: https://explorer.myrxwallet.io (EIP3091 standard)
- Features: EIP155, EIP1559
- Short name: myrx

**About:**
MyrxWallet Network is a healthcare-focused EVM-compatible blockchain powering the MyrxWallet platform — prescription management, pharmacy benefits, and DeFi health savings. Native DEX (MyrxSwap) is live on-chain.

**Validation:**
- Chain ID 8472 is unique and not in conflict with any existing entry
- RPC endpoint is live and responding
- Explorer is live at https://explorer.myrxwallet.io

Reference: https://myrxwallet.io
