### PR TITLE
Add Garuda Chain Mainnet icon (8846)

### DIFF
--- a/_data/chains/eip155-8846.json
+++ b/_data/chains/eip155-8846.json
@@ -19,5 +19,6 @@
       "standard": "EIP3091"
     }
   ],
-  "status": "active"
+  "status": "active",
+  "icon": "garuda"
 }

--- a/_data/icons/garuda.json
+++ b/_data/icons/garuda.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreicnrzbtgdhqbkruyoii3wtuevngdb5dmdy32uer67jx633l5cg4zm",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Adds the Garuda Chain Mainnet icon and links it from `eip155-8846`.

- `_data/icons/garuda.json`
- `"icon": "garuda"` in `_data/chains/eip155-8846.json`

Icon: `ipfs://bafkreicnrzbtgdhqbkruyoii3wtuevngdb5dmdy32uer67jx633l5cg4zm` (512x512 PNG, under 250KB)

Follow-up to #8494.