### PR TITLE
Add LXS (chainId 22540)

### DIFF
--- a/_data/chains/eip155-22540.json
+++ b/_data/chains/eip155-22540.json
@@ -1,5 +1,5 @@
 {
-  "name": "LXS Network",
+  "name": "LXS",
   "chain": "LXS",
   "rpc": [
     "https://lxsnetwork.duckdns.org"

--- a/_data/chains/eip155-22540.json
+++ b/_data/chains/eip155-22540.json
@@ -1,0 +1,23 @@
+{
+  "name": "LXS Network",
+  "chain": "LXS",
+  "rpc": [
+    "https://lxsnetwork.duckdns.org"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "LXS",
+    "symbol": "LXS",
+    "decimals": 18
+  },
+  "features": [
+    {
+      "name": "EIP155"
+    }
+  ],
+  "infoURL": "https://lxs-network.github.io/",
+  "shortName": "lxs",
+  "chainId": 22540,
+  "networkId": 22540,
+  "explorers": []
+}


### PR DESCRIPTION
Adds LXS Network, an EVM-compatible proof-of-work Layer-1.

- Chain ID: 22540 (`eth_chainId` returns `0x580c`)
- Native currency: LXS (18 decimals)
- Public RPC: https://lxsnetwork.duckdns.org
- Website: https://lxs-network.github.io/
- EIP-155 supported. No block explorer yet (`explorers: []`).

shortName `lxs` and chainId 22540 are unused in the registry.