### PR TITLE
Update AEREDIUM (chainId 237) native currency symbol AER -> AERX

### DIFF
--- a/_data/chains/eip155-237.json
+++ b/_data/chains/eip155-237.json
@@ -1,11 +1,11 @@
 {
   "name": "AEREDIUM",
-  "chain": "AER",
+  "chain": "AERX",
   "rpc": ["https://rpc.aeredium.io"],
   "faucets": [],
   "nativeCurrency": {
-    "name": "AER",
-    "symbol": "AER",
+    "name": "AERX",
+    "symbol": "AERX",
     "decimals": 18
   },
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],

--- a/_data/chains/eip155-237.json
+++ b/_data/chains/eip155-237.json
@@ -1,7 +1,7 @@
 {
   "name": "AEREDIUM",
   "chain": "AERX",
-  "rpc": ["https://rpc.aeredium.io"],
+  "rpc": [],
   "faucets": [],
   "nativeCurrency": {
     "name": "AERX",


### PR DESCRIPTION
AEREDIUM (chainId 237) has renamed its native currency from AER to AERX. This PR updates nativeCurrency.name, nativeCurrency.symbol, and the chain field to AERX. shortName left as 'aer' to preserve URL stability. Chain ID (237), RPC, and explorer are unchanged.