### PR TITLE
Add ASHCHAIN Mainnet Beta

### DIFF
--- a/_data/chains/eip155-50366.json
+++ b/_data/chains/eip155-50366.json
@@ -1,0 +1,29 @@
+{
+  "name": "ASHCHAIN",
+  "chain": "ASH",
+  "rpc": [
+    "https://evm-rpc.ashchain.io",
+    "https://evm-rpc2.ashchain.io"
+  ],
+  "faucets": [
+    "https://ashchain.io/faucet"
+  ],
+  "nativeCurrency": {
+    "name": "ASH",
+    "symbol": "ASH",
+    "decimals": 18
+  },
+  "infoURL": "https://ashchain.io",
+  "shortName": "ash",
+  "chainId": 50366,
+  "networkId": 50366,
+  "icon": "ashchain",
+  "explorers": [
+    {
+      "name": "ASHCHAIN Explorer",
+      "url": "https://ashchain.io/explorer",
+      "standard": "none"
+    }
+  ],
+  "status": "active"
+}

--- a/_data/chains/eip155-50366.json
+++ b/_data/chains/eip155-50366.json
@@ -1,13 +1,8 @@
 {
   "name": "ASHCHAIN",
   "chain": "ASH",
-  "rpc": [
-    "https://evm-rpc.ashchain.io",
-    "https://evm-rpc2.ashchain.io"
-  ],
-  "faucets": [
-    "https://ashchain.io/faucet"
-  ],
+  "rpc": ["https://evm-rpc.ashchain.io", "https://evm-rpc2.ashchain.io"],
+  "faucets": ["https://ashchain.io/faucet"],
   "nativeCurrency": {
     "name": "ASH",
     "symbol": "ASH",

--- a/_data/icons/ashchain.json
+++ b/_data/icons/ashchain.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreicjrtxoflhrnr4tvp76ba6p6oxd5lpan24nvaumnvvr7ffsx5ioym",
+    "width": 256,
+    "height": 256,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
This PR adds ASHCHAIN, an EVM-compatible Mainnet Beta network.

Network details:
- Name: ASHCHAIN
- Native currency: ASH
- Chain ID: 50366
- Network ID: 50366
- RPC:
  - https://evm-rpc.ashchain.io
  - https://evm-rpc2.ashchain.io
- Explorer: https://ashchain.io/explorer
- Website: https://ashchain.io
- Faucet: https://ashchain.io/faucet

Both RPC endpoints return eth_chainId = 0xc4be.
The chain icon is pinned to IPFS.