### PR TITLE
Add Citrate (eip155-40204)

### DIFF
--- a/_data/chains/eip155-40204.json
+++ b/_data/chains/eip155-40204.json
@@ -1,0 +1,16 @@
+{
+  "name": "Citrate",
+  "chain": "CITRATE",
+  "rpc": ["https://rpc.citrate.ai", "wss://rpc.citrate.ai"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "SALT",
+    "symbol": "SALT",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://citrate.ai",
+  "shortName": "citrate",
+  "chainId": 40204,
+  "networkId": 40204
+}


### PR DESCRIPTION
Adds the Citrate network.

| Field | Value |
|---|---|
| name | Citrate |
| chainId / networkId | 40204 (`0x9d0c`) |
| shortName | citrate |
| native currency | SALT (18 decimals) |
| RPC | https://rpc.citrate.ai (+ wss://rpc.citrate.ai) |
| infoURL | https://citrate.ai |

Citrate is an AI-native / DePIN compute EVM network. The public RPC is live:

```
$ curl -s https://rpc.citrate.ai -H 'content-type: application/json' \
    -d '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}'
{"jsonrpc":"2.0","result":"0x9d0c","id":1}
```

`net_version` returns `40204`; `web3_clientVersion` returns `citrate/v0.1.0`. chainId 40204 is unclaimed in the registry. Block explorer (explorer.citrate.ai) will be added in a follow-up PR once public.