### PR TITLE
Update 0G Mainnet (16661) and 0G Galileo Testnet (16602) metadata

### DIFF
--- a/_data/chains/eip155-16602.json
+++ b/_data/chains/eip155-16602.json
@@ -1,21 +1,26 @@
 {
-  "name": "0G-Testnet-Galileo",
-  "chain": "0G-Testnet",
+  "name": "0G Galileo Testnet",
+  "chain": "0G",
   "rpc": ["https://evmrpc-testnet.0g.ai"],
-  "faucets": ["https://faucet.0g.ai"],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "faucets": [
+    "https://faucet.0g.ai",
+    "https://cloud.google.com/application/web3/faucet/0g/galileo"
+  ],
   "nativeCurrency": {
     "name": "0G",
     "symbol": "0G",
     "decimals": 18
   },
   "infoURL": "https://0g.ai",
-  "shortName": "0g-testnet-galileo",
+  "shortName": "0g-galileo-testnet",
   "chainId": 16602,
   "networkId": 16602,
+  "slip44": 1,
   "icon": "0g",
   "explorers": [
     {
-      "name": "0G BlockChain Explorer",
+      "name": "0G Chainscan",
       "url": "https://chainscan-galileo.0g.ai",
       "standard": "EIP3091"
     }

--- a/_data/chains/eip155-16661.json
+++ b/_data/chains/eip155-16661.json
@@ -2,6 +2,7 @@
   "name": "0G Mainnet",
   "chain": "0G",
   "rpc": ["https://evmrpc.0g.ai"],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "faucets": [],
   "nativeCurrency": {
     "name": "0G",
@@ -15,7 +16,7 @@
   "icon": "0g",
   "explorers": [
     {
-      "name": "0G BlockChain Explorer",
+      "name": "0G Chainscan",
       "url": "https://chainscan.0g.ai",
       "standard": "EIP3091"
     }


### PR DESCRIPTION
## Summary

Cleanup pass on the two active 0G chain entries — naming standardization, missing fields, and explorer name fix. No new chains; no breaking changes to chainId/networkId.

### `eip155-16661.json` (0G Mainnet)
- Added `features: [EIP155, EIP1559]`.
- Renamed explorer `"0G BlockChain Explorer"` → `"0G Chainscan"` (matches branding; `chainscan.0g.ai` confirmed EIP-3091 compliant).

### `eip155-16602.json` (0G Galileo Testnet)
- Renamed `"0G-Testnet-Galileo"` → `"0G Galileo Testnet"` (spaces, matches `0G Mainnet` and conventions of Hedera/Monad/BNB/Base entries).
- `chain` aligned from `"0G-Testnet"` → `"0G"` (mainnet and testnet share the same `chain` value, matching Hedera/BSC/Monad).
- Added `features: [EIP155, EIP1559]`.
- Added Google Cloud Web3 faucet (listed in 0G's official docs alongside the existing 0G faucet).
- `shortName`: `"0g-testnet-galileo"` → `"0g-galileo-testnet"` (matches `<short>-testnet` pattern used by `hedera-testnet`, `mon-testnet`).
- Added `slip44: 1` (standardized "all testnets" coin type, matches BSC/Monad/Hedera testnet entries).
- Renamed explorer `"0G BlockChain Explorer"` → `"0G Chainscan"` (`chainscan-galileo.0g.ai` confirmed EIP-3091 compliant).

Deprecated entries `eip155-16600.json` (0G Newton Testnet) and `eip155-16601.json` (deprecated Galileo) were reviewed and left unchanged — they correctly preserve historical naming (`A0GI` symbol, `0gai` icon) per the repo's convention of not editing deprecated chains.