### PR TITLE
Update EAV7 icon and name (chainId 72020)

### DIFF
--- a/_data/chains/eip155-72020.json
+++ b/_data/chains/eip155-72020.json
@@ -1,8 +1,10 @@
 {
-  "name": "EAV7 EAVM",
+  "name": "EAV7",
   "chain": "EAV7",
   "icon": "eav7",
-  "rpc": ["https://rpc.eavscan.com"],
+  "rpc": [
+    "https://rpc.eavscan.com"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "EAV7",

--- a/_data/chains/eip155-72020.json
+++ b/_data/chains/eip155-72020.json
@@ -2,9 +2,7 @@
   "name": "EAV7",
   "chain": "EAV7",
   "icon": "eav7",
-  "rpc": [
-    "https://rpc.eavscan.com"
-  ],
+  "rpc": ["https://rpc.eavscan.com"],
   "faucets": [],
   "nativeCurrency": {
     "name": "EAV7",

--- a/_data/icons/eav7.json
+++ b/_data/icons/eav7.json
@@ -1,8 +1,8 @@
 [
   {
-    "url": "ipfs://QmWYAX1nqKS2wpsMKcKpPEiJG1HDV2J9ysyz5Uz1knumDd",
+    "url": "ipfs://QmdbLKnuZNeiPnuUE8rKS2XGuWA2TsjMG5ZiXk5r3fqPCu",
     "width": 512,
-    "height": 504,
+    "height": 512,
     "format": "png"
   }
 ]


### PR DESCRIPTION
## Summary

Update the EAV7 network icon and display name for Chain ID **72020**.

| | |
|---|---|
| **Chain** | EAV7 (`eip155-72020`) |
| **Icon** | `eav7` |
| **New CID** | `ipfs://QmdbLKnuZNeiPnuUE8rKS2XGuWA2TsjMG5ZiXk5r3fqPCu` |
| **Size** | 512×512 PNG |
| **Name** | `EAV7 EAVM` → **`EAV7`** (cleaner wallet label) |

### Preview / mirrors

- IPFS: `ipfs://QmdbLKnuZNeiPnuUE8rKS2XGuWA2TsjMG5ZiXk5r3fqPCu`
- HTTPS mirror: https://eavscan.com/icon-512.png
- App icon: https://eavscan.com/icon.png

### Verification

```bash
ipfs get QmdbLKnuZNeiPnuUE8rKS2XGuWA2TsjMG5ZiXk5r3fqPCu
# or
curl -L -o eav7.png https://eavscan.com/icon-512.png
file eav7.png   # PNG image data, 512 x 512
```

RPC/explorer unchanged and live:

- RPC: https://rpc.eavscan.com (`eth_chainId` → `0x11954`)
- Explorer: https://eavscan.com (EIP-3091)

Thank you for reviewing.
