### PR TITLE
Add QuantumBit chain (chainId: 90909)

### DIFF
--- a/_data/chains/eip155-90909.json
+++ b/_data/chains/eip155-90909.json
@@ -1,0 +1,29 @@
+{
+  "name": "QuantumBit",
+  "chain": "QB",
+  "rpc": [
+    "http://134.122.153.31:8545"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "QuantumBit",
+    "symbol": "QB",
+    "decimals": 18
+  },
+  "features": [
+    { "name": "EIP155" },
+    { "name": "EIP1559" }
+  ],
+  "infoURL": "http://134.122.153.31:3000",
+  "shortName": "qb",
+  "chainId": 90909,
+  "networkId": 90909,
+  "icon": "quantumbit",
+  "explorers": [
+    {
+      "name": "QuantumBit Explorer",
+      "url": "http://134.122.153.31:3000",
+      "standard": "none"
+    }
+  ]
+}

--- a/_data/icons/quantumbit.json
+++ b/_data/icons/quantumbit.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmZY4rJ9xXJdP6S1ZuyrHZjM4b2gDrBHV5sCVWRt8dtgkv",
+    "width": 1254,
+    "height": 1254,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
## Summary

- Add QuantumBit (QB) chain with chainId 90909
- RPC: http://134.122.153.31:8545
- Block Explorer: http://134.122.153.31:3000
- Icon uploaded to IPFS: ipfs://QmZY4rJ9xXJdP6S1ZuyrHZjM4b2gDrBHV5sCVWRt8dtgkv

## Chain Details

| Field | Value |
|-------|-------|
| Name | QuantumBit |
| Symbol | QB |
| Chain ID | 90909 |
| Decimals | 18 |
| Features | EIP155, EIP1559 |