### PR TITLE
Add Gravity Chain (ID: 127001)

### DIFF
--- a/_data/chains/eip155-127001.json
+++ b/_data/chains/eip155-127001.json
@@ -1,0 +1,28 @@
+{
+ "name": "Gravity",
+ "chain": "Gravity",
+ "icon": "gravity",
+ "rpc": ["https://mainnet-rpc.gravity.xyz"],
+ "faucets": [],
+ "nativeCurrency": {
+   "name": "Gravity",
+   "symbol": "G",
+   "decimals": 18
+ },
+ "features": [
+   { "name": "EIP155" },
+   { "name": "EIP1559" }
+ ],
+ "infoURL": "https://gravity.xyz",
+ "shortName": "grav",
+ "chainId": 127001,
+ "networkId": 127001,
+ "explorers": [
+   {
+	 "name": "Gravity Mainnet Explorer",
+	 "url": "https://mainnet-explorer.gravity.xyz",
+	 "standard": "EIP3091"
+   }
+ ]
+}
+

--- a/_data/chains/eip155-127001.json
+++ b/_data/chains/eip155-127001.json
@@ -1,28 +1,24 @@
 {
- "name": "Gravity",
- "chain": "Gravity",
- "icon": "gravity",
- "rpc": ["https://mainnet-rpc.gravity.xyz"],
- "faucets": [],
- "nativeCurrency": {
-   "name": "Gravity",
-   "symbol": "G",
-   "decimals": 18
- },
- "features": [
-   { "name": "EIP155" },
-   { "name": "EIP1559" }
- ],
- "infoURL": "https://gravity.xyz",
- "shortName": "grav",
- "chainId": 127001,
- "networkId": 127001,
- "explorers": [
-   {
-	 "name": "Gravity Mainnet Explorer",
-	 "url": "https://mainnet-explorer.gravity.xyz",
-	 "standard": "EIP3091"
-   }
- ]
+  "name": "Gravity",
+  "chain": "Gravity",
+  "icon": "gravity",
+  "rpc": ["https://mainnet-rpc.gravity.xyz"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Gravity",
+    "symbol": "G",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://gravity.xyz",
+  "shortName": "grav",
+  "chainId": 127001,
+  "networkId": 127001,
+  "explorers": [
+    {
+      "name": "Gravity Mainnet Explorer",
+      "url": "https://mainnet-explorer.gravity.xyz",
+      "standard": "EIP3091"
+    }
+  ]
 }
-


### PR DESCRIPTION
## Add Gravity Chain (Chain ID 127001)

| Field | Value |
|---|---|
| Chain ID | 127001 |
| Name | Gravity |
| Native Currency | Gravity (G), 18 decimals |
| Features | EIP155, EIP1559 |
| Explorer | EIP3091 |
| Short Name | grav |
| Info URL | https://gravity.xyz |

**Files added:**
- `_data/chains/eip155-127001.json`

Gravity is an EVM-compatible L1 blockchain. The L2 chain (Chain ID 1625) is already registered, and L1 reuse the icon of L2(https://github.com/ethereum-lists/chains/blob/master/_data/icons/gravity.json).