### PR TITLE
Add BEXChain (chainId 140586)

### DIFF
--- a/_data/chains/eip155-140586.json
+++ b/_data/chains/eip155-140586.json
@@ -1,0 +1,29 @@
+{
+  "name": "BEXChain",
+  "chain": "BEX",
+  "rpc": [
+    "https://rpc.bexchain.com"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "BEX",
+    "symbol": "BEX",
+    "decimals": 18
+  },
+  "infoURL": "https://bexchain.com",
+  "shortName": "bexchain",
+  "chainId": 140586,
+  "networkId": 140586,
+  "slip44": 60,
+  "features": [
+    { "name": "EIP155" },
+    { "name": "EIP1559" }
+  ],
+  "explorers": [
+    {
+      "name": "BEXChain Scan",
+      "url": "https://scan.bexchain.com",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-140586.json
+++ b/_data/chains/eip155-140586.json
@@ -1,9 +1,7 @@
 {
   "name": "BEXChain",
   "chain": "BEX",
-  "rpc": [
-    "https://rpc.bexchain.com"
-  ],
+  "rpc": ["https://rpc.bexchain.com"],
   "faucets": [],
   "nativeCurrency": {
     "name": "BEX",
@@ -15,10 +13,7 @@
   "chainId": 140586,
   "networkId": 140586,
   "slip44": 60,
-  "features": [
-    { "name": "EIP155" },
-    { "name": "EIP1559" }
-  ],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "explorers": [
     {
       "name": "BEXChain Scan",


### PR DESCRIPTION
Adds BEXChain mainnet metadata entry.

- Chain ID: 140586
- Chain Name: BEXChain
- Symbol: BEX
- RPC: https://rpc.bexchain.com
- Explorer: https://scan.bexchain.com
- Info URL: https://bexchain.com

File added:
- _data/chains/eip155-140586.json
