### PR TITLE
Add icon metadata for BEXChain (chainId 140586)

### DIFF
--- a/_data/chains/eip155-140586.json
+++ b/_data/chains/eip155-140586.json
@@ -13,12 +13,20 @@
   "chainId": 140586,
   "networkId": 140586,
   "slip44": 60,
-  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
+    }
+  ],
   "explorers": [
     {
       "name": "BEXChain Scan",
       "url": "https://scan.bexchain.com",
       "standard": "EIP3091"
     }
-  ]
+  ],
+  "icon": "bexchain"
 }

--- a/_data/icons/bexchain.json
+++ b/_data/icons/bexchain.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreiblcantqquxetwvxuj3roy5x4rkokhiddhyisa675pynztbs6okrm",
+    "width": 500,
+    "height": 500,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Adds icon metadata for BEXChain (chainId 140586).

Changes:
- Added `"icon": "bexchain"` to `_data/chains/eip155-140586.json`
- Added `_data/icons/bexchain.json` with IPFS CID:
  - ipfs://bafkreiblcantqquxetwvxuj3roy5x4rkokhiddhyisa675pynztbs6okrm
