### PR TITLE
Add Insectarium testnet (chainId 43522)

### DIFF
--- a/_data/chains/eip155-43522.json
+++ b/_data/chains/eip155-43522.json
@@ -1,0 +1,39 @@
+{
+  "name": "Insectarium",
+  "title": "Insectarium Testnet",
+  "chain": "MemeCore",
+  "icon": "memecore",
+  "rpc": [
+    "https://rpc.insectarium.memecore.net",
+    "wss://ws.insectarium.memecore.net"
+  ],
+  "faucets": ["https://faucet.memecore.com/insectarium"],
+  "nativeCurrency": {
+    "name": "Insectarium M",
+    "symbol": "M",
+    "decimals": 18
+  },
+  "features": [
+    { "name": "EIP155" },
+    { "name": "EIP1559" },
+    { "name": "EIP4844" },
+    { "name": "EIP7702" }
+  ],
+  "infoURL": "https://memecore.com",
+  "shortName": "insectarium",
+  "chainId": 43522,
+  "networkId": 43522,
+  "slip44": 1,
+  "explorers": [
+    {
+      "name": "MemeCoreScan-Insectarium",
+      "url": "https://insectarium.memecorescan.io",
+      "standard": "EIP3091"
+    },
+    {
+      "name": "Blockscout-Insectarium",
+      "url": "https://insectarium.blockscout.memecore.com",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the MemeCore **Insectarium** testnet (chainId `43522` / `0xaa02`).

### Details
- **Name:** Insectarium (title: "Insectarium Testnet")
- **Chain / Network ID:** 43522
- **Native currency:** M (18 decimals)
- **RPC:** `https://rpc.insectarium.memecore.net`, `wss://ws.insectarium.memecore.net`
- **Faucet:** `https://faucet.memecore.com/insectarium`
- **Explorers:** MemeCoreScan (`https://insectarium.memecorescan.io`), Blockscout
(`https://insectarium.blockscout.memecore.com`)
- **Icon:** reuses the existing `memecore` icon
- **Features:** EIP155, EIP1559, EIP4844, EIP7702 (Cancun and Prague are active on-chain)

### Checks
- [x] `eth_chainId` on the HTTPS RPC returns `0xaa02` (43522), matching the file
- [x] `shortName` `insectarium` is unique across the repo
- [x] `./gradlew run --args="verbose singleChainCheck _data/chains/eip155-43522.json"` → BUILD SUCCESSFUL
- [x] `npx prettier --check '_data/chains/eip155-43522.json'` → passes