### PR TITLE
Add NodeFlare public RPC to 4 under-served chains (Plasma, Soneium, Zircuit, Sei)

### DIFF
--- a/_data/chains/eip155-1329.json
+++ b/_data/chains/eip155-1329.json
@@ -1,7 +1,7 @@
 {
   "name": "Sei Network",
   "chain": "Sei",
-  "rpc": ["https://evm-rpc.sei-apis.com", "wss://evm-ws.sei-apis.com"],
+  "rpc": ["https://evm-rpc.sei-apis.com", "wss://evm-ws.sei-apis.com", "https://rpc.nodeflare.app/sei/public"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Sei",

--- a/_data/chains/eip155-1868.json
+++ b/_data/chains/eip155-1868.json
@@ -3,7 +3,7 @@
   "shortName": "soneium",
   "title": "Soneium mainnet",
   "chain": "ETH",
-  "rpc": ["https://rpc.soneium.org"],
+  "rpc": ["https://rpc.soneium.org", "https://rpc.nodeflare.app/soneium/public"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",

--- a/_data/chains/eip155-48900.json
+++ b/_data/chains/eip155-48900.json
@@ -2,7 +2,7 @@
   "name": "Zircuit Mainnet",
   "chain": "Zircuit Mainnet",
   "icon": "zircuit",
-  "rpc": ["https://mainnet.zircuit.com"],
+  "rpc": ["https://mainnet.zircuit.com", "https://rpc.nodeflare.app/zircuit/public"],
   "faucets": [],
   "nativeCurrency": {
     "name": "ETH",

--- a/_data/chains/eip155-9745.json
+++ b/_data/chains/eip155-9745.json
@@ -1,7 +1,7 @@
 {
   "name": "Plasma Mainnet",
   "chain": "Plasma",
-  "rpc": ["https://rpc.plasma.to"],
+  "rpc": ["https://rpc.plasma.to", "https://rpc.nodeflare.app/plasma/public"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Plasma",


### PR DESCRIPTION
Adds NodeFlare's public RPC endpoint to four chains that currently list only a single HTTPS RPC, giving builders a fallback if the primary endpoint is down.

| Chain | File | Existing HTTPS RPC | Added |
|---|---|---|---|
| Plasma Mainnet | eip155-9745 | 1 | `https://rpc.nodeflare.app/plasma/public` |
| Soneium | eip155-1868 | 1 | `https://rpc.nodeflare.app/soneium/public` |
| Zircuit | eip155-48900 | 1 | `https://rpc.nodeflare.app/zircuit/public` |
| Sei Network | eip155-1329 | 1 | `https://rpc.nodeflare.app/sei/public` |

Each endpoint returns the correct `eth_chainId` and serves standard JSON-RPC with no key required. NodeFlare runs its own dedicated nodes for these chains across multiple regions with automatic failover.

Kept the diff to a single added URL per file; no other fields touched.
