### PR TITLE
Add MyrxWallet Network (Chain 8472)

### DIFF
--- a/_data/chains/eip155/8472.json
+++ b/_data/chains/eip155/8472.json
@@ -1,0 +1,36 @@
+{
+  "name": "MyrxWallet Network",
+  "chain": "MYRX",
+  "icon": "myrxwallet",
+  "rpc": [
+    "https://rpc.myrxwallet.io"
+  ],
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
+    }
+  ],
+  "faucets": [
+    "https://swap.myrxwallet.io/get-mrt/"
+  ],
+  "nativeCurrency": {
+    "name": "MyRx Token",
+    "symbol": "MRT",
+    "decimals": 18
+  },
+  "infoURL": "https://myrxwallet.io",
+  "shortName": "myrx",
+  "chainId": 8472,
+  "networkId": 8472,
+  "slip44": 60,
+  "explorers": [
+    {
+      "name": "MyrxExplorer",
+      "url": "https://explorer.myrxwallet.io",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
## Add MyrxWallet Network (Chain 8472)

- **Chain ID**: 8472
- **Short Name**: myrx
- **Native Currency**: MRT (MyRx Token, 18 decimals)
- **RPC**: https://rpc.myrxwallet.io
- **Explorer**: https://explorer.myrxwallet.io (EIP-3091 standard)
- **Network Type**: EVM-compatible mainnet (Reth + Geth)
- **DEX**: MyrxSwap (Uniswap V2 fork) at https://swap.myrxwallet.io

### Platform
MyRxWallet Network is a HIPAA-compliant healthcare blockchain purpose-built for EHR integration, DeFi healthcare financing, and tokenized health benefits. Live since May 2026.

File location: 