### PR TITLE
Updates Rome mainnet to Rubicon, deprecates Caelian and Aventine

### DIFF
--- a/_data/chains/eip155-121215.json
+++ b/_data/chains/eip155-121215.json
@@ -1,11 +1,11 @@
 {
   "name": "Rome Testnet Caelian",
   "chain": "ROME",
-  "rpc": ["https://caelian-i.testnet.romeprotocol.xyz"],
-  "faucets": ["https://deposit.testnet.romeprotocol.xyz"],
+  "rpc": [],
+  "faucets": [],
   "nativeCurrency": {
-    "name": "RSOL",
-    "symbol": "RSOL",
+    "name": "USDC",
+    "symbol": "USDC",
     "decimals": 18
   },
   "infoURL": "https://rome.builders",
@@ -13,13 +13,5 @@
   "chainId": 121215,
   "networkId": 121215,
   "icon": "rome",
-  "explorers": [
-    {
-      "name": "Rome Testnet Caelian Explorer",
-      "url": "https://romescout-caelian-i.testnet.romeprotocol.xyz",
-      "icon": "rome",
-      "standard": "EIP3091"
-    }
-  ],
-  "status": "active"
+  "status": "deprecated"
 }

--- a/_data/chains/eip155-7531.json
+++ b/_data/chains/eip155-7531.json
@@ -1,14 +1,11 @@
 {
-  "name": "Rome Palatine",
+  "name": "Rome Rubicon Mainnet",
   "chain": "ROME",
-  "rpc": [
-    "https://palatine.romeprotocol.xyz",
-    "https://palatine2.romeprotocol.xyz"
-  ],
-  "faucets": [],
+  "rpc": ["https://rubicon.mainnet.romeprotocol.xyz"],
+  "faucets": ["https://app.mainnet.romeprotocol.xyz"],
   "nativeCurrency": {
-    "name": "RSOL",
-    "symbol": "RSOL",
+    "name": "USDC",
+    "symbol": "USDC",
     "decimals": 18
   },
   "infoURL": "https://rome.builders",
@@ -18,11 +15,10 @@
   "icon": "rome",
   "explorers": [
     {
-      "name": "Rome Palatine Explorer",
-      "url": "https://romescout-palatine.romeprotocol.xyz",
+      "name": "Rome Via Rubicon",
+      "url": "https://via-rubicon.mainnet.romeprotocol.xyz",
       "icon": "rome",
       "standard": "EIP3091"
     }
-  ],
-  "status": "active"
+  ]
 }

--- a/_data/chains/eip155-7532.json
+++ b/_data/chains/eip155-7532.json
@@ -1,11 +1,11 @@
 {
   "name": "Rome Mainnet 0 Aventine",
   "chain": "ROME",
-  "rpc": ["https://aventine-i.mainnet-0.romeprotocol.xyz"],
-  "faucets": ["https://deposit.mainnet-0.romeprotocol.xyz"],
+  "rpc": [],
+  "faucets": [],
   "nativeCurrency": {
-    "name": "RSOL",
-    "symbol": "RSOL",
+    "name": "USDC",
+    "symbol": "USDC",
     "decimals": 18
   },
   "infoURL": "https://rome.builders",
@@ -13,13 +13,5 @@
   "chainId": 7532,
   "networkId": 7532,
   "icon": "rome",
-  "explorers": [
-    {
-      "name": "Rome Mainnet 0 Aventine Explorer",
-      "url": "https://romescout-aventine-i.mainnet-0.romeprotocol.xyz",
-      "icon": "rome",
-      "standard": "EIP3091"
-    }
-  ],
-  "status": "active"
+  "status": "deprecated"
 }


### PR DESCRIPTION
Updates Rome chains for https://rome.builders

- eip155-7531: Rome mainnet is now Rubicon (replaces Palatine) — new RPC and Via explorer, native currency is USDC
- eip155-121215 (Caelian testnet) and eip155-7532 (Aventine mainnet-0): decommissioned, marked deprecated with offline endpoints removed

Follow up to https://github.com/ethereum-lists/chains/pull/8538