### PR TITLE
 Add QuantumBit chain (chainId: 90909)           

### DIFF
--- a/_data/chains/eip155-90909.json
+++ b/_data/chains/eip155-90909.json
@@ -1,19 +1,14 @@
 {
   "name": "QuantumBit",
   "chain": "QB",
-  "rpc": [
-    "https://quantumbit.foo/rpc"
-  ],
+  "rpc": ["https://quantumbit.foo/rpc"],
   "faucets": [],
   "nativeCurrency": {
     "name": "QuantumBit",
     "symbol": "QB",
     "decimals": 18
   },
-  "features": [
-    { "name": "EIP155" },
-    { "name": "EIP1559" }
-  ],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "infoURL": "https://quantumbit.foo",
   "shortName": "qb",
   "chainId": 90909,

--- a/_data/chains/eip155-90909.json
+++ b/_data/chains/eip155-90909.json
@@ -2,7 +2,7 @@
   "name": "QuantumBit",
   "chain": "QB",
   "rpc": [
-    "http://134.122.153.31:8545"
+    "https://quantumbit.foo/rpc"
   ],
   "faucets": [],
   "nativeCurrency": {
@@ -14,7 +14,7 @@
     { "name": "EIP155" },
     { "name": "EIP1559" }
   ],
-  "infoURL": "http://134.122.153.31:3000",
+  "infoURL": "https://quantumbit.foo",
   "shortName": "qb",
   "chainId": 90909,
   "networkId": 90909,
@@ -22,7 +22,7 @@
   "explorers": [
     {
       "name": "QuantumBit Explorer",
-      "url": "http://134.122.153.31:3000",
+      "url": "https://quantumbit.foo",
       "standard": "none"
     }
   ]

--- a/_data/chains/eip155-90909.json
+++ b/_data/chains/eip155-90909.json
@@ -1,0 +1,29 @@
+{
+  "name": "QuantumBit",
+  "chain": "QB",
+  "rpc": [
+    "http://134.122.153.31:8545"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "QuantumBit",
+    "symbol": "QB",
+    "decimals": 18
+  },
+  "features": [
+    { "name": "EIP155" },
+    { "name": "EIP1559" }
+  ],
+  "infoURL": "http://134.122.153.31:3000",
+  "shortName": "qb",
+  "chainId": 90909,
+  "networkId": 90909,
+  "icon": "quantumbit",
+  "explorers": [
+    {
+      "name": "QuantumBit Explorer",
+      "url": "http://134.122.153.31:3000",
+      "standard": "none"
+    }
+  ]
+}

--- a/_data/icons/quantumbit.json
+++ b/_data/icons/quantumbit.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmZY4rJ9xXJdP6S1ZuyrHZjM4b2gDrBHV5sCVWRt8dtgkv",
+    "width": 1254,
+    "height": 1254,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                         
  - Add QuantumBit (QB) chain with chainId 90909                                                                                                                                                                     
  - RPC: https://quantumbit.foo/rpc                                                                                                                                                                                  
  - Explorer: https://quantumbit.foo                                                                                                                                                                                 
  - Native currency: QuantumBit (QB), 18 decimals                                                                                                                                                                    
  - Features: EIP155, EIP1559                                                                                                                                                                                        
  - Icon uploaded to IPFS        