### PR TITLE
Add Xitcoin Testnet (101089)

### DIFF
--- a/_data/chains/eip155-101088.json
+++ b/_data/chains/eip155-101088.json
@@ -5,7 +5,7 @@
   "rpc": ["https://network.xitcoin.org"],
   "nativeCurrency": {
     "name": "Xitcoin",
-    "symbol": "$XTC",
+    "symbol": "XTC",
     "decimals": 8
   },
   "infoURL": "https://docs.xitcoin.org/",

--- a/_data/chains/eip155-101088.json
+++ b/_data/chains/eip155-101088.json
@@ -2,9 +2,7 @@
   "name": "Xitcoin",
   "chain": "XITCOIN",
   "faucets": [],
-  "rpc": [
-    "https://network.xitcoin.org"
-  ],
+  "rpc": ["https://network.xitcoin.org"],
   "nativeCurrency": {
     "name": "Xitcoin",
     "symbol": "XTC",

--- a/_data/chains/eip155-101088.json
+++ b/_data/chains/eip155-101088.json
@@ -2,13 +2,15 @@
   "name": "Xitcoin",
   "chain": "XITCOIN",
   "faucets": [],
-  "rpc": ["https://network.xitcoin.org"],
+  "rpc": [
+    "https://network.xitcoin.org"
+  ],
   "nativeCurrency": {
     "name": "Xitcoin",
     "symbol": "XTC",
-    "decimals": 8
+    "decimals": 18
   },
-  "infoURL": "https://github.com/xitcoin-org/pos-chain",
+  "infoURL": "https://xitcoin.gitbook.io/guide/",
   "shortName": "Xitcoin",
   "chainId": 101088,
   "networkId": 101088,

--- a/_data/chains/eip155-101088.json
+++ b/_data/chains/eip155-101088.json
@@ -8,7 +8,7 @@
     "symbol": "XTC",
     "decimals": 8
   },
-  "infoURL": "https://docs.xitcoin.org/",
+  "infoURL": "https://github.com/xitcoin-org/pos-chain",
   "shortName": "Xitcoin",
   "chainId": 101088,
   "networkId": 101088,

--- a/_data/chains/eip155-101089.json
+++ b/_data/chains/eip155-101089.json
@@ -8,7 +8,7 @@
     "symbol": "XTC",
     "decimals": 18
   },
-  "infoURL": "https://docs.xitcoin.org/",
+  "infoURL": "https://github.com/xitcoin-org/pos-chain",
   "shortName": "xtct",
   "chainId": 101089,
   "networkId": 101089,

--- a/_data/chains/eip155-101089.json
+++ b/_data/chains/eip155-101089.json
@@ -1,0 +1,23 @@
+{
+  "name": "Xitcoin Testnet",
+  "chain": "XITCOIN",
+  "faucets": ["https://faucet-testnet.xitcoin.org/"],
+  "rpc": ["https://evm-rpc-testnet.xitcoin.org"],
+  "nativeCurrency": {
+    "name": "Xitcoin",
+    "symbol": "XTC",
+    "decimals": 18
+  },
+  "infoURL": "https://docs.xitcoin.org/",
+  "shortName": "xtct",
+  "chainId": 101089,
+  "networkId": 101089,
+  "icon": "xitcoin",
+  "explorers": [
+    {
+      "name": "Xitcoin Testnet Explorer",
+      "url": "https://evm-explorer-testnet.xitcoin.org",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-101089.json
+++ b/_data/chains/eip155-101089.json
@@ -1,14 +1,18 @@
 {
   "name": "Xitcoin Testnet",
   "chain": "XITCOIN",
-  "faucets": ["https://faucet-testnet.xitcoin.org/"],
-  "rpc": ["https://evm-rpc-testnet.xitcoin.org"],
+  "faucets": [
+    "https://faucet-testnet.xitcoin.org/"
+  ],
+  "rpc": [
+    "https://evm-rpc-testnet.xitcoin.org"
+  ],
   "nativeCurrency": {
     "name": "Xitcoin",
     "symbol": "XTC",
     "decimals": 18
   },
-  "infoURL": "https://github.com/xitcoin-org/pos-chain",
+  "infoURL": "https://xitcoin.gitbook.io/guide/",
   "shortName": "xtct",
   "chainId": 101089,
   "networkId": 101089,

--- a/_data/chains/eip155-101089.json
+++ b/_data/chains/eip155-101089.json
@@ -1,12 +1,8 @@
 {
   "name": "Xitcoin Testnet",
   "chain": "XITCOIN",
-  "faucets": [
-    "https://faucet-testnet.xitcoin.org/"
-  ],
-  "rpc": [
-    "https://evm-rpc-testnet.xitcoin.org"
-  ],
+  "faucets": ["https://faucet-testnet.xitcoin.org/"],
+  "rpc": ["https://evm-rpc-testnet.xitcoin.org"],
   "nativeCurrency": {
     "name": "Xitcoin",
     "symbol": "XTC",


### PR DESCRIPTION
## Summary

- add Xitcoin Testnet with EVM chain ID 101089
- add the public EVM RPC endpoint
- add the public faucet and EIP-3091 Blockscout explorer
- use XTC with 18 native EVM decimals
- correct the existing Xitcoin mainnet symbol from $XTC to XTC

## Verification

- EVM `eth_chainId`: `0x18ae1`
- public RPC operational
- public explorer operational
- public faucet operational
- repository `tools/schemaCheck.js` completed successfully