### PR TITLE
Add Coinbosa Chain (26262)

### DIFF
--- a/_data/chains/eip155-26262.json
+++ b/_data/chains/eip155-26262.json
@@ -1,0 +1,25 @@
+{
+  "name": "Coinbosa Chain",
+  "chain": "BOSA",
+  "rpc": [
+    "https://explorer.coinbosa.com/rpc"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Coinbosa",
+    "symbol": "BOSA",
+    "decimals": 18
+  },
+  "infoURL": "https://coinbosa.com",
+  "shortName": "bosa",
+  "chainId": 26262,
+  "networkId": 26262,
+  "icon": "coinbosa",
+  "explorers": [
+    {
+      "name": "Coinbosa Explorer",
+      "url": "https://explorer.coinbosa.com",
+      "standard": "none"
+    }
+  ]
+}

--- a/_data/chains/eip155-26262.json
+++ b/_data/chains/eip155-26262.json
@@ -1,9 +1,7 @@
 {
   "name": "Coinbosa Chain",
   "chain": "BOSA",
-  "rpc": [
-    "https://explorer.coinbosa.com/rpc"
-  ],
+  "rpc": ["https://explorer.coinbosa.com/rpc"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Coinbosa",

--- a/_data/icons/coinbosa.json
+++ b/_data/icons/coinbosa.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreiaid7e3fiurx6ubdyjrbzlmrkvvrax5z5gjuoavdgv5dnu4usxb4a",
+    "width": 96,
+    "height": 96,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Adds Coinbosa Chain, an EVM-compatible network. Native currency: BOSA (18 decimals). RPC and explorer are live and serve eth_chainId 0x6696.