### PR TITLE
Add intertrain 4683

### DIFF
--- a/data/chains/eip155-4683.json
+++ b/data/chains/eip155-4683.json
@@ -1,0 +1,15 @@
+{
+  "name": "Intertrain",
+  "chain": "INTE",
+  "icon": "intertrain",
+  "rpc": ["https://rpc.intertrain.online/rpc"],
+  "faucets": [],
+  "nativeCurrency": { "name": "MANNA", "symbol": "MNA", "decimals": 18 },
+  "infoURL": "https://intertrain.online",
+  "shortName": "inte",
+  "chainId": 4683,
+  "networkId": 4683,
+  "explorers": [
+    { "name": "Intertrain Explorer", "url": "https://explorer.intertrain.online", "standard": "none" }
+  ]
+}

--- a/data/chains/eip155-4683.json
+++ b/data/chains/eip155-4683.json
@@ -1,15 +1,24 @@
 {
   "name": "Intertrain",
   "chain": "INTE",
-  "icon": "intertrain",
-  "rpc": ["https://rpc.intertrain.online/rpc"],
+  "rpc": [
+    "https://rpc.intertrain.online/rpc"
+  ],
   "faucets": [],
-  "nativeCurrency": { "name": "MANNA", "symbol": "MNA", "decimals": 18 },
+  "nativeCurrency": {
+    "name": "MANNA",
+    "symbol": "MNA",
+    "decimals": 18
+  },
   "infoURL": "https://intertrain.online",
   "shortName": "inte",
   "chainId": 4683,
   "networkId": 4683,
   "explorers": [
-    { "name": "Intertrain Explorer", "url": "https://explorer.intertrain.online", "standard": "none" }
+    {
+      "name": "Intertrain Explorer",
+      "url": "https://explorer.intertrain.online",
+      "standard": "none"
+    }
   ]
 }

--- a/data/icons/intertrain.json
+++ b/data/icons/intertrain.json
@@ -1,0 +1,3 @@
+[
+  { "url": "ipfs://bafkreie6b72sdcor7uotvwuu3untmvf3cgao7ij7d7lqdwgq35tl4hzhly", "width": 627, "height": 627, "format": "png" }
+]

--- a/data/icons/intertrain.json
+++ b/data/icons/intertrain.json
@@ -1,3 +1,0 @@
-[
-  { "url": "ipfs://bafkreie6b72sdcor7uotvwuu3untmvf3cgao7ij7d7lqdwgq35tl4hzhly", "width": 627, "height": 627, "format": "png" }
-]


### PR DESCRIPTION
Adds Intertrain mainnet, chain ID 4683.

RPC: https://rpc.intertrain.online/rpc
Explorer: https://explorer.intertrain.online
Info: https://intertrain.online

The chain is live with four validators. Icon to follow in a separate PR.