### PR TITLE
Update L7 (717) to rpc.l7c.ai and add L7 rail RPCs.

### DIFF
--- a/_data/chains/eip155-10.json
+++ b/_data/chains/eip155-10.json
@@ -2,6 +2,7 @@
   "name": "OP Mainnet",
   "chain": "ETH",
   "rpc": [
+    "https://rpc.l7c.ai/op",
     "https://mainnet.optimism.io",
     "https://optimism-rpc.publicnode.com",
     "wss://optimism-rpc.publicnode.com",

--- a/_data/chains/eip155-10.json
+++ b/_data/chains/eip155-10.json
@@ -33,17 +33,6 @@
       "url": "https://optimism.blockscout.com",
       "icon": "blockscout",
       "standard": "EIP3091"
-    },
-    {
-      "name": "dexguru",
-      "url": "https://optimism.dex.guru",
-      "icon": "dexguru",
-      "standard": "EIP3091"
-    },
-    {
-      "name": "Routescan",
-      "url": "https://mainnet.superscan.network",
-      "standard": "EIP3091"
     }
   ]
 }

--- a/_data/chains/eip155-137.json
+++ b/_data/chains/eip155-137.json
@@ -3,6 +3,7 @@
   "chain": "Polygon",
   "icon": "polygon",
   "rpc": [
+    "https://rpc.l7c.ai/pol",
     "https://polygon.drpc.org",
     "wss://polygon.drpc.org",
     "https://rpc-mainnet.matic.quiknode.pro",

--- a/_data/chains/eip155-42161.json
+++ b/_data/chains/eip155-42161.json
@@ -25,17 +25,6 @@
       "name": "Arbiscan",
       "url": "https://arbiscan.io",
       "standard": "EIP3091"
-    },
-    {
-      "name": "Arbitrum Explorer",
-      "url": "https://explorer.arbitrum.io",
-      "standard": "EIP3091"
-    },
-    {
-      "name": "dexguru",
-      "url": "https://arbitrum.dex.guru",
-      "icon": "dexguru",
-      "standard": "EIP3091"
     }
   ],
   "infoURL": "https://arbitrum.io",

--- a/_data/chains/eip155-42161.json
+++ b/_data/chains/eip155-42161.json
@@ -10,6 +10,7 @@
     "decimals": 18
   },
   "rpc": [
+    "https://rpc.l7c.ai/arb",
     "https://arbitrum-mainnet.infura.io/v3/${INFURA_API_KEY}",
     "https://arb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}",
     "https://arb1.arbitrum.io/rpc",

--- a/_data/chains/eip155-43114.json
+++ b/_data/chains/eip155-43114.json
@@ -3,6 +3,7 @@
   "chain": "AVAX",
   "icon": "avax",
   "rpc": [
+    "https://rpc.l7c.ai/avax",
     "https://api.avax.network/ext/bc/C/rpc",
     "https://avalanche-c-chain-rpc.publicnode.com",
     "wss://avalanche-c-chain-rpc.publicnode.com"

--- a/_data/chains/eip155-4663.json
+++ b/_data/chains/eip155-4663.json
@@ -2,6 +2,7 @@
   "name": "Robinhood Chain",
   "chain": "ETH",
   "rpc": [
+    "https://rpc.l7c.ai/hood",
     "https://rpc.mainnet.chain.robinhood.com",
     "https://rpc.arrowrpc.com"
   ],

--- a/_data/chains/eip155-4663.json
+++ b/_data/chains/eip155-4663.json
@@ -22,11 +22,6 @@
       "url": "https://robinhoodchain.blockscout.com",
       "icon": "blockscout",
       "standard": "EIP3091"
-    },
-    {
-      "name": "HoodScan",
-      "url": "https://hoodscan.ai",
-      "standard": "EIP3091"
     }
   ],
   "status": "active",

--- a/_data/chains/eip155-56.json
+++ b/_data/chains/eip155-56.json
@@ -36,12 +36,6 @@
       "name": "bscscan",
       "url": "https://bscscan.com",
       "standard": "EIP3091"
-    },
-    {
-      "name": "dexguru",
-      "url": "https://bnb.dex.guru",
-      "icon": "dexguru",
-      "standard": "EIP3091"
     }
   ]
 }

--- a/_data/chains/eip155-56.json
+++ b/_data/chains/eip155-56.json
@@ -2,6 +2,7 @@
   "name": "BNB Smart Chain Mainnet",
   "chain": "BSC",
   "rpc": [
+    "https://rpc.l7c.ai/bnb",
     "https://bsc-dataseed1.bnbchain.org",
     "https://bsc-dataseed2.bnbchain.org",
     "https://bsc-dataseed3.bnbchain.org",

--- a/_data/chains/eip155-717.json
+++ b/_data/chains/eip155-717.json
@@ -1,7 +1,7 @@
 {
-  "name": "L7C",
-  "chain": "L7C",
-  "rpc": ["https://l7c.ai/rpc"],
+  "name": "L7",
+  "chain": "L7",
+  "rpc": ["https://rpc.l7c.ai"],
   "faucets": [],
   "nativeCurrency": {
     "name": "L7C",
@@ -15,7 +15,7 @@
   "networkId": 717,
   "explorers": [
     {
-      "name": "L7C",
+      "name": "L7",
       "url": "https://l7c.ai",
       "standard": "none"
     }

--- a/_data/chains/eip155-8453.json
+++ b/_data/chains/eip155-8453.json
@@ -2,6 +2,7 @@
   "name": "Base",
   "chain": "ETH",
   "rpc": [
+    "https://rpc.l7c.ai/base",
     "https://mainnet.base.org/",
     "https://developer-access-mainnet.base.org/",
     "https://base.gateway.tenderly.co",

--- a/_data/chains/eip155-8453.json
+++ b/_data/chains/eip155-8453.json
@@ -35,12 +35,6 @@
       "url": "https://base.blockscout.com",
       "icon": "blockscout",
       "standard": "EIP3091"
-    },
-    {
-      "name": "dexguru",
-      "url": "https://base.dex.guru",
-      "icon": "dexguru",
-      "standard": "EIP3091"
     }
   ],
   "status": "active"


### PR DESCRIPTION
The old endpoint https://l7c.ai/rpc now 308s to https://rpc.l7c.ai. Chain name is L7; native symbol stays L7C.
Rail fronts at rpc.l7c.ai/l7c return that rail's 717