### PR TITLE
add Khromosome (chainId 777001)

### DIFF
--- a/_data/chains/eip155-777001.json
+++ b/_data/chains/eip155-777001.json
@@ -21,6 +21,7 @@
   "shortName": "khrome",
   "chainId": 777001,
   "networkId": 777001,
+  "icon": "khromosome",
   "explorers": [
     {
       "name": "Khrome Explorer",

--- a/_data/chains/eip155-777001.json
+++ b/_data/chains/eip155-777001.json
@@ -1,0 +1,31 @@
+{
+  "name": "Khromosome",
+  "chain": "KHROME",
+  "rpc": [
+    "https://rpc.khromosome.xyz",
+    "wss://ws.khromosome.xyz"
+  ],
+  "faucets": [
+    "https://faucet.khromosome.network"
+  ],
+  "nativeCurrency": {
+    "name": "Khrome",
+    "symbol": "KHROME",
+    "decimals": 18
+  },
+  "features": [
+    { "name": "EIP155" },
+    { "name": "EIP1559" }
+  ],
+  "infoURL": "https://khromosome.network",
+  "shortName": "khrome",
+  "chainId": 777001,
+  "networkId": 777001,
+  "explorers": [
+    {
+      "name": "Khrome Explorer",
+      "url": "https://explorer.khromosome.network",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/icons/khromosome.json
+++ b/_data/icons/khromosome.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmZzTs8T4Q1UGkqHALzXbjrT87X58tgnxEQMaBX6HQrSSw",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
## Summary

Adds **Khromosome** — an identity-anchored EVM L1 — at chainId **777001**.

- **Native token:** KHROME (18 decimals)
- **Consensus:** Ethereum PoS (Reth execution + Lighthouse consensus)
- **Block time:** ~12 s
- **Explorer (EIP-3091):** https://explorer.khromosome.network (Otterscan reading the chain directly via `ots_` namespace)
- **Public RPC:** https://rpc.khromosome.xyz and `wss://ws.khromosome.xyz`
- **Faucet:** https://faucet.khromosome.network (10 KHROME + 1000 KDEMO per address, 24 h cooldown)
- **Network site:** https://khromosome.network

## Live checks

```
$ curl -sX POST -H 'content-type: application/json' \
       -d '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}' \
       https://rpc.khromosome.xyz
{"jsonrpc":"2.0","id":1,"result":"0xbdb29"}    # 777001 ✓
```

Explorer EIP-3091 endpoints all return 200 OK:
- `/tx/<hash>` — block-explorer transaction view
- `/block/<n>` — block view
- `/address/<addr>` — address view

## Notes

- Icon will be added in a follow-up PR once the asset is pinned to IPFS.
- Chain ID 777001 is currently unclaimed in `_data/chains/`.
- EIP155 + EIP1559 supported (Reth defaults).