### PR TITLE
Add Haus Chain mainnet

### DIFF
--- a/_data/chains/eip155-2445.json
+++ b/_data/chains/eip155-2445.json
@@ -1,0 +1,23 @@
+{
+  "name": "Haus Chain",
+  "chain": "HAUS",
+  "rpc": ["https://rpc-mainnet.hausserver.xyz"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Haus",
+    "symbol": "HAUS",
+    "decimals": 18
+  },
+  "infoURL": "https://hausserver.xyz",
+  "shortName": "haus",
+  "chainId": 2445,
+  "networkId": 2445,
+  "status": "active",
+  "explorers": [
+    {
+      "name": "Haus Chain Explorer",
+      "url": "https://explorer-mainnet.hausserver.xyz",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Adds Haus Chain mainnet to the ethereum-lists chain registry.

- Network: Haus Chain
- Chain ID: 2445 (`0x98d`)
- shortName: `haus`
- Native currency: Haus (`HAUS`), 18 decimals
- RPC: https://rpc-mainnet.hausserver.xyz
- Explorer: https://explorer-mainnet.hausserver.xyz
- Faucet: none
- Status: active

This is a separate mainnet submission from the Haus Chain Testnet PR.

Pre-submission checks completed:
- live `eth_chainId` returned `0x98d`
- live `eth_blockNumber` responded
- mainnet explorer responded
- chain ID/name/shortName collision checks passed
- Prettier completed
- Gradle detected a full JDK
- `./gradlew run` completed successfully