### PR TITLE
Reserve chainIds 944 (ZIGChain mainnet) and 2061 (ZIGChain testnet)

### DIFF
--- a/_data/chains/eip155-2061.json
+++ b/_data/chains/eip155-2061.json
@@ -1,0 +1,16 @@
+{
+  "name": "ZIGChain Testnet",
+  "chain": "ZIG",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "ZIG",
+    "symbol": "ZIG",
+    "decimals": 18
+  },
+  "infoURL": "https://zigchain.com/",
+  "shortName": "zigchain-testnet",
+  "chainId": 2061,
+  "networkId": 2061,
+  "status": "incubating"
+}

--- a/_data/chains/eip155-944.json
+++ b/_data/chains/eip155-944.json
@@ -1,0 +1,16 @@
+{
+  "name": "ZIGChain",
+  "chain": "ZIG",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "ZIG",
+    "symbol": "ZIG",
+    "decimals": 18
+  },
+  "infoURL": "https://zigchain.com/",
+  "shortName": "zigchain",
+  "chainId": 944,
+  "networkId": 944,
+  "status": "incubating"
+}


### PR DESCRIPTION
Adds two EVM chain entries for ZIGChain, currently in the status: "incubating" + empty rpc[] shape to reserve the chainIds while the EVM JSON-RPC service is being enabled on validator nodes.

Follows the same pattern as eip155-152 Redbelly Devnet (and several others — Kotti, Morden, ELA-DID-Sidechain mainnet/testnet, Factory 127).

- ZIGChain — chainId 944, shortName zigchain, status incubating
- ZIGChain Testnet — chainId 2061, shortName zigchain-testnet, status incubating

Once the EVM JSON-RPC + an EVM-aware block explorer are deployed on validator nodes (per the Cosmos EVM docs, [json-rpc] enable = true in app.toml), we'll open a follow-up PR to populate rpc[] and explorers[].