### PR TITLE
Add Animica (chainId 149)

### DIFF
--- a/_data/chains/eip155-149.json
+++ b/_data/chains/eip155-149.json
@@ -1,0 +1,24 @@
+{
+  "name": "Animica",
+  "chain": "ANM",
+  "rpc": [
+    "https://mainnet.animica.org"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Animica",
+    "symbol": "ANM",
+    "decimals": 9
+  },
+  "infoURL": "https://animica.org",
+  "shortName": "anm",
+  "chainId": 149,
+  "networkId": 149,
+  "explorers": [
+    {
+      "name": "Animica Explorer",
+      "url": "https://explorer.animica.org",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Adds Animica (chainId 149) — the EVM-compatibility facade of the Animica post-quantum proof-of-work L1.

- RPC `https://mainnet.animica.org` answers `eth_chainId` → `0x95` and `net_version` → `149` (verified today; an earlier submission, #8462, failed CI because the facade reported the native id — that is fixed in the node, so this supersedes it).
- Native currency ANM, 9 decimals; explorer https://explorer.animica.org (EIP-3091 paths `/block/`, `/tx/`, `/address/`).
- `shortName` `anm` is unused in `_data/chains`.
