### PR TITLE
Add PLN Network (chainId 411994)

### DIFF
--- a/_data/chains/eip155-411994.json
+++ b/_data/chains/eip155-411994.json
@@ -2,12 +2,8 @@
   "name": "PLN Network",
   "chain": "PLN",
   "icon": "pln",
-  "rpc": [
-    "https://oneagent.uk/rpc"
-  ],
-  "faucets": [
-    "https://oneagent.uk"
-  ],
+  "rpc": ["https://oneagent.uk/rpc"],
+  "faucets": ["https://oneagent.uk"],
   "nativeCurrency": {
     "name": "PLN",
     "symbol": "PLN",

--- a/_data/chains/eip155-411994.json
+++ b/_data/chains/eip155-411994.json
@@ -1,0 +1,27 @@
+{
+  "name": "PLN Network",
+  "chain": "PLN",
+  "icon": "pln",
+  "rpc": [
+    "https://oneagent.uk/rpc"
+  ],
+  "faucets": [
+    "https://oneagent.uk"
+  ],
+  "nativeCurrency": {
+    "name": "PLN",
+    "symbol": "PLN",
+    "decimals": 18
+  },
+  "infoURL": "https://oneagent.uk",
+  "shortName": "pln",
+  "chainId": 411994,
+  "networkId": 411994,
+  "explorers": [
+    {
+      "name": "PLNScan",
+      "url": "https://plnscan.com",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/icons/pln.json
+++ b/_data/icons/pln.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "https://oneagent.uk/pln-icon-512.png",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]

--- a/_data/icons/pln.json
+++ b/_data/icons/pln.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "https://oneagent.uk/pln-icon-512.png",
+    "url": "ipfs://bafkreiabrr7ugnm4og2oe3d7pdgkqohc3nil5cdm5lmgt3htipa7k2gwti",
     "width": 512,
     "height": 512,
     "format": "png"


### PR DESCRIPTION
Add PLN Network, a private EVM-compatible PoA chain with Chain ID 411994. Native currency: PLN (18 decimals). RPC: https://oneagent.uk/rpc. Explorer: https://plnscan.com.