### PR TITLE
Add L7C (eip155-717)

### DIFF
--- a/_data/chains/eip155-717.json
+++ b/_data/chains/eip155-717.json
@@ -1,0 +1,23 @@
+{
+  "name": "L7C",
+  "chain": "L7C",
+  "rpc": ["https://l7c.ai/rpc"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "L7C",
+    "symbol": "L7C",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://l7c.ai",
+  "shortName": "l7c",
+  "chainId": 717,
+  "networkId": 717,
+  "explorers": [
+    {
+      "name": "L7C",
+      "url": "https://l7c.ai",
+      "standard": "none"
+    }
+  ]
+}


### PR DESCRIPTION
Adds L7C to the public chain registry.

This PR contains only public network metadata. No application source is included.

- Network: L7C
- Chain ID / Network ID: 717 (0x2cd)
- Native currency: L7C (18 decimals)
- RPC: https://l7c.ai/rpc
- Explorer: https://l7c.ai
- Website: https://l7c.ai
- Status: live

Verified before opening:
- eth_chainId on https://l7c.ai/rpc returns 0x2cd (717)
- net_version returns 717
- chainId 717 is unused in this repository
- shortName l7c and name L7C are unused
- Icon omitted until an official IPFS pin is prepared