### PR TITLE
Replace inactive testnet with TTL Coin (chainId 7777)

### DIFF
--- a/_data/chains/eip155-7777.json
+++ b/_data/chains/eip155-7777.json
@@ -1,29 +1,25 @@
 {
-  "name": "Rise of the Warbots Testnet",
-  "chain": "nmactest",
-  "rpc": [
-    "https://testnet1.riseofthewarbots.com",
-    "https://testnet2.riseofthewarbots.com",
-    "https://testnet3.riseofthewarbots.com",
-    "https://testnet4.riseofthewarbots.com",
-    "https://testnet5.riseofthewarbots.com"
-  ],
+  "name": "TTL Coin",
+  "chain": "TTL",
+  "icon": "ttl",
+  "rpc": ["https://rpc.ttl1.top"],
   "faucets": [],
   "nativeCurrency": {
-    "name": "Nano Machines",
-    "symbol": "NMAC",
+    "name": "TTL Coin",
+    "symbol": "TTL",
     "decimals": 18
   },
-  "infoURL": "https://riseofthewarbots.com/",
-  "shortName": "RiseOfTheWarbotsTestnet",
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://github.com/okneo31/ttlcoin",
+  "shortName": "ttl",
   "chainId": 7777,
   "networkId": 7777,
-  "slip44": 1,
   "explorers": [
     {
-      "name": "avascan",
-      "url": "https://testnet.avascan.info/blockchain/2mZ9doojfwHzXN3VXDQELKnKyZYxv7833U8Yq5eTfFx3hxJtiy",
+      "name": "TTL Scan",
+      "url": "https://scan.ttl1.top",
       "standard": "none"
     }
-  ]
+  ],
+  "status": "active"
 }

--- a/_data/chains/eip155-7777.json
+++ b/_data/chains/eip155-7777.json
@@ -21,5 +21,6 @@
       "standard": "none"
     }
   ],
+  "redFlags": ["reusedChainId"],
   "status": "active"
 }

--- a/_data/icons/ttl.json
+++ b/_data/icons/ttl.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafybeiftd5f7es2zppt73upvu6qu5a45eyy54orrnssodls7f5z5z4lvh4",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
## Summary

Replace the inactive **Rise of the Warbots Testnet** entry (chainId 7777) with **TTL Coin**, an active mainnet.

### Why replace?

- All 5 RPC endpoints of Rise of the Warbots Testnet (`testnet1-5.riseofthewarbots.com`) are **unreachable/down**
- Their explorer link on avascan is also non-functional
- The previous entry was a **testnet** (`slip44: 1`), not a mainnet

### TTL Coin details

| Field | Value |
|-------|-------|
| **Name** | TTL Coin |
| **Symbol** | TTL |
| **Chain ID** | 7777 |
| **RPC** | https://rpc.ttl1.top |
| **WebSocket** | wss://ws.ttl1.top |
| **Explorer** | https://scan.ttl1.top |
| **Block Time** | 5 seconds |
| **Consensus** | PoA (Parlia/BSC fork) |
| **Status** | Active mainnet, producing blocks |
| **Source** | https://github.com/okneo31/ttlcoin |

### Changes

- `_data/chains/eip155-7777.json` — replaced chain entry
- `_data/icons/ttl.json` — added TTL icon (IPFS: `bafybeiftd5f7es2zppt73upvu6qu5a45eyy54orrnssodls7f5z5z4lvh4`)

### Verification

You can verify TTL Coin is active:
```bash
curl -s -X POST https://rpc.ttl1.top -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
```