### PR TITLE
Add Morph Tachyon mainnet and testnet

### DIFF
--- a/_data/chains/eip155-2184.json
+++ b/_data/chains/eip155-2184.json
@@ -1,0 +1,24 @@
+{
+  "name": "Morph Tachyon",
+  "title": "Morph Tachyon Mainnet",
+  "chain": "Morph Tachyon",
+  "rpc": ["https://api.popdex.xyz/api/v1/web3/rpc"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "BGB",
+    "symbol": "BGB",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://popdex.xyz",
+  "shortName": "morphtachyon",
+  "chainId": 2184,
+  "networkId": 2184,
+  "explorers": [
+    {
+      "name": "Morph Tachyon Explorer",
+      "url": "https://app.popdex.xyz/explorer",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-2184.json
+++ b/_data/chains/eip155-2184.json
@@ -18,7 +18,7 @@
     {
       "name": "Morph Tachyon Explorer",
       "url": "https://app.popdex.xyz/explorer",
-      "standard": "EIP3091"
+      "standard": "none"
     }
   ]
 }

--- a/_data/chains/eip155-34952.json
+++ b/_data/chains/eip155-34952.json
@@ -1,5 +1,6 @@
 {
   "name": "Morph Tachyon Testnet",
+  "title": "Morph Tachyon Testnet",
   "chain": "Morph Tachyon",
   "rpc": ["https://testnet-api.popdex.xyz/api/v1/web3/rpc"],
   "faucets": [],
@@ -17,7 +18,7 @@
     {
       "name": "Morph Tachyon Testnet Explorer",
       "url": "https://testnet-app.popdex.xyz/explorer",
-      "standard": "EIP3091"
+      "standard": "none"
     }
   ]
 }

--- a/_data/chains/eip155-34952.json
+++ b/_data/chains/eip155-34952.json
@@ -1,0 +1,23 @@
+{
+  "name": "Morph Tachyon Testnet",
+  "chain": "Morph Tachyon",
+  "rpc": ["https://testnet-api.popdex.xyz/api/v1/web3/rpc"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "BGB",
+    "symbol": "BGB",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://popdex.xyz",
+  "shortName": "morphtachyontestnet",
+  "chainId": 34952,
+  "networkId": 34952,
+  "explorers": [
+    {
+      "name": "Morph Tachyon Testnet Explorer",
+      "url": "https://testnet-app.popdex.xyz/explorer",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Add `Morph Tachyon` mainnet and testnet

* `Morph Tachyon` mainnet
```
Chain ID: 2184
Native token: BGB (18 decimals) 
Chain rpc: https://api.popdex.xyz/api/v1/web3/rpc 
Website: https://popdex.xyz/ 
Explorer: https://app.popdex.xyz/explorer
```

* `Morph Tachyon` testnet
```
Chain ID: 34952
Native token: BGB (18 decimals) 
Chain rpc: https://testnet-api.popdex.xyz/api/v1/web3/rpc 
Website: https://popdex.xyz/ 
Explorer: https://testnet-app.popdex.xyz/explorer
```