### PR TITLE
Add Whitechain Sepolia

### DIFF
--- a/_data/chains/eip155-1874.json
+++ b/_data/chains/eip155-1874.json
@@ -1,0 +1,27 @@
+{
+  "name": "Whitechain Sepolia",
+  "chain": "WCH",
+  "rpc": ["https://rpc.testnet.whitechain.io"],
+  "faucets": ["https://faucet.testnet.whitechain.io"],
+  "nativeCurrency": {
+    "name": "WBT",
+    "symbol": "WBT",
+    "decimals": 18
+  },
+  "infoURL": "https://docs.whitechain.io",
+  "shortName": "wch-sepolia",
+  "chainId": 1874,
+  "networkId": 1874,
+  "icon": "whitechain-sepolia",
+  "explorers": [
+    {
+      "name": "Whitechain Testnet Explorer",
+      "url": "https://explorer.testnet.whitechain.io",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-11155111"
+  }
+}

--- a/_data/icons/whitechain-sepolia.json
+++ b/_data/icons/whitechain-sepolia.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmYF9yMTjEGKCGnDr5TUFdDUX3oHyE2Gt4Yof8obJDvpLM",
+    "width": 256,
+    "height": 256,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
## Add Whitechain Sepolia (chainId 1874)

### Chain details
| field | value |
|---|---|
| name | Whitechain Sepolia |
| chainId / networkId | 1874 |
| shortName | wch-sepolia |
| native currency | WBT, 18 decimals |
| RPC | https://rpc.testnet.whitechain.io |
| explorer | https://explorer.testnet.whitechain.io |
| infoURL | https://docs.whitechain.io |
| type | L2 |
