### PR TITLE
Update BearNetworkChain (Chain ID 641230) Mainnet Name，RPC，NativeCurrency  Name，Explorers Name

### DIFF
--- a/_data/chains/eip155-641230.json
+++ b/_data/chains/eip155-641230.json
@@ -1,14 +1,16 @@
 {
-  "name": "Bear Network Chain Mainnet",
+  "name": "BearNetworkChain Mainnet",
   "chain": "BRNKC",
   "icon": "brnkc",
   "rpc": [
     "https://brnkc-mainnet.bearnetwork.net",
-    "https://brnkc-mainnet1.bearnetwork.net"
+    "https://brnkc-mainnet1.bearnetwork.net",
+    "https://bnes-mainnet.bearnetwork.net",
+    "https://bnes-mainnet1.bearnetwork.net"
   ],
   "faucets": [],
   "nativeCurrency": {
-    "name": "Bear Network Chain Native Token",
+    "name": "BRNKC",
     "symbol": "BRNKC",
     "decimals": 18
   },
@@ -18,7 +20,7 @@
   "networkId": 641230,
   "explorers": [
     {
-      "name": "brnkscan",
+      "name": "BNC Explorer",
       "url": "https://brnkscan.bearnetwork.net",
       "standard": "EIP3091"
     }

--- a/_data/icons/brnkc.json
+++ b/_data/icons/brnkc.json
@@ -1,8 +1,8 @@
 [
   {
     "url": "ipfs://QmQqhH28QpUrreoRw5Gj8YShzdHxxVGMjfVrx3TqJNLSLv",
-    "width": 1024,
-    "height": 1024,
+    "width": 1067,
+    "height": 1067,
     "format": "png"
   }
 ]

--- a/_data/icons/brnkc.json
+++ b/_data/icons/brnkc.json
@@ -1,8 +1,8 @@
 [
   {
     "url": "ipfs://QmQqhH28QpUrreoRw5Gj8YShzdHxxVGMjfVrx3TqJNLSLv",
-    "width": 1067,
-    "height": 1067,
+    "width": 1024,
+    "height": 1024,
     "format": "png"
   }
 ]


### PR DESCRIPTION
Update configuration details for BearNetworkChain Mainnet (Chain ID 641230).

Changes include:

* Name: Updated from Bear Network Chain Mainnet to BearNetworkChain Mainnet.

* RPC: added bnes-mainnet and bnes-mainnet1.

* Native Currency Name: Updated from Bear Network Chain Native Token to BRNKC.

* Explorer Name: Updated from brnkscan to BNC Explorer.