### PR TITLE
Add RPC URLs and explorer to eip155-5550.json

### DIFF
--- a/_data/chains/eip155-5550.json
+++ b/_data/chains/eip155-5550.json
@@ -12,6 +12,7 @@
   "shortName": "ogb",
   "chainId": 5550,
   "networkId": 5550,
+  "icon": "ordenglobal",
   "explorers": [
     {
       "name": "ordenscan",

--- a/_data/chains/eip155-5550.json
+++ b/_data/chains/eip155-5550.json
@@ -1,7 +1,10 @@
 {
   "name": "Orden Global",
   "chain": "OGB",
-  "rpc": [],
+  "rpc": [
+    "https://ordenglobal-rpc.com",
+    "https://rpc.ordenglobal-rpc.com"
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Origen",
@@ -12,5 +15,12 @@
   "shortName": "ogb",
   "chainId": 5550,
   "networkId": 5550,
+  "explorers": [
+    {
+      "name": "ordenscan",
+      "url": "https://ordenscan.com",
+      "standard": "EIP3091"
+    }
+  ],
   "status": "incubating"
 }

--- a/_data/chains/eip155-5550.json
+++ b/_data/chains/eip155-5550.json
@@ -1,10 +1,7 @@
 {
   "name": "Orden Global",
   "chain": "OGB",
-  "rpc": [
-    "https://ordenglobal-rpc.com",
-    "https://rpc.ordenglobal-rpc.com"
-  ],
+  "rpc": ["https://ordenglobal-rpc.com", "https://rpc.ordenglobal-rpc.com"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Origen",

--- a/_data/icons/ordenglobal.json
+++ b/_data/icons/ordenglobal.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreicn6kctjauo7yoam3daqzs3vybogw6nkwuhtls7isnhubti74qqvi",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
The chain ID 5550 was reserved in #8594 with an empty `rpc` array. This PR fills it in now that the network is live.

- Two HTTPS RPC endpoints. Both answer `eth_chainId` with `0x15ae` (5550) and `net_version` with `5550`.
- Block explorer at ordenscan.com, EIP-3091 compliant: `/block/<n>`, `/tx/<hash>` and `/address/<0x...>` all return 200.
- `status` intentionally stays `incubating` until additional validators are online.

Verified locally against the repository's own processor: BUILD SUCCESSFUL.