### PR TITLE
Add Tea Mainnet (Chain ID 6122) and update RPC for Tea Sepolia (Chain ID 10218)

### DIFF
--- a/_data/chains/eip155-10218.json
+++ b/_data/chains/eip155-10218.json
@@ -3,12 +3,6 @@
   "chain": "ETH",
   "rpc": ["https://tea-sepolia.g.alchemy.com/public"],
   "faucets": ["https://faucet-sepolia.tea.xyz"],
-  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
-  "nativeCurrency": { "name": "Sepolia Tea", "symbol": "TEA", "decimals": 18 },
-  "infoURL": "https://tea.xyz",
-  "shortName": "teasep",
-  "chainId": 10218,
-  "networkId": 10218,
   "explorers": [
     {
       "name": "blockscout",
@@ -17,6 +11,18 @@
       "standard": "EIP3091"
     }
   ],
-  "parent": { "type": "L2", "chain": "eip155-11155111" },
+  "nativeCurrency": {
+    "name": "Sepolia Tea",
+    "symbol": "TEA",
+    "decimals": 18
+  },
+  "infoURL": "https://tea.xyz",
+  "shortName": "teasep",
+  "chainId": 10218,
+  "networkId": 10218,
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-11155111"
+  },
   "status": "active"
 }

--- a/_data/chains/eip155-10218.json
+++ b/_data/chains/eip155-10218.json
@@ -3,13 +3,20 @@
   "chain": "ETH",
   "rpc": ["https://tea-sepolia.g.alchemy.com/public"],
   "faucets": ["https://faucet-sepolia.tea.xyz"],
-  "features": [{"name": "EIP155"}, {"name": "EIP1559"}],
-  "nativeCurrency": {"name": "Sepolia Tea", "symbol": "TEA", "decimals": 18},
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "nativeCurrency": { "name": "Sepolia Tea", "symbol": "TEA", "decimals": 18 },
   "infoURL": "https://tea.xyz",
   "shortName": "teasep",
   "chainId": 10218,
   "networkId": 10218,
-  "explorers": [{"name": "blockscout", "url": "https://sepolia.tea.xyz", "icon": "blockscout", "standard": "EIP3091"}],
-  "parent": {"type": "L2", "chain": "eip155-11155111"},
+  "explorers": [
+    {
+      "name": "blockscout",
+      "url": "https://sepolia.tea.xyz",
+      "icon": "blockscout",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": { "type": "L2", "chain": "eip155-11155111" },
   "status": "active"
 }

--- a/_data/chains/eip155-10218.json
+++ b/_data/chains/eip155-10218.json
@@ -3,26 +3,13 @@
   "chain": "ETH",
   "rpc": ["https://tea-sepolia.g.alchemy.com/public"],
   "faucets": ["https://faucet-sepolia.tea.xyz"],
-  "explorers": [
-    {
-      "name": "blockscout",
-      "url": "https://sepolia.tea.xyz",
-      "icon": "blockscout",
-      "standard": "EIP3091"
-    }
-  ],
-  "nativeCurrency": {
-    "name": "Sepolia Tea",
-    "symbol": "TEA",
-    "decimals": 18
-  },
+  "features": [{"name": "EIP155"}, {"name": "EIP1559"}],
+  "nativeCurrency": {"name": "Sepolia Tea", "symbol": "TEA", "decimals": 18},
   "infoURL": "https://tea.xyz",
   "shortName": "teasep",
   "chainId": 10218,
   "networkId": 10218,
-  "parent": {
-    "type": "L2",
-    "chain": "eip155-11155111"
-  },
+  "explorers": [{"name": "blockscout", "url": "https://sepolia.tea.xyz", "icon": "blockscout", "standard": "EIP3091"}],
+  "parent": {"type": "L2", "chain": "eip155-11155111"},
   "status": "active"
 }

--- a/_data/chains/eip155-6122.json
+++ b/_data/chains/eip155-6122.json
@@ -3,7 +3,6 @@
   "chain": "TEA",
   "rpc": ["https://rpc.tea.xyz"],
   "faucets": [],
-  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "nativeCurrency": { "name": "Tea", "symbol": "TEA", "decimals": 18 },
   "infoURL": "https://tea.xyz",
   "shortName": "tea",

--- a/_data/chains/eip155-6122.json
+++ b/_data/chains/eip155-6122.json
@@ -1,7 +1,7 @@
 {
   "name": "Tea Mainnet",
   "chain": "TEA",
-  "rpc": ["https://rpc.tea.xyz"],
+  "rpc": ["https://rpc.tea.xyz", "https://tea.drpc.org"],
   "faucets": [],
   "nativeCurrency": { "name": "Tea", "symbol": "TEA", "decimals": 18 },
   "infoURL": "https://tea.xyz",

--- a/_data/chains/eip155-6122.json
+++ b/_data/chains/eip155-6122.json
@@ -7,6 +7,7 @@
   "nativeCurrency": {"name": "Tea", "symbol": "TEA", "decimals": 18},
   "infoURL": "https://tea.xyz",
   "shortName": "tea",
+  "icon": "tea",
   "chainId": 6122,
   "networkId": 6122,
   "explorers": [{"name": "blockscout", "url": "https://scout.tea.xyz", "icon": "blockscout", "standard": "EIP3091"}],

--- a/_data/chains/eip155-6122.json
+++ b/_data/chains/eip155-6122.json
@@ -1,20 +1,15 @@
 {
   "name": "Tea Mainnet",
   "chain": "TEA",
-  "rpc": [],
+  "rpc": ["https://rpc.tea.xyz"],
   "faucets": [],
-  "nativeCurrency": {
-    "name": "Tea",
-    "symbol": "TEA",
-    "decimals": 18
-  },
+  "features": [{"name": "EIP155"}, {"name": "EIP1559"}],
+  "nativeCurrency": {"name": "Tea", "symbol": "TEA", "decimals": 18},
   "infoURL": "https://tea.xyz",
   "shortName": "tea",
   "chainId": 6122,
   "networkId": 6122,
-  "parent": {
-    "type": "L2",
-    "chain": "eip155-1"
-  },
-  "status": "incubating"
+  "explorers": [{"name": "blockscout", "url": "https://scout.tea.xyz", "icon": "blockscout", "standard": "EIP3091"}],
+  "parent": {"type": "L2", "chain": "eip155-1"},
+  "status": "active"
 }

--- a/_data/chains/eip155-6122.json
+++ b/_data/chains/eip155-6122.json
@@ -3,14 +3,21 @@
   "chain": "TEA",
   "rpc": ["https://rpc.tea.xyz"],
   "faucets": [],
-  "features": [{"name": "EIP155"}, {"name": "EIP1559"}],
-  "nativeCurrency": {"name": "Tea", "symbol": "TEA", "decimals": 18},
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "nativeCurrency": { "name": "Tea", "symbol": "TEA", "decimals": 18 },
   "infoURL": "https://tea.xyz",
   "shortName": "tea",
   "icon": "tea",
   "chainId": 6122,
   "networkId": 6122,
-  "explorers": [{"name": "blockscout", "url": "https://explorer.tea.xyz", "icon": "blockscout", "standard": "EIP3091"}],
-  "parent": {"type": "L2", "chain": "eip155-1"},
+  "explorers": [
+    {
+      "name": "blockscout",
+      "url": "https://explorer.tea.xyz",
+      "icon": "blockscout",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": { "type": "L2", "chain": "eip155-1" },
   "status": "active"
 }

--- a/_data/chains/eip155-6122.json
+++ b/_data/chains/eip155-6122.json
@@ -10,7 +10,7 @@
   "icon": "tea",
   "chainId": 6122,
   "networkId": 6122,
-  "explorers": [{"name": "blockscout", "url": "https://scout.tea.xyz", "icon": "blockscout", "standard": "EIP3091"}],
+  "explorers": [{"name": "blockscout", "url": "https://explorer.tea.xyz", "icon": "blockscout", "standard": "EIP3091"}],
   "parent": {"type": "L2", "chain": "eip155-1"},
   "status": "active"
 }

--- a/_data/icons/tea.json
+++ b/_data/icons/tea.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreihmgtifbavavexido3aww2ga35z7qsn5yl2pbwx4iv5fmyn76eieq",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Adds Tea Mainnet (eip155-6122) and updates Tea Sepolia (eip155-10218) with RPC endpoints.
Tea Mainnet:

Chain ID: 6122
Stack: OP Stack L2
RPC: https://rpc.tea.xyz
Explorer: https://scout.tea.xyz (Blockscout, EIP3091)
Native token: TEA (18 decimals)
EIP-155 + EIP-1559 confirmed
Status: active

Tea Sepolia (Testnet):

Chain ID: 10218
RPC: https://tea-sepolia.g.alchemy.com/public
Explorer: https://sepolia.tea.xyz