### PR TITLE
Add ACME Mainnet Stealth (chainId 8224)

### DIFF
--- a/_data/chains/eip155-8224.json
+++ b/_data/chains/eip155-8224.json
@@ -1,0 +1,16 @@
+{
+  "name": "ACME Mainnet Stealth",
+  "chain": "ASM",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "",
+  "shortName": "acme-mainnet",
+  "chainId": 8224,
+  "networkId": 8224,
+  "explorers": []
+}


### PR DESCRIPTION
Adds a new EVM chain.

| Field | Value |
|---|---|
| name | ACME Mainnet Stealth |
| chain | ASM |
| shortName | acme-mainnet |
| chainId | 8224 |
| networkId | 8224 |
| nativeCurrency | ETH (Ether, 18) |

Validated locally with `./gradlew run` → BUILD SUCCESSFUL, and Prettier clean.

Note: `rpc` and `infoURL` are intentionally empty/minimal for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)