### PR TITLE
fix: update Chain 8472 MYRX Mainnet symbol MRT to MYRX after rebrand

### DIFF
--- a/_data/chains/eip155-8472.json
+++ b/_data/chains/eip155-8472.json
@@ -1,20 +1,23 @@
 {
-  "name": "MyRx Network",
-  "chain": "MRT",
-  "rpc": ["https://rpc.myrxwallet.io", "wss://rpc.myrxwallet.io"],
+  "name": "MYRX Mainnet",
+  "chain": "MYRX",
+  "rpc": [
+    "https://rpc.myrxwallet.io",
+    "wss://rpc.myrxwallet.io"
+  ],
   "faucets": [],
   "nativeCurrency": {
-    "name": "MyRx Token",
-    "symbol": "MRT",
+    "name": "MYRX Token",
+    "symbol": "MYRX",
     "decimals": 18
   },
   "infoURL": "https://myrxwallet.io",
-  "shortName": "mrt",
+  "shortName": "myrx",
   "chainId": 8472,
   "networkId": 8472,
   "explorers": [
     {
-      "name": "MyRx Explorer",
+      "name": "MYRX Explorer",
       "url": "https://explorer.myrxwallet.io",
       "standard": "EIP3091"
     }

--- a/_data/chains/eip155-8472.json
+++ b/_data/chains/eip155-8472.json
@@ -1,10 +1,7 @@
 {
   "name": "MYRX Mainnet",
   "chain": "MYRX",
-  "rpc": [
-    "https://rpc.myrxwallet.io",
-    "wss://rpc.myrxwallet.io"
-  ],
+  "rpc": ["https://rpc.myrxwallet.io", "wss://rpc.myrxwallet.io"],
   "faucets": [],
   "nativeCurrency": {
     "name": "MYRX Token",


### PR DESCRIPTION
Updates Chain 8472 entry. Chain is live at rpc.myrxwallet.io. Rebranded from MRT to MYRX. Note: PR #8286 (Aurigraph) conflicts with existing merged chain 8472 registration.