### PR TITLE
Add SELEMAN Chain (chainId 73571)

### DIFF
--- a/_data/chains/eip155-73571.json
+++ b/_data/chains/eip155-73571.json
@@ -1,0 +1,34 @@
+{
+  "name": "SELEMAN Chain",
+  "chain": "SMN",
+  "rpc": [
+    "https://seleman.monarcaproject.com/rpc",
+    "https://seleman-edge.mineriafjs.workers.dev/rpc",
+    "wss://seleman-ws.monarcaproject.com"
+  ],
+  "faucets": ["https://seleman.monarcaproject.com/trust-wallet"],
+  "nativeCurrency": {
+    "name": "SELEMAN",
+    "symbol": "SMN",
+    "decimals": 18
+  },
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
+    }
+  ],
+  "infoURL": "https://seleman.monarcaproject.com/seleman-chain",
+  "shortName": "seleman",
+  "chainId": 73571,
+  "networkId": 73571,
+  "explorers": [
+    {
+      "name": "seleman",
+      "url": "https://seleman.monarcaproject.com",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds `eip155-73571.json` for **SELEMAN Chain**.

## Live endpoints (verified)
- Explorer: https://seleman.monarcaproject.com → **HTTP 200**
- RPC: https://seleman.monarcaproject.com/rpc → `eth_chainId` = `0x11f63`
- Fallback RPC: https://seleman-edge.mineriafjs.workers.dev/rpc
- WSS: wss://seleman-ws.monarcaproject.com

## Note
Supersedes #8549 (same chain entry; new branch so Actions can run after prior first-time approval).