### PR TITLE
Update Citrate (chainId 40204): add explorer + active status

### DIFF
--- a/_data/chains/eip155-40204.json
+++ b/_data/chains/eip155-40204.json
@@ -12,5 +12,13 @@
   "infoURL": "https://citrate.ai",
   "shortName": "citrate",
   "chainId": 40204,
-  "networkId": 40204
+  "networkId": 40204,
+  "status": "active",
+  "explorers": [
+    {
+      "name": "CitrateScan",
+      "url": "https://explorer.citrate.ai",
+      "standard": "EIP3091"
+    }
+  ]
 }


### PR DESCRIPTION
The existing `eip155-40204.json` (Citrate) has no `explorers` array, so chainlist.org shows no block-explorer link for the chain. This adds:

- `explorers`: CitrateScan (`https://explorer.citrate.ai`, EIP-3091 standard)
- `status`: `active`

RPC `https://rpc.citrate.ai` responds to `eth_chainId` with `0x9d0c` (40204). No other fields changed.