### PR TITLE
Add MyRx Network (chainId 8472)

### DIFF
--- a/_data/chains/eip155-8472.json
+++ b/_data/chains/eip155-8472.json
@@ -1,10 +1,7 @@
 {
   "name": "MyRx Network",
   "chain": "MRT",
-  "rpc": [
-    "https://rpc.myrxwallet.io",
-    "wss://rpc.myrxwallet.io"
-  ],
+  "rpc": ["https://rpc.myrxwallet.io", "wss://rpc.myrxwallet.io"],
   "faucets": [],
   "nativeCurrency": {
     "name": "MyRx Token",

--- a/_data/chains/eip155-8472.json
+++ b/_data/chains/eip155-8472.json
@@ -1,28 +1,23 @@
 {
-  "name": "MyrxWallet Network",
-  "chain": "MYRX",
-  "rpc": ["https://rpc.myrxwallet.io"],
-  "features": [
-    {
-      "name": "EIP155"
-    },
-    {
-      "name": "EIP1559"
-    }
+  "name": "MyRx Network",
+  "chain": "MRT",
+  "rpc": [
+    "https://rpc.myrxwallet.io",
+    "wss://rpc.myrxwallet.io"
   ],
   "faucets": [],
   "nativeCurrency": {
-    "name": "MRT",
+    "name": "MyRx Token",
     "symbol": "MRT",
     "decimals": 18
   },
   "infoURL": "https://myrxwallet.io",
-  "shortName": "myrx",
+  "shortName": "mrt",
   "chainId": 8472,
   "networkId": 8472,
   "explorers": [
     {
-      "name": "MyrxWallet Explorer",
+      "name": "MyRx Explorer",
       "url": "https://explorer.myrxwallet.io",
       "standard": "EIP3091"
     }


### PR DESCRIPTION
## Summary

Adds MyRx Network to the chain registry.

- **Chain ID:** 8472
- **Network ID:** 8472
- **Native currency:** MRT (MyRx Token, 18 decimals)
- **RPC:** https://rpc.myrxwallet.io
- **Explorer:** https://explorer.myrxwallet.io (Blockscout v6.10.0)
- **Info URL:** https://myrxwallet.io

MyRx Network is a healthcare-focused EVM-compatible PoA blockchain built on reth, powering the MyRxWallet platform.