### PR TITLE
Add BattleChain Mainnet (chainId 626)

### DIFF
--- a/_data/chains/eip155-626.json
+++ b/_data/chains/eip155-626.json
@@ -1,7 +1,7 @@
 {
   "name": "BattleChain Mainnet",
   "chain": "ETH",
-  "rpc": [],
+  "rpc": ["https://mainnet.battlechain.com"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
@@ -13,8 +13,13 @@
   "chainId": 626,
   "networkId": 626,
   "icon": "battlechain",
-  "status": "incubating",
-  "explorers": [],
+  "explorers": [
+    {
+      "name": "BattleChain Explorer",
+      "url": "https://explorer.battlechain.com",
+      "standard": "EIP3091"
+    }
+  ],
   "parent": {
     "type": "L2",
     "chain": "eip155-1",


### PR DESCRIPTION
Promotes the existing incubating `eip155-626.json` to active now that BattleChain mainnet is live: adds the public RPC and block explorer and drops the `incubating` status.

BattleChain is Cyfrin's ZKsync-based Ethereum L2; native currency is bridged ETH. The `battlechain` icon is already present from the testnet entry (627).