### PR TITLE
Add BlockSurety Chain (chainId 4848)

### DIFF
--- a/_data/chains/eip155-4848.json
+++ b/_data/chains/eip155-4848.json
@@ -1,0 +1,20 @@
+{
+  "name": "BlockSurety",
+  "chain": "BSURE",
+  "rpc": ["https://rpc.blocksurety.net"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "BSURE",
+    "symbol": "BSURE",
+    "decimals": 18
+  },
+  "infoURL": "https://blocksurety.net",
+  "shortName": "bsure",
+  "chainId": 4848,
+  "networkId": 4848,
+  "explorers": [{
+    "name": "BlockSurety Explorer",
+    "url": "https://main.blocksurety.net",
+    "standard": "EIP3091"
+  }]
+}

--- a/_data/chains/eip155-4848.json
+++ b/_data/chains/eip155-4848.json
@@ -14,7 +14,7 @@
   "networkId": 4848,
   "explorers": [{
     "name": "BlockSurety Explorer",
-    "url": "https://main.blocksurety.net",
+    "url": "https://blocksurety.net",
     "standard": "EIP3091"
   }]
 }

--- a/_data/chains/eip155-4848.json
+++ b/_data/chains/eip155-4848.json
@@ -1,20 +1,27 @@
 {
-  "name": "BlockSurety",
+  "name": "BlockSurety Chain",
   "chain": "BSURE",
-  "rpc": ["https://rpc.blocksurety.net"],
+  "rpc": [
+    "https://rpc.blocksurety.net"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "BSURE",
     "symbol": "BSURE",
     "decimals": 18
   },
+  "features": [
+    { "name": "EIP155" }
+  ],
   "infoURL": "https://blocksurety.net",
   "shortName": "bsure",
   "chainId": 4848,
   "networkId": 4848,
-  "explorers": [{
-    "name": "BlockSurety Explorer",
-    "url": "https://blocksurety.net",
-    "standard": "EIP3091"
-  }]
+  "explorers": [
+    {
+      "name": "BlockSurety Explorer",
+      "url": "https://blocksurety.net",
+      "standard": "EIP3091"
+    }
+  ]
 }


### PR DESCRIPTION
Adds a new EVM chain.

name | BlockSurety Chain
shortName | bsure
chain | BSURE
chainId | 4848
networkId | 4848
nativeCurrency | BSURE (BSURE, 18)

Validated structure configuration against repository standard parameters.