### PR TITLE
Change MainnetChain native token symbol to PYR

### DIFF
--- a/_data/chains/eip155-1339.json
+++ b/_data/chains/eip155-1339.json
@@ -5,12 +5,12 @@
   "rpc": ["https://rpc.elysiumchain.tech", "https://rpc.elysiumchain.us"],
   "faucets": ["https://faucet.elysiumchain.tech"],
   "nativeCurrency": {
-    "name": "ELY",
-    "symbol": "ELY",
+    "name": "PYR",
+    "symbol": "PYR",
     "decimals": 18
   },
   "infoURL": "https://elysiumchain.tech/",
-  "shortName": "ELY",
+  "shortName": "PYR",
   "chainId": 1339,
   "networkId": 1339,
   "icon": "elysium",


### PR DESCRIPTION
I have updated the native currency symbol from ELY to PYR.
The symbol has also been updated on the Substrate chain metadata.

**RPC verification:**

```
curl -X POST https://rpc.atlantischain.network \
  -H "Content-Type: application/json" \
  --data '{"jsonrpc":"2.0","method":"system_properties","params":[],"id":1}'
```

**Response:**

```
{
  "jsonrpc":"2.0",
  "result":{
    "ss58Format":42,
    "tokenDecimals":18,
    "tokenSymbol":"PYR"
  },
  "id":1
}
```