### PR TITLE
Add Robinhood Chain mainnet

### DIFF
--- a/_data/chains/eip155-4663.json
+++ b/_data/chains/eip155-4663.json
@@ -1,0 +1,30 @@
+{
+  "name": "Robinhood Chain",
+  "title": "Robinhood Chain",
+  "chain": "ETH",
+  "rpc": ["https://rpc.mainnet.chain.robinhood.com"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://docs.robinhood.com/chain/",
+  "shortName": "rh",
+  "chainId": 4663,
+  "networkId": 4663,
+  "slip44": 60,
+  "explorers": [
+    {
+      "name": "blockscout",
+      "url": "https://robinhoodchain.blockscout.com",
+      "icon": "blockscout",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-1",
+    "bridges": [{ "url": "https://portal.arbitrum.io/bridge" }]
+  }
+}


### PR DESCRIPTION
## Summary
- add Robinhood Chain mainnet metadata for chain ID 4663
- include the public mainnet RPC, Blockscout explorer, ETH native currency, and Ethereum L1 parent bridge metadata

## Verification
- `curl` eth_chainId against `https://rpc.mainnet.chain.robinhood.com` returned `0x1237`
- `npx prettier --check _data/chains/eip155-4663.json`
- `git diff --check`
- `JAVA_HOME=/opt/homebrew/opt/openjdk ./gradlew run`

References:
- https://docs.robinhood.com/chain/
- https://robinhood.com/us/en/chain/