### PR TITLE
Move Intertrain (4683) into _data and add its icon

### DIFF
--- a/_data/chains/eip155-4683.json
+++ b/_data/chains/eip155-4683.json
@@ -1,15 +1,10 @@
 {
   "name": "Intertrain",
   "chain": "INTE",
-  "rpc": [
-    "https://rpc.intertrain.online/rpc"
-  ],
+  "icon": "intertrain",
+  "rpc": ["https://rpc.intertrain.online/rpc"],
   "faucets": [],
-  "nativeCurrency": {
-    "name": "MANNA",
-    "symbol": "MNA",
-    "decimals": 18
-  },
+  "nativeCurrency": { "name": "MANNA", "symbol": "MNA", "decimals": 18 },
   "infoURL": "https://intertrain.online",
   "shortName": "inte",
   "chainId": 4683,

--- a/_data/icons/intertrain.json
+++ b/_data/icons/intertrain.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreie6b72sdcor7uotvwuu3untmvf3cgao7ij7d7lqdwgq35tl4hzhly",
+    "width": 627,
+    "height": 627,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
The Intertrain entry (chain 4683) was merged in #8615 but landed in
`data/chains/` rather than `_data/chains/`. That directory isn't read by the
build, so the chain has never appeared in the published `chains.json`.

This PR:
- adds `_data/chains/eip155-4683.json` (the same entry, plus an `icon` field)
- adds `_data/icons/intertrain.json`
- removes the stray `data/chains/eip155-4683.json`

The icon is a 627x627 PNG pinned on IPFS; the dimensions in the icon file are
read from the file itself. The RPC endpoint is live and returns chain id 4683.

Note: `data/chains/eip155-20488.json` sits in the same stray directory and is
presumably missing from `chains.json` for the same reason, but it isn't mine so
I've left it alone.