### PR TITLE
Fix MFENX RPC endpoint for chain 177155

### DIFF
--- a/_data/chains/eip155-177155.json
+++ b/_data/chains/eip155-177155.json
@@ -1,7 +1,7 @@
 {
   "name": "mfenx",
   "chain": "MFENX",
-  "rpc": ["https://indexer.mfenx.com/rpc"],
+  "rpc": ["https://rpc.mfenx.com"],
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
The existing MFENX RPC URL does not resolve. This replaces it with the live canonical endpoint behind the health-checked multi-region edge.

Validation:
- ChainList single-chain Gradle check passed
- Endpoint returned `power-house/0.3.2/finalized-native-rpc`
- Chain ID `177155` and block number were validated by the ChainList processor
- Prettier and JSON syntax checks passed