### PR TITLE
Add BEXChain Metadata Configuration and Logo Icon

### DIFF
--- a/_data/chains/eip155-140586.json
+++ b/_data/chains/eip155-140586.json
@@ -1,0 +1,29 @@
+{
+  "name": "BEXChain",
+  "chain": "BEX",
+  "rpc": [
+    "https://rpc.bexchain.com"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "BEX",
+    "symbol": "BEX",
+    "decimals": 18
+  },
+  "infoURL": "https://bexchain.com",
+  "shortName": "bexchain",
+  "chainId": 140586,
+  "networkId": 140586,
+  "slip44": 60,
+  "features": [
+    { "name": "EIP155" },
+    { "name": "EIP1559" }
+  ],
+  "explorers": [
+    {
+      "name": "BEXChain Scan",
+      "url": "https://scan.bexchain.com",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-140586.json
+++ b/_data/chains/eip155-140586.json
@@ -12,6 +12,7 @@
   "shortName": "bexchain",
   "chainId": 140586,
   "networkId": 140586,
+  "icon": "bexchain",
   "slip44": 60,
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "explorers": [

--- a/_data/chains/eip155-140586.json
+++ b/_data/chains/eip155-140586.json
@@ -1,9 +1,7 @@
 {
   "name": "BEXChain",
   "chain": "BEX",
-  "rpc": [
-    "https://rpc.bexchain.com"
-  ],
+  "rpc": ["https://rpc.bexchain.com"],
   "faucets": [],
   "nativeCurrency": {
     "name": "BEX",
@@ -15,10 +13,7 @@
   "chainId": 140586,
   "networkId": 140586,
   "slip44": 60,
-  "features": [
-    { "name": "EIP155" },
-    { "name": "EIP1559" }
-  ],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "explorers": [
     {
       "name": "BEXChain Scan",

--- a/_data/icons/bexchain.json
+++ b/_data/icons/bexchain.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreiblcantqquxetwvxuj3roy5x4rkokhiddhyisa675pynztbs6okrm",
+    "width": 500,
+    "height": 500,
+    "format": "png"
+  }
+]

--- a/_data/icons/bexchain.json
+++ b/_data/icons/bexchain.json
@@ -1,8 +1,9 @@
 [
   {
-    "url": "ipfs://bafkreignyeyyatz73wlub7nepf2fxe6xtzoxknm2qbcrar4tzu3yf7nxea"
+    "url": "ipfs://bafkreignyeyyatz73wlub7nepf2fxe6xtzoxknm2qbcrar4tzu3yf7nxea", 
     "width": 500,
     "height": 500,
     "format": "png"
   }
 ]
+

--- a/_data/icons/bexchain.json
+++ b/_data/icons/bexchain.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "ipfs://bafkreiblcantqquxetwvxuj3roy5x4rkokhiddhyisa675pynztbs6okrm",
+    "url": "ipfs://bafkreignyeyyatz73wlub7nepf2fxe6xtzoxknm2qbcrar4tzu3yf7nxea"
     "width": 500,
     "height": 500,
     "format": "png"


### PR DESCRIPTION
### Description
This PR adds the official network metadata configuration and logo icon for BEXChain (Chain ID: 140586).

### Details
- **Chain Name:** BEXChain
- **Chain ID:** 140586
- **Currency Symbol:** BEX

All JSON fields and icon paths have been verified against the ethereum-lists specification. Ready for review.
