### PR TITLE
Add KriptoAman Mainnet (Chain ID 22028)

### DIFF
--- a/_data/chains/eip155-22028.json
+++ b/_data/chains/eip155-22028.json
@@ -1,0 +1,24 @@
+{
+  "name": "KriptoAman Mainnet",
+  "chain": "KAM",
+  "rpc": ["https://rpc.kriptoaman.com"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "KriptoAman",
+    "symbol": "KAM",
+    "decimals": 18
+  },
+  "infoURL": "https://kriptoaman.com",
+  "shortName": "kriptoaman",
+  "chainId": 22028,
+  "networkId": 22028,
+  "icon": "kriptoaman",
+  "status": "incubating",
+  "explorers": [
+    {
+      "name": "KriptoAman Explorer",
+      "url": "https://explorer.kriptoaman.com",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/icons/kriptoaman.json
+++ b/_data/icons/kriptoaman.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreicorcwbkyjyw3rdbvuxfpw7bvrf74nsp4vaakclaoh6a67enzd36a",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Adds KriptoAman Network metadata for Chain ID 22028 (0x560c), native currency KAM, public RPC, explorer, and network icon.

Status: incubating while final KriptoAman production-readiness gates continue.

RPC: https://rpc.kriptoaman.com
Explorer: https://explorer.kriptoaman.com
Website: https://kriptoaman.com