### PR TITLE
Update IKChain Testnet (eip155-4270): native currency IKCr → IKToken

### DIFF
--- a/_data/chains/eip155-4270.json
+++ b/_data/chains/eip155-4270.json
@@ -6,8 +6,8 @@
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "faucets": ["https://testnet-explorer.ikchain.net"],
   "nativeCurrency": {
-    "name": "IKCrypto",
-    "symbol": "IKCr",
+    "name": "IKToken",
+    "symbol": "IKToken",
     "decimals": 18
   },
   "infoURL": "https://ikchain.net",

--- a/_data/chains/eip155-4270.json
+++ b/_data/chains/eip155-4270.json
@@ -7,7 +7,7 @@
   "faucets": ["https://testnet-explorer.ikchain.net"],
   "nativeCurrency": {
     "name": "IKToken",
-    "symbol": "IKToken",
+    "symbol": "IKTokn",
     "decimals": 18
   },
   "infoURL": "https://ikchain.net",


### PR DESCRIPTION
Updates the native currency for **IKChain Testnet** (chain ID 4270, originally added in #8184) from `IKCr` to `IKToken`.

**Why:** IKChain's native gas coin and its on-chain ERC-20 token (`IKCrypto`) were both labelled `IKCr`. Wallets (MetaMask, etc.) validate a chain's native-currency symbol against this registry, so a user sending the ERC-20 saw `Value: 0 IKCr` (the native field) which read as a contradiction. We've renamed the **native coin** to `IKToken`; the ERC-20 keeps its own on-chain `symbol()` ("IKCr") and is not part of this chain metadata.

**Scope:** only the `nativeCurrency.name`/`symbol` fields change (IKCrypto/IKCr → IKToken/IKToken). RPC, explorer, chainId, networkId, slip44, features — all unchanged.

**Verification:** `https://testnet-rpc.ikchain.net` `eth_chainId` → `0x10ae` (4270), live and synced.