### PR TITLE
Add Veri5 (chain ID 63868)

### DIFF
--- a/_data/chains/eip155-63868.json
+++ b/_data/chains/eip155-63868.json
@@ -1,0 +1,23 @@
+{
+  "name": "Veri5",
+  "chain": "VERI5",
+  "rpc": ["https://rpc0.veri5.network"],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Unit",
+    "symbol": "UNIT",
+    "decimals": 18
+  },
+  "infoURL": "https://veri5.technology",
+  "shortName": "veri5",
+  "chainId": 63868,
+  "networkId": 63868,
+  "explorers": [
+    {
+      "name": "Veri5 Explorer",
+      "url": "https://explorer.veri5.network",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-63868.json
+++ b/_data/chains/eip155-63868.json
@@ -1,6 +1,7 @@
 {
   "name": "Veri5",
   "chain": "VERI5",
+  "icon": "veri5",
   "rpc": ["https://rpc0.veri5.network"],
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "faucets": [],

--- a/_data/icons/veri5.json
+++ b/_data/icons/veri5.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafybeihqekabx2rg2m2crfg3r63fmcngqj5ghk4gucknmr66empihp6bfq",
+    "width": 1024,
+    "height": 1024,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Adds **Veri5** (chain ID 63868), an EIP-1559 EVM network operated by Hefes LLC.

- **RPC:** https://rpc0.veri5.network (returns chainId `0xf97c` / 63868)
- **Explorer:** https://explorer.veri5.network (Blockscout, EIP-3091)
- **Native currency:** Unit (UNIT), 18 decimals
- **Info:** https://veri5.technology

Single new file `_data/chains/eip155-63868.json`. shortName `veri5` and chainId `63868` are unique.