### PR TITLE
Update GembaBlockchain Testnet (eip155-821207) RPC endpoints

### DIFF
--- a/_data/chains/eip155-821207.json
+++ b/_data/chains/eip155-821207.json
@@ -3,9 +3,9 @@
   "chain": "GMB",
   "icon": "gemba",
   "rpc": [
-    "https://testnet.gembascan.io/rpc",
     "https://rpc1.gembascan.io",
-    "https://rpc2.gembascan.io"
+    "https://rpc2.gembascan.io",
+    "https://rpc3.gembascan.io"
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
Updates the RPC list for **GembaBlockchain Testnet** (chainId `821207`).

`https://testnet.gembascan.io/rpc` is our explorer/archive node (runs the indexer; not suited as a public wallet RPC). Replaced by our dedicated public RPC endpoints:

- `https://rpc1.gembascan.io` (primary)
- `https://rpc2.gembascan.io`
- `https://rpc3.gembascan.io`

All three live, serve chainId `821207`, behind Cloudflare + TLS. Only the `rpc` array changed; all other metadata unchanged.