### PR TITLE
Add Vitreus Mainnet (1943)

### DIFF
--- a/_data/chains/eip155-1943.json
+++ b/_data/chains/eip155-1943.json
@@ -4,7 +4,7 @@
   "rpc": ["https://rpc-mainnet.vtrs.io", "wss://rpc-mainnet.vtrs.io"],
   "faucets": [],
   "nativeCurrency": {
-    "name": "Energy",
+    "name": "VNRG",
     "symbol": "VNRG",
     "decimals": 18
   },

--- a/_data/chains/eip155-1943.json
+++ b/_data/chains/eip155-1943.json
@@ -1,0 +1,27 @@
+{
+  "name": "Vitreus Mainnet",
+  "chain": "VTRS",
+  "rpc": ["https://rpc-mainnet.vtrs.io", "wss://rpc-mainnet.vtrs.io"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Energy",
+    "symbol": "VNRG",
+    "decimals": 18
+  },
+  "features": [
+    {
+      "name": "EIP155"
+    }
+  ],
+  "infoURL": "https://vitreus.io",
+  "shortName": "vtrs",
+  "chainId": 1943,
+  "networkId": 1943,
+  "explorers": [
+    {
+      "name": "Vitreus Explorer",
+      "url": "https://explorer.vtrs.io",
+      "standard": "none"
+    }
+  ]
+}

--- a/_data/chains/eip155-1943.json
+++ b/_data/chains/eip155-1943.json
@@ -22,6 +22,11 @@
       "name": "Vitreus Explorer",
       "url": "https://explorer.vtrs.io",
       "standard": "none"
+    },
+    {
+      "name": "Vitreus Polkadot Explorer",
+      "url": "https://polkadot.js.org/apps/?rpc=wss://rpc-mainnet.vtrs.io#/explorer",
+      "standard": "none"
     }
   ]
 }


### PR DESCRIPTION
Add Vitreus Mainnet (chainId 1943).

Vitreus is dual-token: VTRS (Substrate) and VNRG. For EVM nativeCurrency is VNRG.

- Website: https://vitreus.io
- RPC: https://rpc-mainnet.vtrs.io
- Explorer: https://explorer.vtrs.io
- Native currency (EVM): VNRG