### PR TITLE
Add Torium Testnet (eip155-1414484564)

### DIFF
--- a/_data/chains/eip155-1414484564.json
+++ b/_data/chains/eip155-1414484564.json
@@ -1,0 +1,26 @@
+{
+  "name": "Torium Testnet",
+  "chain": "Torium",
+  "rpc": [
+    "https://rpc.testnet.torium.network",
+    "wss://ws.testnet.torium.network"
+  ],
+  "faucets": ["https://faucet.testnet.torium.network"],
+  "nativeCurrency": {
+    "name": "Torium Test Token",
+    "symbol": "tTOR",
+    "decimals": 18
+  },
+  "infoURL": "https://torium.network",
+  "shortName": "torium-testnet",
+  "chainId": 1414484564,
+  "networkId": 1414484564,
+  "slip44": 1,
+  "explorers": [
+    {
+      "name": "Torium Testnet Explorer",
+      "url": "https://explorer.testnet.torium.network",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Adds Torium Testnet to the registry, chain ID 1414484564.

- Network: Torium Testnet, the public testnet of the Torium network
- Chain ID / Network ID: 1414484564 (0x544f5254)
- Native currency: tTOR (18 decimals), valueless test token
- RPC: https://rpc.testnet.torium.network and wss://ws.testnet.torium.network
- Faucet: https://faucet.testnet.torium.network
- Explorer: https://explorer.testnet.torium.network (Blockscout, EIP3091)
- Info: https://torium.network

Verified before opening:
- eth_chainId on the RPC returns 0x544f5254 (1414484564)
- chainId 1414484564, shortName torium-testnet and the Torium name are unused in this repository
- The chain is live with four validators and a public faucet
- Icon to follow in a separate PR