### PR TITLE
feat: add relaunched Humanity Protocol chain (chainId 13600000), deprecate 6985385

### DIFF
--- a/_data/chains/eip155-13600000.json
+++ b/_data/chains/eip155-13600000.json
@@ -1,7 +1,7 @@
 {
-  "name": "Humanity Protocol",
+  "name": "Humanity",
   "chain": "Humanity",
-  "rpc": ["https://humanity-mainnet.g.alchemy.com/public"],
+  "rpc": ["https://humanity-main.g.alchemy.com/public"],
   "faucets": [],
   "nativeCurrency": {
     "name": "H",
@@ -14,19 +14,19 @@
     "chain": "eip155-42161",
     "bridges": [
       {
-        "url": "https://bridge.arbitrum.io"
+        "url": "https://bridge.humanity.org"
       }
     ]
   },
-  "shortName": "hpold",
-  "chainId": 6985385,
-  "networkId": 6985385,
-  "status": "deprecated",
+  "shortName": "hp",
+  "chainId": 13600000,
+  "networkId": 13600000,
+  "status": "active",
   "explorers": [
     {
       "name": "Humanity Mainnet explorer",
-      "url": "https://humanity-mainnet.explorer.alchemy.com",
-      "standard": "none"
+      "url": "https://humanity-main.explorer.alchemy.com",
+      "standard": "EIP3091"
     }
   ],
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }]


### PR DESCRIPTION
Adds the relaunched Humanity Protocol mainnet (chainId 13600000) and deprecates the previous chain (6985385).

Supersedes #8424, which points its RPC and explorer at the old 6985385 chain (`humanity-mainnet.g.alchemy.com` returns `eth_chainId = 0x6a96a9`), causing its `build` check to fail, and reuses the taken `hp` shortName without freeing it.

### Chain details (eip155-13600000)

- **Name:** Humanity — relaunch of the Humanity Protocol mainnet
- **RPC:** https://humanity-main.g.alchemy.com/public — verified: `eth_chainId` returns `0xcf8500` (13600000)
- **Explorer:** https://humanity-main.explorer.alchemy.com (Blockscout, EIP3091) — verified live
- **Native currency:** H (18 decimals); L2 on Arbitrum One (eip155-42161)
- **shortName:** `hp`, carried over from the deprecated chain (both chains are operated by the Humanity Protocol team; the relaunch is intended to take over the name)

### eip155-6985385 (old chain)

- `status` → `deprecated`
- `shortName` → `hpold` (frees `hp` for the relaunched chain, keeps uniqueness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)