### PR TITLE
Add rpcfree.com public RPC for Arbitrum One

### DIFF
--- a/_data/chains/eip155-42161.json
+++ b/_data/chains/eip155-42161.json
@@ -14,7 +14,8 @@
     "https://arb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}",
     "https://arb1.arbitrum.io/rpc",
     "https://arbitrum-one-rpc.publicnode.com",
-    "wss://arbitrum-one-rpc.publicnode.com"
+    "wss://arbitrum-one-rpc.publicnode.com",
+    "https://rpcfree.com/arbitrum-rpc"
   ],
   "faucets": [],
   "explorers": [


### PR DESCRIPTION
Adds rpcfree.com public RPC endpoint for Arbitrum One (chain ID 42161).

### Service

- URL: `https://rpcfree.com/arbitrum-rpc`
- Operator: Etox (PAPRIKASOFT SRL, Romania)
- No signup, no API key required
- Privacy policy: https://rpcfree.com/privacy

### Verification

Endpoint returns the correct chain ID:

```
    $ curl -X POST https://rpcfree.com/arbitrum-rpc \
        -H "Content-Type: application/json" \
        -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
    
    {"jsonrpc":"2.0","id":1,"result":"0xa4b1"}
```

