### PR TITLE
Add Midpoint Cross Mainnet (1394) and Testnet (139420)

### DIFF
--- a/_data/chains/eip155-1394.json
+++ b/_data/chains/eip155-1394.json
@@ -1,0 +1,24 @@
+{
+  "name": "Midpoint Cross",
+  "chain": "MIDX",
+  "rpc": ["https://mainnet.midpointcross.com"],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Midpoint Cross",
+    "symbol": "MIDX",
+    "decimals": 18
+  },
+  "infoURL": "https://www.midpointcross.com",
+  "shortName": "midx",
+  "chainId": 1394,
+  "networkId": 1394,
+  "icon": "midx",
+  "explorers": [
+    {
+      "name": "Midpoint Cross",
+      "url": "https://transactions.midpointcross.com",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-139420.json
+++ b/_data/chains/eip155-139420.json
@@ -1,0 +1,24 @@
+{
+  "name": "Midpoint Cross Testnet",
+  "chain": "MIDX",
+  "rpc": ["https://testnet.midpointcross.com"],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Midpoint Cross Testnet",
+    "symbol": "tMIDX",
+    "decimals": 18
+  },
+  "infoURL": "https://www.midpointcross.com",
+  "shortName": "midxt",
+  "chainId": 139420,
+  "networkId": 139420,
+  "slip44": 1,
+  "explorers": [
+    {
+      "name": "Midpoint Cross Testnet",
+      "url": "https://testnet-transactions.midpointcross.com",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/icons/midx.json
+++ b/_data/icons/midx.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreibcp2mgvdjzrmrcx2pytoht2v6dangeur7ndmjfaxgc4ynacgj7tq",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
This PR adds Midpoint Cross networks:

- `eip155-1394.json` — Midpoint Cross Mainnet, chainId/networkId 1394, native currency MIDX
- `eip155-139420.json` — Midpoint Cross Testnet, chainId/networkId 139420, native currency tMIDX (slip44: 1)
- `_data/icons/midx.json` — chain icon, 512x512 PNG on IPFS (~21 KB)

Verification:

- `https://mainnet.midpointcross.com` returns `eth_chainId` = `0x572` (1394)
- `https://testnet.midpointcross.com` returns `eth_chainId` = `0x2209c` (139420)
- Explorers follow EIP3091
- No chainId or shortName collisions with existing chains