### PR TITLE
Add Azul RPC for Base (chainId 8453)

### DIFF
--- a/_data/chains/eip155-8453.json
+++ b/_data/chains/eip155-8453.json
@@ -8,7 +8,8 @@
     "wss://base.gateway.tenderly.co",
     "https://base-rpc.publicnode.com",
     "wss://base-rpc.publicnode.com",
-    "https://rpcfree.com/base-rpc"
+    "https://rpcfree.com/base-rpc",
+    "https://rpc.baseazul.dev"
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
Adding [Azul](https://baseazul.dev) — a free, no-signup public RPC for Base mainnet.

- **Endpoint:** `https://rpc.baseazul.dev`
- **chainId verified:** returns `0x2105` ✓
- **Tip parity with `mainnet.base.org`:** delta 0 blocks at submission ✓
- **HTTPS + valid cert:** ✓
- **CORS:** `Access-Control-Allow-Origin: *` (POST + OPTIONS allowed) ✓
- **Region:** us-east-1 (Virginia)
- **Privacy:** does not log IPs, request bodies, wallet addresses, or any user-identifiable data — full statement at https://baseazul.dev/privacy

One-line addition to the end of the `rpc` array, matching the existing convention (plain HTTPS string).