### PR TITLE
fix: rename VALYGO Smart Contract to VALYGO Smartchain, add fallback RPC

### DIFF
--- a/_data/chains/eip155-7771777.json
+++ b/_data/chains/eip155-7771777.json
@@ -1,8 +1,9 @@
 {
-  "name": "VALYGO Smart Contract",
+  "name": "VALYGO Smartchain",
   "chain": "VYO",
   "rpc": [
-    "https://rpc-gw-1.vyoscan.com/ext/bc/2t51dXsuxUvd9teY9TKEJmgxmxMk3CRF88UYTA4HQgjeYZqzSX/rpc"
+    "https://rpc-gw-1.vyoscan.com/ext/bc/2t51dXsuxUvd9teY9TKEJmgxmxMk3CRF88UYTA4HQgjeYZqzSX/rpc",
+    "https://rpc-gw-2.vyoscan.com/ext/bc/2t51dXsuxUvd9teY9TKEJmgxmxMk3CRF88UYTA4HQgjeYZqzSX/rpc"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-7773777.json
+++ b/_data/chains/eip155-7773777.json
@@ -2,7 +2,8 @@
   "name": "VALYGO NFT",
   "chain": "VYO",
   "rpc": [
-    "https://rpc-gw-1.vyoscan.com/ext/bc/2RyzsmGypNQZPby1miwMMV8spTvhgd9qd2peNRzU1mErUQqSSw/rpc"
+    "https://rpc-gw-1.vyoscan.com/ext/bc/2RyzsmGypNQZPby1miwMMV8spTvhgd9qd2peNRzU1mErUQqSSw/rpc",
+    "https://rpc-gw-2.vyoscan.com/ext/bc/2RyzsmGypNQZPby1miwMMV8spTvhgd9qd2peNRzU1mErUQqSSw/rpc"
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
- Rename "VALYGO Smart Contract" to "VALYGO Smartchain" (7771777) — "Smart Contract" describes something deployed on a chain, not the chain itself
- Add rpc-gw-2 as fallback RPC endpoint for both VALYGO chains (7771777, 7773777)