### PR TITLE
Add Mantle Hoodi Testnet (50002)

### DIFF
--- a/_data/chains/eip155-50002.json
+++ b/_data/chains/eip155-50002.json
@@ -1,0 +1,23 @@
+{
+  "name": "Mantle Hoodi Testnet",
+  "chain": "ETH",
+  "rpc": ["https://rpc.hoodi.mantle.xyz"],
+  "faucets": ["https://faucet.hoodi.mantle.xyz"],
+  "nativeCurrency": {
+    "name": "Hoodi Mantle",
+    "symbol": "MNT",
+    "decimals": 18
+  },
+  "infoURL": "https://mantle.xyz",
+  "shortName": "mnt-hoodi",
+  "chainId": 50002,
+  "networkId": 50002,
+  "slip44": 1,
+  "explorers": [
+    {
+      "name": "blockscout",
+      "url": "https://explorer.hoodi.mantle.xyz",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-50002.json
+++ b/_data/chains/eip155-50002.json
@@ -2,7 +2,7 @@
   "name": "Mantle Hoodi Testnet",
   "chain": "ETH",
   "rpc": ["https://rpc.hoodi.mantle.xyz"],
-  "faucets": ["https://faucet.hoodi.mantle.xyz"],
+  "faucets": ["https://faucet.sepolia.mantle.xyz"],
   "nativeCurrency": {
     "name": "Hoodi Mantle",
     "symbol": "MNT",

--- a/_data/chains/eip155-50002.json
+++ b/_data/chains/eip155-50002.json
@@ -2,7 +2,7 @@
   "name": "Mantle Hoodi Testnet",
   "chain": "ETH",
   "rpc": ["https://rpc.hoodi.mantle.xyz"],
-  "faucets": ["https://faucet.sepolia.mantle.xyz"],
+  "faucets": ["https://faucet.mantle.xyz"],
   "nativeCurrency": {
     "name": "Hoodi Mantle",
     "symbol": "MNT",


### PR DESCRIPTION
Adds the Mantle Hoodi Testnet (chainId 50002), a new Mantle L2 testnet running on top of Ethereum's Hoodi testnet.

- **chainId / networkId**: 50002
- **shortName**: `mnt-hoodi`
- **slip44**: 1 (testnet)
- **Native currency**: MNT (18 decimals)
- **RPC**: https://rpc.hoodi.mantle.xyz
- **Faucet**: https://faucet.mantle.xyz
- **Explorer**: https://explorer.hoodi.mantle.xyz (blockscout, EIP-3091)

### Checklist
- [x] chainId is unused in `_data/chains/`
- [x] shortName `mnt-hoodi` is unique across the repository
- [x] Explorer adheres to EIP-3091
- [x] Testnet flagged with `slip44: 1`