### PR TITLE
Add tajirchain mainnet

### DIFF
--- a/_data/chains/eip155-3377.json
+++ b/_data/chains/eip155-3377.json
@@ -1,0 +1,39 @@
+{
+    "name": "Tajirchain",
+    "chain": "TJR",
+    "rpc": [
+      "https://rpc.tajirchain.com",
+      "wss://ws.tajirchain.com"
+    ],
+    "faucets": [],
+    "nativeCurrency": {
+      "name": "Tajirchain Token",
+      "symbol": "TJR",
+      "decimals": 18
+    },
+    "features": [
+      { "name": "EIP155" },
+      { "name": "EIP1559" }
+    ],
+    "infoURL": "https://tajirchain.com",
+    "shortName": "tjr",
+    "chainId": 3377,
+    "networkId": 3377,
+    "icon": "tajirchain",
+    "status": "incubating",
+    "parent": {
+      "type": "L2",
+      "chain": "eip155-1",
+      "bridges": [
+        { "url": "https://bridge.tajirchain.com" }
+      ]
+    },
+    "explorers": [
+      {
+        "name": "Tajirchain Explorer",
+        "url": "https://explorer.tajirchain.com",
+        "icon": "tajirchain",
+        "standard": "EIP3091"
+      }
+    ]
+  }

--- a/_data/chains/eip155-3377.json
+++ b/_data/chains/eip155-3377.json
@@ -7,7 +7,7 @@
     ],
     "faucets": [],
     "nativeCurrency": {
-      "name": "Tajirchain Token",
+      "name": "Tajir",
       "symbol": "TJR",
       "decimals": 18
     },
@@ -25,7 +25,8 @@
       "type": "L2",
       "chain": "eip155-1",
       "bridges": [
-        { "url": "https://bridge.tajirchain.com" }
+        { "url": "https://bridge.tajirchain.com" },
+        { "url": "https://ui.agglayer.dev/" }
       ]
     },
     "explorers": [


### PR DESCRIPTION
Chain Details:

Name: Tajirchain
Chain ID: 3377
Network ID: 3377
Short Name: tjr-mainnet
Native Currency: TJR (18 decimals)
Type: L2 (parent: eip155-1)

Infrastructure:

RPC:
https://rpc.tajirchain.com/
wss://wss.tajirchain.com

Explorer:
https://explorer.tajirchain.com/
(EIP-3091 compatible)

Bridge:
https://bridge.tajirchain.com/

Additional Notes:

EIP-155 supported
Chain is currently incubating
Icon SVG uploaded to IPFS and referenced in _data/icons/tajirchain.json
All endpoints are live and responding correctly