### PR TITLE
Add gembablockchain testnet

### DIFF
--- a/_data/chains/eip155-821207.json
+++ b/_data/chains/eip155-821207.json
@@ -2,7 +2,11 @@
   "name": "GembaBlockchain Testnet",
   "chain": "GMB",
   "icon": "gemba",
-  "rpc": ["https://testnet.gembascan.io/rpc"],
+  "rpc": [
+    "https://testnet.gembascan.io/rpc",
+    "https://rpc1.gembascan.io",
+    "https://rpc2.gembascan.io"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Gemba",

--- a/_data/chains/eip155-821207.json
+++ b/_data/chains/eip155-821207.json
@@ -9,7 +9,7 @@
     "symbol": "GMB",
     "decimals": 18
   },
-  "infoURL": "https://gembascan.io",
+  "infoURL": "https://gembachain.io",
   "shortName": "gembatest",
   "chainId": 821207,
   "networkId": 821207,

--- a/_data/chains/eip155-821207.json
+++ b/_data/chains/eip155-821207.json
@@ -1,0 +1,28 @@
+{
+  "name": "GembaBlockchain Testnet",
+  "chain": "GMB",
+  "icon": "gemba",
+  "rpc": [
+    "https://testnet.gembascan.io/rpc"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Gemba",
+    "symbol": "GMB",
+    "decimals": 18
+  },
+  "infoURL": "https://gembascan.io",
+  "shortName": "gembatest",
+  "chainId": 821207,
+  "networkId": 821207,
+  "explorers": [
+    {
+      "name": "GembaScan",
+      "url": "https://testnet.gembascan.io",
+      "icon": "gemba",
+      "standard": "EIP3091"
+    }
+  ],
+  "status": "active",
+  "title": "GembaBlockchain Testnet"
+}

--- a/_data/chains/eip155-821207.json
+++ b/_data/chains/eip155-821207.json
@@ -2,9 +2,7 @@
   "name": "GembaBlockchain Testnet",
   "chain": "GMB",
   "icon": "gemba",
-  "rpc": [
-    "https://testnet.gembascan.io/rpc"
-  ],
+  "rpc": ["https://testnet.gembascan.io/rpc"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Gemba",

--- a/_data/icons/gemba.json
+++ b/_data/icons/gemba.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreiaq324rpiikfjdho6p6sayvswdhihxaebzkooho6eisoko72jx2wu",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
 Title:
  Add GembaBlockchain Testnet (821207)
  
  Description:
  Adds GembaBlockchain Testnet (chainId 821207) — a Cosmos EVM (CometBFT PoS) public test network.
  
  - RPC https://testnet.gembascan.io/rpc returns eth_chainId = 0xc87d7 (821207)
  - Explorer (EIP-3091): https://testnet.gembascan.io
  - Native currency: Gemba (GMB), 18 decimals
  - Icon pinned to IPFS
  
  Files:
  - _data/chains/eip155-821207.json
  - _data/icons/gemba.json
