### PR TITLE
Add RPC and explorer for Ault Blockchain (904, 10904)

### DIFF
--- a/_data/chains/eip155-10904.json
+++ b/_data/chains/eip155-10904.json
@@ -2,7 +2,7 @@
   "name": "Ault Blockchain Testnet",
   "chain": "AULT",
   "icon": "ault",
-  "rpc": [],
+  "rpc": ["https://test-json-rpc.cloud.aultblockchain.xyz"],
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "faucets": [],
   "nativeCurrency": {
@@ -14,5 +14,12 @@
   "shortName": "ault-testnet",
   "chainId": 10904,
   "networkId": 10904,
-  "explorers": []
+  "explorers": [
+    {
+      "name": "Ault Testnet Explorer",
+      "url": "https://ault-testnet.explorer.orynt.tech",
+      "standard": "EIP3091",
+      "icon": "ault"
+    }
+  ]
 }

--- a/_data/chains/eip155-904.json
+++ b/_data/chains/eip155-904.json
@@ -2,7 +2,7 @@
   "name": "Ault Blockchain Mainnet",
   "chain": "AULT",
   "icon": "ault",
-  "rpc": [],
+  "rpc": ["https://main-json-rpc.cloud.aultblockchain.xyz"],
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "faucets": [],
   "nativeCurrency": {
@@ -14,5 +14,12 @@
   "shortName": "ault",
   "chainId": 904,
   "networkId": 904,
-  "explorers": []
+  "explorers": [
+    {
+      "name": "Ault Mainnet Explorer",
+      "url": "https://ault.explorer.orynt.tech",
+      "standard": "EIP3091",
+      "icon": "ault"
+    }
+  ]
 }


### PR DESCRIPTION
Adds RPC endpoints and block explorers for Ault Blockchain Mainnet (904) and Testnet (10904).

- Mainnet RPC: https://main-json-rpc.cloud.aultblockchain.xyz (eth_chainId -> 0x388)
- Mainnet explorer: https://ault.explorer.orynt.tech
- Testnet RPC: https://test-json-rpc.cloud.aultblockchain.xyz (eth_chainId -> 0x2a98)
- Testnet explorer: https://ault-testnet.explorer.orynt.tech