### PR TITLE
Update GUT Network icon

### DIFF
--- a/_data/icons/gut.json
+++ b/_data/icons/gut.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "ipfs://QmahgR3BoertJe4WtWtcfzJ4WtNUmc7d6Tr8nEShikpbju",
+    "url": "ipfs://QmcVCd2aDK3xYF7LCjLPkG72h2VDrVVg3Fs19eDCmThq5R",
     "width": 512,
     "height": 512,
     "format": "png"


### PR DESCRIPTION
Updates the GUT Network icon to a new IPFS CID.

- CID: QmcVCd2aDK3xYF7LCjLPkG72h2VDrVVg3Fs19eDCmThq5R
- Format: PNG
- Dimensions: 512 × 512
- Size: 137507 bytes
- SHA-256: fd314d0b7c5359c96d1670d8b2d7e8081814c9ee092ec9c25ff22730d056cf8c
- Permanently pinned on the GUT Network Kubo node.