### PR TITLE
Add SVPChain testnet

### DIFF
--- a/_data/chains/eip155-2517.json
+++ b/_data/chains/eip155-2517.json
@@ -1,0 +1,26 @@
+{
+  "name": "SVPChain Testnet",
+  "chain": "SVP",
+  "rpc": [
+    "https://svp-dataseed1-testnet.svpchain.org",
+    "https://svp-dataseed2-testnet.svpchain.org",
+    "https://svp-dataseed3-testnet.svpchain.org"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "SVP Token",
+    "symbol": "SVP",
+    "decimals": 18
+  },
+  "infoURL": "https://svpchain.org",
+  "shortName": "svptest",
+  "chainId": 2517,
+  "networkId": 2517,
+  "explorers": [
+    {
+      "name": "blockscout",
+      "url": "https://explorer.svpchain.com",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Adds SVPChain testnet to the chain list.

  - **Network:** SVPChain Testnet
  - **Chain ID:** 2517 (eip155-2517)
  - **Native token:** SVP, 18 decimals
  - **Type:** Cosmos SDK chain with cosmos/evm module (EVM-compatible JSON-RPC)
  - **RPC:** 3 public endpoints (svp-dataseed1/2/3-testnet.svpchain.org)
  - **Explorer:** Blockscout (EIP3091), https://explorer.svpchain.com
  - **Info:** https://svpchain.org

  Validated locally with \`./gradlew run\`; JSON formatted with prettier.
