### PR TITLE
Update Sei icon to new brand mark (maroon)

### DIFF
--- a/_data/icons/sei.json
+++ b/_data/icons/sei.json
@@ -1,8 +1,8 @@
 [
   {
-    "url": "ipfs://bafybeierzqumyqtarwehonib2mkvg67lyhdypj4umrw7j667prejlorq7e",
-    "width": 535,
-    "height": 535,
-    "format": "svg"
+    "url": "ipfs://bafkreidctb56i4l27zl5mcxnm4hrzc2z652enprv7kxiozstw32zhcezym",
+    "width": 512,
+    "height": 512,
+    "format": "png"
   }
 ]


### PR DESCRIPTION
## What

Update `_data/icons/sei.json` to point at the new Sei brand mark.

The current entry resolves to `ipfs://bafybeierzqumyqtarwehonib2mkvg67lyhdypj4umrw7j667prejlorq7e`, which is the previous red (`#9E1F19`) Sei wordmark/mark. Sei has rebranded; the new mark is the maroon (`#600014`) symmetric wave glyph distributed at https://brand.sei.io.

This icon is referenced by three Sei chain entries:

- `_data/chains/eip155-1329.json` (Sei Network mainnet, chainId 1329)
- `_data/chains/eip155-1328.json` (Sei Testnet, chainId 1328)
- `_data/chains/eip155-713715.json` (Sei Devnet, chainId 713715, deprecated)

All three reference `"icon": "sei"`, so this single change updates the icon resolved by every Sei chain in this registry.

## Why

The Sei rebrand was announced in https://blog.sei.io/infrastructure-for-the-modern-economy/. The brand portal at https://brand.sei.io is the canonical source for the new mark, color, and lockups. The previous IPFS-pinned asset is now off-brand and inconsistent with how Sei is represented across downstream tools (MetaMask, RainbowKit, viem chains, chainlist.org, etc.) that consume this registry.

## Changes

- `_data/icons/sei.json` — replace IPFS URL with new pin, update `width`/`height` to `512`, update `format` from `"svg"` to `"png"`.
- New asset: 512x512 PNG of the new mark, rendered from the official `sei-mark.svg` filled with brand maroon `#600014` on a white background. File size ~30 KB, well under the 250 KB limit.
- No changes to the three `eip155-*.json` chain files (they continue to reference `"icon": "sei"`).

## Verification

- New PNG is 512x512, format `png`, ~30 KB.
- Dominant non-white pixel color is `rgb(96, 0, 20)` (= `#600014`, the new Sei brand maroon).
- New IPFS CID is publicly resolvable (pin pushed before PR open).

## References

- Sei brand portal: https://brand.sei.io
- Rebrand announcement: https://blog.sei.io/infrastructure-for-the-modern-economy/
