### PR TITLE
Add Unitsky String Technologies (EIP-155 778889)

### DIFF
--- a/_data/chains/eip155-778889.json
+++ b/_data/chains/eip155-778889.json
@@ -1,0 +1,29 @@
+{
+  "name": "Unitsky String Technologies",
+  "chain": "Unitsky",
+  "rpc": [
+    "https://147-45-143-23.sslip.io/rpc"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Unitsky Token",
+    "symbol": "UST",
+    "decimals": 18
+  },
+  "features": [
+    {
+      "name": "EIP155"
+    }
+  ],
+  "infoURL": "https://147-45-143-23.sslip.io",
+  "shortName": "ust",
+  "chainId": 778889,
+  "networkId": 778889,
+  "explorers": [
+    {
+      "name": "Unitsky Explorer",
+      "url": "https://147-45-143-23.sslip.io",
+      "standard": "none"
+    }
+  ]
+}

--- a/_data/chains/eip155-778889.json
+++ b/_data/chains/eip155-778889.json
@@ -1,9 +1,7 @@
 {
   "name": "Unitsky String Technologies",
   "chain": "Unitsky",
-  "rpc": [
-    "https://147-45-143-23.sslip.io/rpc"
-  ],
+  "rpc": ["https://147-45-143-23.sslip.io/rpc"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Unitsky Token",


### PR DESCRIPTION
Add Unitsky String Technologies — independent EVM network.

- Chain ID: 778889
- Native token: UST (18 decimals)
- HTTPS RPC: https://147-45-143-23.sslip.io/rpc
- Explorer: https://147-45-143-23.sslip.io
- Consensus: Clique PoA (5s blocks) + PoW mining smart contract
- GitHub: https://github.com/klaren1987/unitsky-chain

Made with [Cursor](https://cursor.com)