### PR TITLE
Add MFENX network icon for chain 177155

### DIFF
--- a/_data/chains/eip155-177155.json
+++ b/_data/chains/eip155-177155.json
@@ -13,5 +13,6 @@
   "shortName": "mfenx",
   "chainId": 177155,
   "networkId": 177155,
+  "icon": "mfenx",
   "status": "active"
 }

--- a/_data/icons/mfenx.json
+++ b/_data/icons/mfenx.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmRfVbYhLSo68KLPJb9gHD7CPzCgPNEZpQLafL4AwGQxoV",
+    "width": 1024,
+    "height": 1024,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Adds the first-party MFENX network icon to the existing chain `177155` record.

- Icon key: `mfenx`
- Format: PNG
- Dimensions: 1024 x 1024
- Size: 247,375 bytes
- SHA-256: `c16a32c782a2b13cdf6c3296c66d3a4c9dadd04a22b388f6ea6c023301d24e31`
- IPFS CID: `QmRfVbYhLSo68KLPJb9gHD7CPzCgPNEZpQLafL4AwGQxoV`

The CID is retrievable directly through IPFS and through public gateways. Both edited JSON files pass the repository Prettier check.