### PR TITLE
BitVault BVM20 chain (chainId 31338)

### DIFF
--- a/_data/chains/eip155-31338.json
+++ b/_data/chains/eip155-31338.json
@@ -1,0 +1,29 @@
+{
+  "name": "BitVault BVM20",
+  "chain": "BVM20",
+  "icon": "bitvault",
+  "rpc": [
+    "https://rpc.bitvault.club"
+  ],
+  "features": [
+    { "name": "EIP155" },
+    { "name": "EIP1559" }
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://bitvault.club",
+  "shortName": "bvm20",
+  "chainId": 31338,
+  "networkId": 31338,
+  "explorers": [
+    {
+      "name": "BitVault Explorer",
+      "url": "https://explorer.bitvault.club",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Add BitVault BVM20 EVM-compatible L2 chain (chainId 31338)

- RPC: https://rpc.bitvault.club
- Explorer: https://explorer.bitvault.club  
- Faucet: https://faucet.bitvault.club
- Native token: BVTW (BitVault Wrapped Token, 18 decimals)
- Chain type: EVM-compatible, Clique PoA