### PR TITLE
Add rpcfree.com public RPC for Base

### DIFF
--- a/_data/chains/eip155-8453.json
+++ b/_data/chains/eip155-8453.json
@@ -7,7 +7,8 @@
     "https://base.gateway.tenderly.co",
     "wss://base.gateway.tenderly.co",
     "https://base-rpc.publicnode.com",
-    "wss://base-rpc.publicnode.com"
+    "wss://base-rpc.publicnode.com",
+    "https://rpcfree.com/base-rpc"
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
Adds rpcfree.com public RPC endpoint for Base Mainnet (chain ID 8453).

### Service

- URL: `https://rpcfree.com/base-rpc`
- Operator: Etox (PAPRIKASOFT SRL, Romania)
- No signup, no API key required
- Privacy policy: https://rpcfree.com/privacy

### Verification

Endpoint :

```
    $ curl -X POST https://rpcfree.com/base-rpc \
        -H "Content-Type: application/json" \
        -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
    
    {"jsonrpc":"2.0","id":1,"result":"0x2105"}
```

