### PR TITLE
feat: add icon for MyRx Network (Chain 8472)

### DIFF
--- a/_data/chains/eip155-8472.json
+++ b/_data/chains/eip155-8472.json
@@ -1,7 +1,8 @@
 {
-  "name": "MyrxWallet Network",
+  "name": "MyRx Network",
   "chain": "MYRX",
-  "rpc": ["https://rpc.myrxwallet.io"],
+  "icon": "myrx",
+  "rpc": ["https://rpc.myrxwallet.io", "wss://rpc.myrxwallet.io"],
   "features": [
     {
       "name": "EIP155"
@@ -22,7 +23,7 @@
   "networkId": 8472,
   "explorers": [
     {
-      "name": "MyrxWallet Explorer",
+      "name": "MyRx Explorer",
       "url": "https://explorer.myrxwallet.io",
       "standard": "EIP3091"
     }

--- a/_data/icons/myrx.json
+++ b/_data/icons/myrx.json
@@ -1,0 +1,1 @@
+[{"url":"ipfs://Qmf66SX7e9WxY3uUCom6XWEcsYKgFds22pjGV5oD4b4KZv","width":256,"height":256,"format":"png"}]


### PR DESCRIPTION
Adds logo icon for MyRx Network (Chain 8472, MRT).

- Added `_data/icons/myrx.json` pointing to IPFS-pinned PNG (256x256)
- Updated `_data/chains/eip155-8472.json` with `icon: myrx` field and corrected chain name + added WSS RPC endpoint

IPFS CID: `Qmf66SX7e9WxY3uUCom6XWEcsYKgFds22pjGV5oD4b4KZv`