### PR TITLE
Add ACME stealth testnet (chainId 355)

### DIFF
--- a/_data/chains/eip155-355.json
+++ b/_data/chains/eip155-355.json
@@ -1,0 +1,16 @@
+{
+  "name": "ACME stealth testnet",
+  "chain": "AST",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "",
+  "shortName": "acme-testnet",
+  "chainId": 355,
+  "networkId": 355,
+  "explorers": []
+}


### PR DESCRIPTION
Adds a new EVM chain.

| Field | Value |
|---|---|
| name | ACME stealth testnet |
| shortName | acme-testnet |
| chain | AST |
| chainId | 355 |
| networkId | 355 |
| nativeCurrency | ETH (Ether, 18) |

Validated locally with `./gradlew run` → BUILD SUCCESSFUL, and formatted with Prettier.

Note: `rpc` and `infoURL` are intentionally empty/minimal for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)