### PR TITLE
Reassign chain ID 8 from Ubiq to c8ntinuum

### DIFF
--- a/_data/chains/eip155-8.json
+++ b/_data/chains/eip155-8.json
@@ -1,23 +1,36 @@
 {
-  "name": "Ubiq",
-  "chain": "UBQ",
-  "rpc": ["https://rpc.octano.dev", "https://pyrus2.ubiqscan.io"],
+  "name": "c8ntinuum",
+  "chain": "CTM",
+  "rpc": [
+    "https://rpc.c8ntinuum.com",
+    "https://rpc.c8ntinuum.io",
+    "https://rpc.c8ntinuum.link"
+  ],
   "faucets": [],
   "nativeCurrency": {
-    "name": "Ubiq Ether",
-    "symbol": "UBQ",
+    "name": "c8ntinuum",
+    "symbol": "CTM",
     "decimals": 18
   },
-  "infoURL": "https://ubiqsmart.com",
-  "shortName": "ubq",
+  "features": [
+    { "name": "EIP155" },
+    { "name": "EIP1559" },
+    { "name": "EIP2930" },
+    { "name": "EIP7702" }
+  ],
+  "infoURL": "https://c8ntinuum.com",
+  "shortName": "ctm",
   "chainId": 8,
   "networkId": 8,
-  "slip44": 108,
+  "slip44": 60,
+  "icon": "c8ntinuum",
   "explorers": [
     {
-      "name": "ubiqscan",
-      "url": "https://ubiqscan.io",
+      "name": "CTMScan",
+      "url": "https://ctmscan.io",
       "standard": "EIP3091"
     }
-  ]
+  ],
+  "status": "active",
+  "redFlags": ["reusedChainId"]
 }

--- a/_data/chains/eip155-8888.json
+++ b/_data/chains/eip155-8888.json
@@ -1,12 +1,11 @@
 {
-  "name": "c8ntinuum",
+  "name": "c8ntinuum Testnet",
   "chain": "CTM",
   "rpc": [
-    "https://rpc.c8ntinuum.com",
-    "https://rpc.c8ntinuum.io",
-    "https://rpc.c8ntinuum.link"
+    "https://rpc-testnet.c8ntinuum.com",
+    "https://rpc-testnet.c8ntinuum.link"
   ],
-  "faucets": [],
+  "faucets": ["https://testnet-faucet.c8ntinuum.io/"],
   "nativeCurrency": {
     "name": "c8ntinuum",
     "symbol": "CTM",
@@ -19,18 +18,17 @@
     { "name": "EIP7702" }
   ],
   "infoURL": "https://c8ntinuum.com",
-  "shortName": "ctm",
+  "shortName": "tctm",
   "chainId": 8888,
   "networkId": 8888,
-  "slip44": 60,
+  "slip44": 1,
   "icon": "c8ntinuum",
   "explorers": [
     {
-      "name": "CTMScan",
-      "url": "https://ctmscan.io",
+      "name": "CTMScan Testnet",
+      "url": "https://testnet.ctmscan.io",
       "standard": "EIP3091"
     }
   ],
-  "status": "active",
   "redFlags": ["reusedChainId"]
 }


### PR DESCRIPTION
This PR proposes reassigning chain ID 8, currently associated with Ubiq, to c8ntinuum, while assigning chain ID 8888 to c8ntinuum’s public testnet.

c8ntinuum was initially configured with chain ID 2184 in 2025. We later discovered that the same chain ID had already been registered by another network. Resolving this conflict requires rebuilding the genesis configuration and migrating the network. Since this migration requires us to select a new permanent chain ID, we have opted for chain ID 8, a number with particular significance to the project.

Current status of Ubiq:
- The [chain](https://octano.dev/#vitals) is no longer producing blocks.
- Its [registered endpoints](https://chainid.network/chain/8/) are unavailable.
- We could not identify any active [exchange listings](https://octano.dev/#markets)
- Its [repositories](https://github.com/ubiq) and [official community channels](https://octano.dev/#channels) are inactive.
- [ubiqsmart.com](https://ubiqsmart.com/) no longer serves content related to the project.

Given that Ubiq is no longer producing blocks and inactive and unmaintained as well as the low transaction activity throughout its lifetime, the practical risk of cross-chain replay attacks is minimal.

We also reached out directly to Ubiq’s founder, [jyap808](https://github.com/jyap808), whose recent public activity drifted away from Ubiq, but no response followed.