### PR TITLE
feat: add icon for Chain 8472 MYRX-MAINNET

### DIFF
--- a/_data/chains/eip155-8472.json
+++ b/_data/chains/eip155-8472.json
@@ -1,6 +1,7 @@
 {
   "name": "MyrxWallet Network",
   "chain": "MYRX",
+  "icon": "myrx",
   "rpc": ["https://rpc.myrxwallet.io"],
   "features": [
     {

--- a/_data/icons/myrx.json
+++ b/_data/icons/myrx.json
@@ -1,0 +1,1 @@
+[{"url":"https://myrxwallet.io/myrx_logo_256.png","width":256,"height":256,"format":"png"}]


### PR DESCRIPTION
## Summary

Adds icon support for Chain 8472 (MYRX-MAINNET / MyrxWallet Network).

### Changes
- Added `_data/icons/myrx.json` with logo URL: `https://myrxwallet.io/myrx_logo_256.png` (256x256 PNG)
- Updated `_data/chains/eip155-8472.json` to reference `"icon": "myrx"`

### Chain Details
- **Name:** MyrxWallet Network
- **Chain ID:** 8472
- **Symbol:** MRT
- **RPC:** https://rpc.myrxwallet.io
- **Explorer:** https://explorer.myrxwallet.io
- **Info URL:** https://myrxwallet.io