### PR TITLE
fix: Update MANTRA Chain native currency symbol to MANTRA (chainId 5888)

### DIFF
--- a/_data/chains/eip155-5888.json
+++ b/_data/chains/eip155-5888.json
@@ -1,24 +1,24 @@
 {
-  "name": "MANTRACHAIN Mainnet",
-  "chain": "MANTRACHAIN",
+  "name": "MANTRA Chain",
+  "chain": "MANTRA",
   "rpc": ["https://evm.mantrachain.io", "wss://evm.mantrachain.io/ws"],
   "faucets": [],
   "nativeCurrency": {
-    "name": "OM",
-    "symbol": "OM",
+    "name": "MANTRA",
+    "symbol": "MANTRA",
     "decimals": 18
   },
   "infoURL": "https://mantrachain.io",
-  "shortName": "mantrachain",
+  "shortName": "mantra",
   "chainId": 5888,
   "networkId": 5888,
   "slip44": 1,
   "icon": "om",
   "explorers": [
     {
-      "name": "MANTRACHAIN Explorer",
-      "url": "http://mantrascan.io",
-      "standard": "none",
+      "name": "MANTRA Explorer",
+      "url": "https://blockscout.mantrascan.io",
+      "standard": "EIP3091",
       "icon": "om"
     }
   ]


### PR DESCRIPTION
## Summary

Updates the MANTRA Chain (chainId 5888) entry to correct outdated values following the OM → MANTRA token redenomination.

## Changes

| Field | Before | After |
|-------|--------|-------|
| `name` | MANTRACHAIN Mainnet | MANTRA Chain |
| `chain` | MANTRACHAIN | MANTRA |
| `nativeCurrency.name` | OM | MANTRA |
| `nativeCurrency.symbol` | OM | MANTRA |
| `shortName` | mantrachain | mantra |
| `explorers[0].name` | MANTRACHAIN Explorer | MANTRA Explorer |
| `explorers[0].url` | http://mantrascan.io | https://blockscout.mantrascan.io |
| `explorers[0].standard` | none | EIP3091 |

## Context

- The native token was redenominated from **OM** to **MANTRA** 
- The chain name should be "MANTRA Chain" (with a space), not "MANTRACHAIN"
- The explorer URL has been updated to the current Blockscout instance with HTTPS
- This affects how the chain appears on Chainlist.org and downstream wallets

## References

- Official docs: https://docs.mantrachain.io
- Explorer: https://blockscout.mantrascan.io
- Website: https://mantrachain.io
- Cosmos chain-registry: https://github.com/cosmos/chain-registry/tree/master/mantrachain