### PR TITLE
Add Liberty Testnet (chainId 13373)

### DIFF
--- a/_data/chains/eip155-13373.json
+++ b/_data/chains/eip155-13373.json
@@ -1,0 +1,25 @@
+{
+  "name": "Liberty Testnet",
+  "chain": "LBRTY",
+  "icon": "lbrty",
+  "rpc": [
+    "https://testnet-rpc.libertychain.org"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Liberty",
+    "symbol": "LBRTY",
+    "decimals": 18
+  },
+  "infoURL": "https://libertychain.org",
+  "shortName": "lbrty-testnet",
+  "chainId": 13373,
+  "networkId": 13373,
+  "explorers": [
+    {
+      "name": "blockscout",
+      "url": "https://explorer.libertychain.org",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/icons/lbrty.json
+++ b/_data/icons/lbrty.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreieyrtkdick4cp34evvidd5xauuyinyvdpojectuo6hsi4fupe5mua",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Adds **Liberty Testnet** to the chain registry.

- **chainId:** 13373
- **Native currency:** Liberty (LBRTY), 18 decimals
- **RPC:** https://testnet-rpc.libertychain.org (POST `eth_chainId` returns `0x343d`)
- **Explorer:** Blockscout (EIP3091) at https://explorer.libertychain.org
- **Icon:** 512x512 PNG pinned on IPFS

RPC verified reachable and returning the correct chainId. JSON validated.