### PR TITLE
Update Intertrain (4683) icon to the gold mark

### DIFF
--- a/_data/icons/intertrain.json
+++ b/_data/icons/intertrain.json
@@ -1,8 +1,8 @@
 [
   {
-    "url": "ipfs://bafkreie6b72sdcor7uotvwuu3untmvf3cgao7ij7d7lqdwgq35tl4hzhly",
-    "width": 627,
-    "height": 627,
+    "url": "ipfs://bafkreicjmwxhgwcvpldndx3ybxjncngmlqnesgzxn6a4pkivhaqpznabxq",
+    "width": 397,
+    "height": 397,
     "format": "png"
   }
 ]


### PR DESCRIPTION
Swaps the Intertrain icon for the gold version of the mark, which is the
brand's actual logo. The previous CID was a monochrome variant submitted
by mistake.

The new asset is pinned and resolves via public gateways:
ipfs://bafkreicjmwxhgwcvpldndx3ybxjncngmlqnesgzxn6a4pkivhaqpznabxq

397x397 png. No change to _data/chains/eip155-4683.json, which already
references this icon by name.