### PR TITLE
Add Maroo Testnet (eip155-450815)

### DIFF
--- a/_data/chains/eip155-450815.json
+++ b/_data/chains/eip155-450815.json
@@ -1,0 +1,28 @@
+{
+  "name": "Maroo Testnet",
+  "chain": "MAROO",
+  "icon": "maroo",
+  "rpc": ["https://rpc-testnet.maroo.io"],
+  "features": [
+    { "name": "EIP155" },
+    { "name": "EIP1559" },
+    { "name": "EIP7702" }
+  ],
+  "faucets": ["https://faucet.maroo.io"],
+  "nativeCurrency": {
+    "name": "Testnet OKRW",
+    "symbol": "tOKRW",
+    "decimals": 18
+  },
+  "infoURL": "https://maroo.io",
+  "shortName": "maroo-testnet",
+  "chainId": 450815,
+  "networkId": 450815,
+  "explorers": [
+    {
+      "name": "blockscout",
+      "url": "https://explorer-testnet.maroo.io",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/icons/maroo.json
+++ b/_data/icons/maroo.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreiftnaqr2cdmvnz5jbzyu5q24eujpp3jfpue6ujnpexdif2bxj4cve",
+    "width": 192,
+    "height": 192,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Adds Maroo Testnet to the chain list.

- Network: Maroo Testnet
- Chain ID: 450815 (eip155-450815)
- Native token: Testnet OKRW (tOKRW), 18 decimals
- RPC: https://rpc-testnet.maroo.io
- Explorer: Blockscout (EIP3091), https://explorer-testnet.maroo.io
- Faucet: https://faucet.maroo.io
- Features: EIP155, EIP1559, EIP7702
- Icon: pinned in IPFS, 192x192 PNG
- Info: https://maroo.io
