### PR TITLE
Update RANNTA X-Chain native currency decimals to 18

### DIFF
--- a/_data/chains/eip155-13113.json
+++ b/_data/chains/eip155-13113.json
@@ -2,12 +2,12 @@
   "name": "RANNTA X-Chain",
   "chain": "RANNTA",
   "icon": "rannta",
-  "rpc": ["https://rpc.rannta.com/api/rpc"],
+  "rpc": ["https://rpc.rannta.com"],
   "faucets": [],
   "nativeCurrency": {
     "name": "RANNTA Core X",
     "symbol": "RNTX",
-    "decimals": 13
+    "decimals": 18
   },
   "infoURL": "https://rannta.com",
   "shortName": "rntx",


### PR DESCRIPTION
This PR updates the RANNTA X-Chain metadata after the official native RNTX 18-decimal migration.

Changes:
- nativeCurrency.decimals: 13 -> 18
- rpc: https://rpc.rannta.com
- Keeps chain ID 13113 / 0x3339 unchanged
- Keeps native identity unchanged: RANNTA Core X / RNTX / NANTA

Reason:
RANNTA X-Chain migrated native RNTX from 13 decimals to 18 decimals for EVM wallet compatibility. NANTA remains the smallest unit, now scaled as 1 RNTX = 10^18 NANTA.

Verification:
- Public RPC eth_chainId returns 0x3339
- Public RPC eth_getBalance for the treasury returns 0x110f837d8942a518a000000
- Explorer and wallet metadata are updated to 18 decimals