### PR TITLE
Add AEREDIUM Testnet (chainId 2237); deprecate AEREDIUM Testnet 1 (chainId 1237)

### DIFF
--- a/_data/chains/eip155-1237.json
+++ b/_data/chains/eip155-1237.json
@@ -1,9 +1,10 @@
 {
-  "name": "AEREDIUM Testnet",
-  "title": "AEREDIUM Testnet",
+  "name": "AEREDIUM Testnet 1",
+  "title": "AEREDIUM Testnet 1",
   "chain": "AER",
-  "rpc": ["https://testnet.rpc.aeredium.io"],
-  "faucets": ["https://aeredium.io/faucet.html"],
+  "status": "deprecated",
+  "rpc": [],
+  "faucets": [],
   "nativeCurrency": {
     "name": "Testnet AER",
     "symbol": "tAER",
@@ -16,11 +17,5 @@
   "networkId": 1237,
   "slip44": 1,
   "icon": "aeredium",
-  "explorers": [
-    {
-      "name": "AEREDIUM Testnet Explorer",
-      "url": "https://testnet.explorer.aeredium.io",
-      "standard": "EIP3091"
-    }
-  ]
+  "explorers": []
 }

--- a/_data/chains/eip155-2237.json
+++ b/_data/chains/eip155-2237.json
@@ -1,0 +1,26 @@
+{
+  "name": "AEREDIUM Testnet",
+  "title": "AEREDIUM Testnet",
+  "chain": "AER",
+  "rpc": ["https://testnet.rpc.aeredium.io"],
+  "faucets": ["https://aeredium.io/faucet.html"],
+  "nativeCurrency": {
+    "name": "SEAR",
+    "symbol": "SEAR",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://aeredium.io",
+  "shortName": "sea",
+  "chainId": 2237,
+  "networkId": 2237,
+  "slip44": 1,
+  "icon": "aeredium",
+  "explorers": [
+    {
+      "name": "AEREDIUM Testnet Explorer",
+      "url": "https://testnet.explorer.aeredium.io",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Adds eip155-2237.json for AEREDIUM Testnet, the public test network for the AEREDIUM L1 (EVM-compatible, TEE-BFT consensus). Native currency is SEAR. RPC, faucet, and explorer are live and the RPC reports chain ID 2237.

Also updates eip155-1237.json: that network is retired and replaced by 2237. It is renamed "AEREDIUM Testnet 1", marked "status": "deprecated", and its RPC/faucet/explorer entries are emptied because those URLs now serve the new chain. Its shortName is unchanged.

Companion to the existing AEREDIUM entries: mainnet 237 aer) and the deprecated 1237 aer-testnet).