### PR TITLE
Add AEREDIUM Testnet (chainId 1237)

### DIFF
--- a/_data/chains/eip155-1237.json
+++ b/_data/chains/eip155-1237.json
@@ -2,8 +2,8 @@
   "name": "AEREDIUM Testnet",
   "title": "AEREDIUM Testnet",
   "chain": "AER",
-  "rpc": ["https://testnet.aeredium.io"],
-  "faucets": [],
+  "rpc": ["https://testnet.rpc.aeredium.io"],
+  "faucets": ["https://aeredium.io/faucet.html"],
   "nativeCurrency": {
     "name": "Testnet AER",
     "symbol": "tAER",
@@ -19,7 +19,7 @@
   "explorers": [
     {
       "name": "AEREDIUM Testnet Explorer",
-      "url": "https://testnet-explorer.aeredium.io",
+      "url": "https://testnet.explorer.aeredium.io",
       "standard": "EIP3091"
     }
   ]

--- a/_data/chains/eip155-1237.json
+++ b/_data/chains/eip155-1237.json
@@ -1,0 +1,26 @@
+{
+  "name": "AEREDIUM Testnet",
+  "title": "AEREDIUM Testnet",
+  "chain": "AER",
+  "rpc": ["https://testnet.aeredium.io"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Testnet AER",
+    "symbol": "tAER",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://aeredium.io",
+  "shortName": "aer-testnet",
+  "chainId": 1237,
+  "networkId": 1237,
+  "slip44": 1,
+  "icon": "aeredium",
+  "explorers": [
+    {
+      "name": "AEREDIUM Testnet Explorer",
+      "url": "https://testnet-explorer.aeredium.io",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
## Add AEREDIUM Testnet

AEREDIUM Testnet is the public test network for the AEREDIUM L1, an EVM-compatible chain built on TEE-BFT consensus. Companion to the mainnet registration in #8232.

### Chain details

| Field | Value |
|---|---|
| Chain name | AEREDIUM Testnet |
| Chain ID | 1237 |
| Network ID | 1237 |
| Short name | aer-testnet |
| Native currency | tAER (18 decimals) |
| RPC | https://testnet.aeredium.io |
| Explorer | https://testnet-explorer.aeredium.io (EIP-3091) |
| Info URL | https://aeredium.io |
| SLIP-44 | 1 (standard testnet coin type) |
| Features | EIP-155, EIP-1559 |

### Notes

- Chain ID 1237 was chosen as `1` (testnet prefix) + `237` (mainnet chain ID, registered in #8232).
- Icon reuses the `aeredium` icon registered in the mainnet PR.

### Checklist

- [x] Chain ID is not already used
- [x] shortName is unique
- [x] Explorer URL provided and EIP-3091 compatible
- [x] Prettier-formatted
