### PR TITLE
update MemeCore Mainnet (chainId 4352)

### DIFF
--- a/_data/chains/eip155-4352.json
+++ b/_data/chains/eip155-4352.json
@@ -1,6 +1,6 @@
 {
   "name": "MemeCore",
-  "title": "MemeCore",
+  "title": "MemeCore Mainnet",
   "chain": "MemeCore",
   "icon": "memecore",
   "rpc": ["https://rpc.memecore.net", "wss://ws.memecore.net"],
@@ -9,7 +9,12 @@
     "symbol": "M",
     "decimals": 18
   },
-  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "features": [
+    { "name": "EIP155" },
+    { "name": "EIP1559" },
+    { "name": "EIP4844" },
+    { "name": "EIP7702" }
+  ],
   "faucets": [],
   "infoURL": "https://memecore.com",
   "shortName": "m",
@@ -17,17 +22,12 @@
   "networkId": 4352,
   "explorers": [
     {
-      "name": "OKX-MemeCore",
-      "url": "https://www.okx.com/web3/explorer/memecore",
-      "standard": "EIP3091"
-    },
-    {
       "name": "MemeCoreScan",
       "url": "https://memecorescan.io",
       "standard": "EIP3091"
     },
     {
-      "name": "MemeCore explorer",
+      "name": "Blockscout",
       "url": "https://blockscout.memecore.com",
       "standard": "EIP3091"
     }


### PR DESCRIPTION
Bring the MemeCore mainnet entry in line with the Insectarium testnet (chainId 43522) entry, using values verified against the live mainnet RPC (eth_chainId returns 0x1100, client Gmeme/v1.15.3).

- Add EIP4844 and EIP7702 to features: the latest block header carries blobGasUsed/excessBlobGas (Cancun) and requestsHash (Prague), so both forks are active on-chain.
- Remove the OKX explorer entry, which 301-redirects to a 404.
- Rename the Blockscout explorer from "MemeCore explorer" to "Blockscout" and set the title to "MemeCore Mainnet".