### PR TITLE
Add NodeFlare public RPC endpoints for 15 chains

### DIFF
--- a/_data/chains/eip155-130.json
+++ b/_data/chains/eip155-130.json
@@ -4,7 +4,8 @@
   "rpc": [
     "https://mainnet.unichain.org",
     "https://unichain-rpc.publicnode.com",
-    "wss://unichain-rpc.publicnode.com"
+    "wss://unichain-rpc.publicnode.com",
+    "https://rpc.nodeflare.app/unichain/public"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-1329.json
+++ b/_data/chains/eip155-1329.json
@@ -1,7 +1,11 @@
 {
   "name": "Sei Network",
   "chain": "Sei",
-  "rpc": ["https://evm-rpc.sei-apis.com", "wss://evm-ws.sei-apis.com"],
+  "rpc": [
+    "https://evm-rpc.sei-apis.com",
+    "wss://evm-ws.sei-apis.com",
+    "https://rpc.nodeflare.app/sei/public"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Sei",

--- a/_data/chains/eip155-137.json
+++ b/_data/chains/eip155-137.json
@@ -11,7 +11,8 @@
     "https://polygon.gateway.tenderly.co",
     "wss://polygon.gateway.tenderly.co",
     "https://rpc.satelink.network/rpc/polygon",
-    "https://rpcfree.com/polygon-rpc"
+    "https://rpcfree.com/polygon-rpc",
+    "https://rpc.nodeflare.app/polygon/public"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-146.json
+++ b/_data/chains/eip155-146.json
@@ -4,7 +4,8 @@
   "rpc": [
     "https://rpc.soniclabs.com",
     "https://sonic-rpc.publicnode.com",
-    "wss://sonic-rpc.publicnode.com"
+    "wss://sonic-rpc.publicnode.com",
+    "https://rpc.nodeflare.app/sonic/public"
   ],
   "faucets": [],
   "nativeCurrency": {
@@ -12,7 +13,11 @@
     "symbol": "S",
     "decimals": 18
   },
-  "features": [{ "name": "EIP155" }],
+  "features": [
+    {
+      "name": "EIP155"
+    }
+  ],
   "infoURL": "https://soniclabs.com",
   "shortName": "sonic",
   "chainId": 146,

--- a/_data/chains/eip155-1868.json
+++ b/_data/chains/eip155-1868.json
@@ -3,7 +3,10 @@
   "shortName": "soneium",
   "title": "Soneium mainnet",
   "chain": "ETH",
-  "rpc": ["https://rpc.soneium.org"],
+  "rpc": [
+    "https://rpc.soneium.org",
+    "https://rpc.nodeflare.app/soneium/public"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",
@@ -35,6 +38,10 @@
   "parent": {
     "type": "L2",
     "chain": "eip155-1",
-    "bridges": [{ "url": "https://superbridge.app/soneium" }]
+    "bridges": [
+      {
+        "url": "https://superbridge.app/soneium"
+      }
+    ]
   }
 }

--- a/_data/chains/eip155-196.json
+++ b/_data/chains/eip155-196.json
@@ -1,7 +1,11 @@
 {
   "name": "X Layer Mainnet",
   "chain": "X Layer",
-  "rpc": ["https://rpc.xlayer.tech", "https://xlayerrpc.okx.com"],
+  "rpc": [
+    "https://rpc.xlayer.tech",
+    "https://xlayerrpc.okx.com",
+    "https://rpc.nodeflare.app/xlayer/public"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "X Layer Global Utility Token",

--- a/_data/chains/eip155-25.json
+++ b/_data/chains/eip155-25.json
@@ -6,9 +6,14 @@
     "https://cronos-evm-rpc.publicnode.com",
     "wss://cronos-evm-rpc.publicnode.com",
     "https://cronos.drpc.org",
-    "wss://cronos.drpc.org"
+    "wss://cronos.drpc.org",
+    "https://rpc.nodeflare.app/cronos/public"
   ],
-  "features": [{ "name": "EIP1559" }],
+  "features": [
+    {
+      "name": "EIP1559"
+    }
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Cronos",

--- a/_data/chains/eip155-34443.json
+++ b/_data/chains/eip155-34443.json
@@ -4,7 +4,8 @@
   "rpc": [
     "https://mainnet.mode.network",
     "https://mode.drpc.org",
-    "wss://mode.drpc.org"
+    "wss://mode.drpc.org",
+    "https://rpc.nodeflare.app/mode/public"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-42170.json
+++ b/_data/chains/eip155-42170.json
@@ -12,7 +12,8 @@
   "rpc": [
     "https://nova.arbitrum.io/rpc",
     "https://arbitrum-nova-rpc.publicnode.com",
-    "wss://arbitrum-nova-rpc.publicnode.com"
+    "wss://arbitrum-nova-rpc.publicnode.com",
+    "https://rpc.nodeflare.app/nova/public"
   ],
   "faucets": [],
   "explorers": [
@@ -27,6 +28,10 @@
   "parent": {
     "type": "L2",
     "chain": "eip155-1",
-    "bridges": [{ "url": "https://bridge.arbitrum.io" }]
+    "bridges": [
+      {
+        "url": "https://bridge.arbitrum.io"
+      }
+    ]
   }
 }

--- a/_data/chains/eip155-48900.json
+++ b/_data/chains/eip155-48900.json
@@ -2,7 +2,10 @@
   "name": "Zircuit Mainnet",
   "chain": "Zircuit Mainnet",
   "icon": "zircuit",
-  "rpc": ["https://mainnet.zircuit.com"],
+  "rpc": [
+    "https://mainnet.zircuit.com",
+    "https://rpc.nodeflare.app/zircuit/public"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "ETH",

--- a/_data/chains/eip155-5000.json
+++ b/_data/chains/eip155-5000.json
@@ -5,7 +5,8 @@
   "rpc": [
     "https://rpc.mantle.xyz",
     "https://mantle-rpc.publicnode.com",
-    "wss://mantle-rpc.publicnode.com"
+    "wss://mantle-rpc.publicnode.com",
+    "https://rpc.nodeflare.app/mantle/public"
   ],
   "faucets": [],
   "nativeCurrency": {
@@ -32,6 +33,10 @@
   "parent": {
     "type": "L2",
     "chain": "eip155-1",
-    "bridges": [{ "url": "https://bridge.mantle.xyz" }]
+    "bridges": [
+      {
+        "url": "https://bridge.mantle.xyz"
+      }
+    ]
   }
 }

--- a/_data/chains/eip155-57073.json
+++ b/_data/chains/eip155-57073.json
@@ -5,10 +5,20 @@
     "https://rpc-gel.inkonchain.com",
     "https://rpc-qnd.inkonchain.com",
     "wss://rpc-gel.inkonchain.com",
-    "wss://rpc-qnd.inkonchain.com"
+    "wss://rpc-qnd.inkonchain.com",
+    "https://rpc.nodeflare.app/ink/public"
   ],
-  "faucets": ["https://inkonchain.com/faucet"],
-  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "faucets": [
+    "https://inkonchain.com/faucet"
+  ],
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
+    }
+  ],
   "nativeCurrency": {
     "name": "Ether",
     "symbol": "ETH",

--- a/_data/chains/eip155-59144.json
+++ b/_data/chains/eip155-59144.json
@@ -8,7 +8,8 @@
     "https://linea-mainnet.infura.io/v3/${INFURA_API_KEY}",
     "wss://linea-mainnet.infura.io/ws/v3/${INFURA_API_KEY}",
     "https://linea-rpc.publicnode.com",
-    "wss://linea-rpc.publicnode.com"
+    "wss://linea-rpc.publicnode.com",
+    "https://rpc.nodeflare.app/linea/public"
   ],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/chains/eip155-60808.json
+++ b/_data/chains/eip155-60808.json
@@ -5,7 +5,8 @@
     "https://rpc.gobob.xyz",
     "wss://rpc.gobob.xyz",
     "https://bob-mainnet.public.blastapi.io",
-    "wss://bob-mainnet.public.blastapi.io"
+    "wss://bob-mainnet.public.blastapi.io",
+    "https://rpc.nodeflare.app/bob/public"
   ],
   "faucets": [],
   "nativeCurrency": {
@@ -30,6 +31,10 @@
   "parent": {
     "type": "L2",
     "chain": "eip155-1",
-    "bridges": [{ "url": "https://app.gobob.xyz" }]
+    "bridges": [
+      {
+        "url": "https://app.gobob.xyz"
+      }
+    ]
   }
 }

--- a/_data/chains/eip155-9745.json
+++ b/_data/chains/eip155-9745.json
@@ -1,7 +1,10 @@
 {
   "name": "Plasma Mainnet",
   "chain": "Plasma",
-  "rpc": ["https://rpc.plasma.to"],
+  "rpc": [
+    "https://rpc.plasma.to",
+    "https://rpc.nodeflare.app/plasma/public"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Plasma",


### PR DESCRIPTION
Adds NodeFlare's free public RPC endpoints (`https://rpc.nodeflare.app/{chain}/public`) to 15 chains: Unichain (130), Sonic (146), Polygon (137), Linea (59144), Mantle (5000), Zircuit (48900), XLayer (196), Soneium (1868), Arbitrum Nova (42170), BOB (60808), Ink (57073), Cronos (25), Mode (34443), Sei (1329), Plasma (9745).

All endpoints are live and verified — correct `eth_chainId`, synced to chain tip, no API key required, served from multi-region bare-metal nodes with automatic failover. Same provider as previously merged #8359.

🤖 Generated with [Claude Code](https://claude.com/claude-code)