### PR TITLE
deprecate Formicarium testnet (chainId 43521)

### DIFF
--- a/_data/chains/eip155-43521.json
+++ b/_data/chains/eip155-43521.json
@@ -2,6 +2,7 @@
   "name": "Formicarium",
   "title": "MemeCore Testnet Formicarium",
   "chain": "MemeCore",
+  "status": "deprecated",
   "icon": "memecore",
   "rpc": [
     "https://rpc.formicarium.memecore.net",
@@ -18,22 +19,5 @@
   "shortName": "form",
   "chainId": 43521,
   "networkId": 43521,
-  "slip44": 1,
-  "explorers": [
-    {
-      "name": "OKX-Formicarium",
-      "url": "https://www.okx.com/web3/explorer/formicarium-testnet",
-      "standard": "EIP3091"
-    },
-    {
-      "name": "MemeCoreScan-Formicarium",
-      "url": "https://formicarium.memecorescan.io",
-      "standard": "EIP3091"
-    },
-    {
-      "name": "MemeCore Testnet Formicarium Explorer",
-      "url": "https://formicarium.blockscout.memecore.com",
-      "standard": "EIP3091"
-    }
-  ]
+  "slip44": 1
 }


### PR DESCRIPTION
MemeCore's Formicarium testnet (chainId 43521) has reached end of life and
has been superseded by the Insectarium testnet (chainId 43522). The
sunset was announced by the MemeCore team for June 16, and the chain's
endpoints no longer respond:

- RPC `https://rpc.formicarium.memecore.net` -> HTTP 503
- WSS `wss://ws.formicarium.memecore.net` -> HTTP 503
- Explorer `www.okx.com/web3/explorer/formicarium-testnet` -> 301 -> 404
- Explorer `formicarium.memecorescan.io` -> DNS no longer resolves
- Explorer `formicarium.blockscout.memecore.com` -> HTTP 503

Changes to `_data/chains/eip155-43521.json`:

- Set `"status": "deprecated"`.
- Remove the three explorer entries (OKX, MemeCoreScan, Blockscout), all
  of which are unreachable. The RPC entries are kept since `rpc` is a
  mandatory field.

The chain JSON is kept (rather than deleted) so the chainId stays reserved.