### PR TITLE
Update Access Network (chainId 22888) - temporary domain during registry outage

### DIFF
--- a/_data/chains/eip155-22888.json
+++ b/_data/chains/eip155-22888.json
@@ -10,13 +10,13 @@
     "symbol": "ACCESS",
     "decimals": 18
   },
-  "rpc": ["https://accesschain.org/rpc"],
+  "rpc": ["https://accesschainapp.site/rpc"],
   "faucets": [],
-  "infoURL": "https://accesschain.org",
+  "infoURL": "https://accesschainapp.site",
   "explorers": [
     {
       "name": "Access Network Explorer",
-      "url": "https://accesschain.org/explorer",
+      "url": "https://accesschainapp.site/explorer",
       "standard": "EIP3091",
       "icon": "access"
     }

--- a/_data/chains/eip155-22888.json
+++ b/_data/chains/eip155-22888.json
@@ -10,13 +10,16 @@
     "symbol": "ACCESS",
     "decimals": 18
   },
-  "rpc": ["https://accesschainapp.site/rpc", "https://accesschain.org/rpc"],
+  "rpc": [
+    "https://accesschain.org/rpc",
+    "https://accesschainapp.site/rpc"
+  ],
   "faucets": [],
-  "infoURL": "https://accesschainapp.site",
+  "infoURL": "https://accesschain.org",
   "explorers": [
     {
       "name": "Access Network Explorer",
-      "url": "https://accesschainapp.site/explorer",
+      "url": "https://accesschain.org/explorer",
       "standard": "EIP3091",
       "icon": "access"
     }

--- a/_data/chains/eip155-22888.json
+++ b/_data/chains/eip155-22888.json
@@ -10,7 +10,7 @@
     "symbol": "ACCESS",
     "decimals": 18
   },
-  "rpc": ["https://accesschainapp.site/rpc"],
+  "rpc": ["https://accesschainapp.site/rpc", "https://accesschain.org/rpc"],
   "faucets": [],
   "infoURL": "https://accesschainapp.site",
   "explorers": [


### PR DESCRIPTION
## Update: accesschain.org restored as primary RPC

The primary domain `accesschain.org` has been restored and is fully resolving again.

This PR now reflects the correct production configuration:

- **Primary RPC:** `https://accesschain.org/rpc` — main domain, fully operational
- **Fallback RPC:** `https://accesschainapp.site/rpc` — backup domain, kept for redundancy

Both endpoints point to the same infrastructure (same server, same chain data).
The fallback is retained so wallet users experience zero downtime if either domain has a temporary issue in the future.

**No further PR will be needed** — this listing is now stable with dual-endpoint redundancy.
