### PR TITLE
Add Duck Four Four Chain (chain ID 2716446429837001)

### DIFF
--- a/_data/chains/eip155-2716446429837001.json
+++ b/_data/chains/eip155-2716446429837001.json
@@ -1,0 +1,24 @@
+{
+  "name": "Duck Four Four Chain",
+  "chain": "DFFC",
+  "rpc": [
+    "https://rpc-duckchain.duckdns.org"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Duck Four Four Chain",
+    "symbol": "DFFC",
+    "decimals": 18
+  },
+  "infoURL": "https://duckfourchain.duckdns.org",
+  "shortName": "duckchain",
+  "chainId": 2716446429837001,
+  "networkId": 2716446429837001,
+  "explorers": [
+    {
+      "name": "DuckChain Explorer",
+      "url": "https://duckfourchain.duckdns.org",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds Duck Four Four Chain (DFFC), an EVM-compatible blockchain using Clique Proof-of-Authority consensus.

## Network Details
- **Chain ID**: 2716446429837001 (0x9a697f88076c9)
- **Name**: Duck Four Four Chain
- **Native Currency**: DFFC
- **RPC**: https://rpc-duckchain.duckdns.org
- **Explorer**: https://duckfourchain.duckdns.org (EIP-3091 compliant)
- **Short Name**: duckchain

## Status
- ✅ Public RPC endpoint active
- ✅ Block explorer with EIP-3091 support
- ✅ Chain operational and producing blocks