### PR TITLE
Add Haus Chain Testnet (2443)

### DIFF
--- a/_data/chains/eip155-2443.json
+++ b/_data/chains/eip155-2443.json
@@ -1,0 +1,23 @@
+{
+  "name": "Haus Chain Testnet",
+  "chain": "HAUS",
+  "rpc": ["https://rpc-testnet.hausserver.xyz"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Haus",
+    "symbol": "HAUS",
+    "decimals": 18
+  },
+  "infoURL": "https://hausserver.xyz",
+  "shortName": "t-haus",
+  "chainId": 2443,
+  "networkId": 2443,
+  "status": "active",
+  "explorers": [
+    {
+      "name": "Haus Chain Testnet Explorer",
+      "url": "https://explorer-testnet.hausserver.xyz",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-2443.json
+++ b/_data/chains/eip155-2443.json
@@ -1,14 +1,25 @@
 {
   "name": "Haus Chain Testnet",
   "chain": "HAUS",
-  "rpc": ["https://rpc-testnet.hausserver.xyz"],
-  "faucets": [],
+  "rpc": [
+    "https://rpc-testnet.hausserver.xyz",
+    "wss://rpc-testnet.hausserver.xyz"
+  ],
+  "faucets": ["https://faucet-testnet.hausserver.xyz"],
   "nativeCurrency": {
     "name": "Haus",
     "symbol": "HAUS",
     "decimals": 18
   },
-  "infoURL": "https://hausserver.xyz",
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
+    }
+  ],
+  "infoURL": "https://www.hausserver.xyz",
   "shortName": "t-haus",
   "chainId": 2443,
   "networkId": 2443,


### PR DESCRIPTION
## Haus Chain Testnet — Chain ID 2443

Adds the live Haus Chain Testnet to the EVM chain registry.

### Network

- Chain ID: `2443`
- Network ID: `2443`
- Chain ID hex: `0x98b`
- Native currency: `HAUS`
- Decimals: `18`
- Status: Active
- EVM compatible: Yes

### Public endpoints

- HTTP RPC: https://rpc-testnet.hausserver.xyz
- WebSocket RPC: wss://rpc-testnet.hausserver.xyz
- Explorer: https://explorer-testnet.hausserver.xyz
- Faucet: https://faucet-testnet.hausserver.xyz
- Website: https://www.hausserver.xyz

### Verification

The live RPC returns:

- `eth_chainId`: `0x98b`
- `net_version`: `2443`

The explorer is a live Blockscout instance and Haus Chain Testnet has already
been accepted into the Blockscout ChainScout registry:

https://github.com/blockscout/chainscout/pull/271

Local repository validation completed successfully:

- `./gradlew run` — BUILD SUCCESSFUL
- Prettier — passed
- JSON validation — passed
- `git diff --check` — passed

This submission is for Haus Chain Testnet only.
