### PR TITLE
Replace defunct UB Smart Chain with ADI Network AB Testnet on chainId 99999

### DIFF
--- a/_data/chains/eip155-99999.json
+++ b/_data/chains/eip155-99999.json
@@ -2,12 +2,8 @@
   "name": "ADI Network AB Testnet",
   "title": "ADI Network AB Testnet (prev. UB Smart Chain)",
   "chain": "ADI",
-  "rpc": [
-    "https://rpc.ab.testnet.adifoundation.ai/"
-  ],
-  "faucets": [
-    "http://faucet.ab.testnet.adifoundation.ai/"
-  ],
+  "rpc": ["https://rpc.ab.testnet.adifoundation.ai/"],
+  "faucets": ["http://faucet.ab.testnet.adifoundation.ai/"],
   "nativeCurrency": {
     "name": "ADI",
     "symbol": "ADI",
@@ -20,11 +16,9 @@
   "explorers": [
     {
       "name": "ADI Testnet Explorer",
-      "url": "https://explorer.ab.testnet.adifoundation.ai/",
+      "url": "https://explorer.ab.testnet.adifoundation.ai",
       "standard": "EIP3091"
     }
   ],
-  "redFlags": [
-    "reusedChainId"
-  ]
+  "redFlags": ["reusedChainId"]
 }

--- a/_data/chains/eip155-99999.json
+++ b/_data/chains/eip155-99999.json
@@ -2,8 +2,12 @@
   "name": "ADI Network AB Testnet",
   "title": "ADI Network AB Testnet (prev. UB Smart Chain)",
   "chain": "ADI",
-  "rpc": ["https://rpc.ab.testnet.adifoundation.ai/"],
-  "faucets": ["http://faucet.ab.testnet.adifoundation.ai/"],
+  "rpc": [
+    "https://rpc.ab.testnet.adifoundation.ai/"
+  ],
+  "faucets": [
+    "http://faucet.ab.testnet.adifoundation.ai/"
+  ],
   "nativeCurrency": {
     "name": "ADI",
     "symbol": "ADI",
@@ -19,5 +23,8 @@
       "url": "https://explorer.ab.testnet.adifoundation.ai/",
       "standard": "EIP3091"
     }
+  ],
+  "redFlags": [
+    "reusedChainId"
   ]
 }

--- a/_data/chains/eip155-99999.json
+++ b/_data/chains/eip155-99999.json
@@ -1,15 +1,23 @@
 {
-  "name": "UB Smart Chain",
-  "chain": "USC",
-  "rpc": ["https://rpc.uschain.network"],
-  "faucets": [],
+  "name": "ADI Network AB Testnet",
+  "title": "ADI Network AB Testnet (prev. UB Smart Chain)",
+  "chain": "ADI",
+  "rpc": ["https://rpc.ab.testnet.adifoundation.ai/"],
+  "faucets": ["http://faucet.ab.testnet.adifoundation.ai/"],
   "nativeCurrency": {
-    "name": "UBC",
-    "symbol": "UBC",
+    "name": "ADI",
+    "symbol": "ADI",
     "decimals": 18
   },
-  "infoURL": "https://www.ubchain.site/",
-  "shortName": "usc",
+  "infoURL": "https://docs.adi.foundation",
+  "shortName": "adi-testnet",
   "chainId": 99999,
-  "networkId": 99999
+  "networkId": 99999,
+  "explorers": [
+    {
+      "name": "ADI Testnet Explorer",
+      "url": "https://explorer.ab.testnet.adifoundation.ai/",
+      "standard": "EIP3091"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Chain ID **99999** was previously occupied by **UB Smart Chain (USC)**, which is now defunct:
- RPC endpoint `https://rpc.uschain.network` is unreachable
- Website `https://www.ubchain.site/` is unreachable
- No activity since at least 2022

**ADI Network AB Testnet** ([docs.adi.foundation](https://docs.adi.foundation/adi-networks/adi-testnet.md)) is actively running on chainId 99999 with:
- **RPC:** `https://rpc.ab.testnet.adifoundation.ai/`
- **Explorer:** `https://explorer.ab.testnet.adifoundation.ai/`
- **Currency:** ADI
- **Faucet:** `http://faucet.ab.testnet.adifoundation.ai/`

## Changes

Updated `_data/chains/eip155-99999.json` to reflect the active chain on this chainId.