### PR TITLE
Reserve chain ID 1663 for Liquichain Staging

### DIFF
--- a/_data/chains/eip155-1663.json
+++ b/_data/chains/eip155-1663.json
@@ -1,27 +1,17 @@
 {
-  "name": "Horizen Gobi Testnet",
-  "shortName": "Gobi",
-  "chain": "Gobi",
-  "icon": "eon",
+  "name": "Liquichain Staging",
+  "shortName": "lqcstg",
+  "chain": "LQC",
   "rpc": [],
-  "features": [
-    {
-      "name": "EIP155"
-    },
-    {
-      "name": "EIP1559"
-    }
-  ],
   "faucets": [],
   "nativeCurrency": {
-    "name": "Testnet Zen",
-    "symbol": "tZEN",
+    "name": "Test Licoin",
+    "symbol": "tLCN",
     "decimals": 18
   },
-  "infoURL": "https://horizen.io/",
+  "infoURL": "https://liquichain.io/",
   "chainId": 1663,
   "networkId": 1663,
-  "slip44": 1,
-  "explorers": [],
-  "status": "deprecated"
+  "status": "incubating",
+  "redFlags": ["reusedChainId"]
 }


### PR DESCRIPTION
## Summary

Reassigns the deprecated chain ID `1663` from Horizen Gobi Testnet to the incubating Liquichain Staging network.

Liquichain mainnet is already registered as chain ID `1662`; using `1663` for staging keeps the two environments distinct while preserving the existing mainnet identity.

## Reassignment

- The existing Horizen Gobi Testnet entry is already marked `deprecated`.
- The replacement explicitly carries `redFlags: ["reusedChainId"]`.
- The staging network does not import Gobi state, assets, or history.
- Liquichain Staging uses independent signing keys and test currency `tLCN`.

The network is marked `incubating`. Public RPC, explorer, and faucet metadata are intentionally left empty until the staging deployment is available; a follow-up PR will add verified endpoints.

## Validation

- JSON parsed successfully with `jq`.
- Prettier check passed.
- Entry passed the repository JSON schema with `ajv-cli`.
- The Gradle validator could not be run locally because this environment has no JDK; GitHub CI will run the official checks.
