### PR TITLE
Add HIPERCAPITAL FINANCE Chain configuration

### DIFF
--- a/_data/chains/eip155-240884.json
+++ b/_data/chains/eip155-240884.json
@@ -1,0 +1,27 @@
+{
+  "name": "HIPERCAPITAL FINANCE Chain",
+  "chain": "HIPCF",
+  "rpc": [
+    "https://rpc.hipercapitalfinance.com"
+  ],
+  "features": [
+    { "name": "EIP155" }
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "HIPERCAPITAL FINANCE Token",
+    "symbol": "HIP",
+    "decimals": 18
+  },
+  "infoURL": "https://hipercapitalfinance.com",
+  "shortName": "hipcf",
+  "chainId": 240884,
+  "networkId": 240884,
+  "explorers": [
+    {
+      "name": "HIPERCAPITAL FINANCE Explorer",
+      "url": "https://explorer.hipercapitalfinance.com",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-240884.json
+++ b/_data/chains/eip155-240884.json
@@ -1,12 +1,8 @@
 {
   "name": "HIPERCAPITAL FINANCE Chain",
   "chain": "HIPCF",
-  "rpc": [
-    "https://rpc.hipercapitalfinance.com"
-  ],
-  "features": [
-    { "name": "EIP155" }
-  ],
+  "rpc": ["https://rpc.hipercapitalfinance.com"],
+  "features": [{ "name": "EIP155" }],
   "faucets": [],
   "nativeCurrency": {
     "name": "HIPERCAPITAL FINANCE Token",


### PR DESCRIPTION
Adding HIPERCAPITAL FINANCE Chain to the registry.
  
  - Name: HIPERCAPITAL FINANCE Chain
  - Short name: hipcf
  - Chain ID: 240884
  - Native currency: HIP (HIPERCAPITAL FINANCE Token)
  - RPC: https://rpc.hipercapitalfinance.com
  - Explorer: https://explorer.hipercapitalfinance.com (EIP-3091 compatible)
  - Consensus: Geth Clique PoA
  - Operator: HIPERCAPITAL FINANCE — institutional sovereign blockchain
  - Status: Production, over 1,000,000 blocks produced
  
  Verifications:
  - [x] RPC responds to eth_chainId returning 0x3acf4 (240884)
  - [x] Explorer is EIP-3091 compliant
  - [x] Chain ID 240884 is not registered yet