### PR TITLE
Update Mars Credit (110110): drop dead RPC, add Blockscout explorer, add EIP155/EIP1559

### DIFF
--- a/_data/chains/eip155-110110.json
+++ b/_data/chains/eip155-110110.json
@@ -1,10 +1,8 @@
 {
   "name": "Mars Credit",
   "chain": "MARS",
-  "rpc": [
-    "https://node99-production-dd5f.up.railway.app:443",
-    "https://rpc.marscredit.xyz:443"
-  ],
+  "rpc": ["https://rpc.marscredit.xyz:443"],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "faucets": [],
   "nativeCurrency": {
     "name": "Mars Credit",
@@ -17,6 +15,12 @@
   "networkId": 110110,
   "slip44": 1,
   "icon": "marscredit",
-  "explorers": [],
+  "explorers": [
+    {
+      "name": "blockscout",
+      "url": "https://blockscan.marscredit.xyz",
+      "standard": "EIP3091"
+    }
+  ],
   "redFlags": []
 }


### PR DESCRIPTION
## Summary

Minimal metadata update for Mars Credit (chainId `110110`):

- **Remove dead RPC**: `https://node99-production-dd5f.up.railway.app:443` returns HTTP 404 (Railway endpoint decommissioned). Keeps working RPC `https://rpc.marscredit.xyz:443` (verified live, current block `0x47c3a9`).
- **Add explorer**: Blockscout at `https://blockscan.marscredit.xyz` — EIP-3091 compliant (`/tx/{hash}` and `/block/{n}` both return 200).
- **Add features**: `EIP155` and `EIP1559` (London hard fork active from genesis on this go-ethereum 1.10.18 fork).

## Verification

- RPC live: `curl -d '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber"}' https://rpc.marscredit.xyz` → `{"result":"0x47c3a9"}`
- Explorer live: `curl -o /dev/null -w '%{http_code}' https://blockscan.marscredit.xyz/tx/0x0...0` → `200`

No changes to `name`, `infoURL`, `slip44`, or `icon`. Single-file diff, prettier-formatted.