### PR TITLE
Rebrand HashKey Chain to HSKChain (chainId 177 & 133)

### DIFF
--- a/_data/chains/eip155-133.json
+++ b/_data/chains/eip155-133.json
@@ -1,7 +1,8 @@
 {
-  "name": "HashKey Chain Testnet",
-  "title": "HashKey Chain Testnet",
-  "chain": "HashKey Chain Testnet",
+  "name": "HSKChain Testnet",
+  "title": "HSKChain Testnet",
+  "chain": "HSKChain Testnet",
+  "icon": "hskchain",
   "rpc": ["https://testnet.hsk.xyz"],
   "faucets": [],
   "nativeCurrency": {
@@ -9,14 +10,14 @@
     "symbol": "HSK",
     "decimals": 18
   },
-  "infoURL": "https://hashkeychain.net",
+  "infoURL": "https://hskchain.net",
   "shortName": "HSKT",
   "chainId": 133,
   "networkId": 133,
   "explorers": [
     {
       "name": "blockscout",
-      "url": "https://testnet-explorer.hsk.xyz",
+      "url": "https://testnet-explorer.hskchain.net",
       "icon": "blockscout",
       "standard": "EIP3091"
     }

--- a/_data/chains/eip155-177.json
+++ b/_data/chains/eip155-177.json
@@ -1,7 +1,8 @@
 {
-  "name": "HashKey Chain",
-  "title": "HashKey Chain",
-  "chain": "HashKey Chain",
+  "name": "HSKChain",
+  "title": "HSKChain",
+  "chain": "HSKChain",
+  "icon": "hskchain",
   "rpc": ["https://mainnet.hsk.xyz"],
   "faucets": [],
   "nativeCurrency": {
@@ -9,20 +10,14 @@
     "symbol": "HSK",
     "decimals": 18
   },
-  "infoURL": "https://hsk.xyz",
+  "infoURL": "https://hskchain.net",
   "shortName": "hsk",
   "chainId": 177,
   "networkId": 177,
   "explorers": [
     {
       "name": "blockscout",
-      "url": "https://hashkey.blockscout.com",
-      "icon": "blockscout",
-      "standard": "EIP3091"
-    },
-    {
-      "name": "blockscout",
-      "url": "https://explorer.hsk.xyz",
+      "url": "https://hsk.blockscout.com",
       "icon": "blockscout",
       "standard": "EIP3091"
     }

--- a/_data/icons/hskchain.json
+++ b/_data/icons/hskchain.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreih3bto5rvvbteubflxqta2vxqepdfmpdogr53ib32evohqc2hd254",
+    "width": 200,
+    "height": 200,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Update chain names, infoURL and explorer endpoints to the new hskchain.net domains, and add the HSKChain icon shared by both mainnet and testnet.