### PR TITLE
feat: add Humanity Protocol chain (chainId 13600000)

### DIFF
--- a/_data/chains/eip155-13600000.json
+++ b/_data/chains/eip155-13600000.json
@@ -1,0 +1,33 @@
+{
+  "name": "Humanity",
+  "chain": "Humanity",
+  "rpc": ["https://humanity-mainnet.g.alchemy.com/public"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "H",
+    "symbol": "H",
+    "decimals": 18
+  },
+  "infoURL": "https://humanity.org",
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-42161",
+    "bridges": [
+      {
+        "url": "https://bridge.humanity.org"
+      }
+    ]
+  },
+  "shortName": "hp",
+  "chainId": 13600000,
+  "networkId": 13600000,
+  "status": "active",
+  "explorers": [
+    {
+      "name": "Humanity Mainnet explorer",
+      "url": "https://humanity-mainnet.explorer.alchemy.com",
+      "standard": "none"
+    }
+  ],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }]
+}


### PR DESCRIPTION
## Add Humanity Protocol chain (chainId 13600000)

Adds the relaunched Humanity Protocol mainnet with chain ID 13600000.

This is a fresh chain relaunch by the Humanity Protocol team. The previous chain (6985385) is being deprecated separately.

### Chain details

- **Name:** Humanity Protocol
- **Chain ID:** 13600000
- **Network ID:** 13600000
- **Native currency:** H (18 decimals)
- **RPC:** https://humanity-mainnet.g.alchemy.com/public
- **Explorer:** https://humanity-mainnet.explorer.alchemy.com
- **Parent:** L2 on Arbitrum (eip155-42161)
- **Short name:** hp
- **Info URL:** https://humanity.org

> Note: The existing chain 6985385 also uses shortName `hp` and name `Humanity Protocol`. A separate PR will deprecate that chain. If CI flags the duplicate, we can coordinate the deprecation PR first.
