### PR TITLE
Mark Xitcoin Mainnet as prelaunch

### DIFF
--- a/_data/chains/eip155-101088.json
+++ b/_data/chains/eip155-101088.json
@@ -2,7 +2,7 @@
   "name": "Xitcoin",
   "chain": "XITCOIN",
   "faucets": [],
-  "rpc": ["https://network.xitcoin.org"],
+  "rpc": [],
   "nativeCurrency": {
     "name": "Xitcoin",
     "symbol": "XTC",
@@ -13,5 +13,6 @@
   "chainId": 101088,
   "networkId": 101088,
   "icon": "xitcoin",
-  "explorers": []
+  "explorers": [],
+  "status": "incubating"
 }


### PR DESCRIPTION
Aligns Xitcoin Mainnet chain ID 101088 with its current prelaunch state.

- retains the canonical XTC symbol and 18 decimals;
- retains the current Xitcoin GitBook information URL;
- removes the historical RPC endpoint;
- marks Mainnet as incubating until the production network is launched.

Xitcoin Testnet chain ID 101089 remains active and unchanged.