### PR TITLE
Add LadyChain (eip155-589)

### DIFF
--- a/_data/chains/eip155-589.json
+++ b/_data/chains/eip155-589.json
@@ -1,0 +1,24 @@
+{
+  "name": "LadyChain",
+  "chain": "LADY",
+  "rpc": [
+    "https://ladyrpc.us/rpc"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Lady",
+    "symbol": "LADY",
+    "decimals": 18
+  },
+  "infoURL": "https://ladyswap.us",
+  "shortName": "lady",
+  "chainId": 589,
+  "networkId": 589,
+  "explorers": [
+    {
+      "name": "LadyScan",
+      "url": "https://ladyscan.us",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-589.json
+++ b/_data/chains/eip155-589.json
@@ -2,9 +2,7 @@
   "name": "LadyChain",
   "chain": "LADY",
   "icon": "lady",
-  "rpc": [
-    "https://ladyrpc.us/rpc"
-  ],
+  "rpc": ["https://ladyrpc.us/rpc"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Lady",

--- a/_data/chains/eip155-589.json
+++ b/_data/chains/eip155-589.json
@@ -1,6 +1,7 @@
 {
   "name": "LadyChain",
   "chain": "LADY",
+  "icon": "lady",
   "rpc": [
     "https://ladyrpc.us/rpc"
   ],

--- a/_data/icons/lady.json
+++ b/_data/icons/lady.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "ipfs://QmSeW4eB8NRrBaBfk4dEfmWztX2EJ41d52ZHQf7xEn2UeG",
+    "url": "ipfs://QmWcjr13L8Meo6XcokKAFH8TAn7cEdwQb7Qcva1bjZnVLh",
     "width": 640,
     "height": 640,
     "format": "png"

--- a/_data/icons/lady.json
+++ b/_data/icons/lady.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmSeW4eB8NRrBaBfk4dEfmWztX2EJ41d52ZHQf7xEn2UeG",
+    "width": 640,
+    "height": 640,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
## Add LadyChain (chainId 589)

Adds the LadyChain network to the registry.

- **Name:** LadyChain
- **Chain ID / Network ID:** 589
- **Native currency:** LADY (18 decimals)
- **RPC:** https://ladyrpc.us/rpc (live, HTTPS, returns `0x24d`)
- **Explorer:** https://ladyscan.us (EIP-3091)

Verified that chainId 589, networkId 589 and shortName `lady` are not already in use.