### PR TITLE
Add QMS mainnet (1948), incubating

### DIFF
--- a/_data/chains/eip155-1948.json
+++ b/_data/chains/eip155-1948.json
@@ -1,0 +1,12 @@
+{
+  "name": "QMS",
+  "chain": "QMS",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": { "name": "QMS", "symbol": "QMS", "decimals": 18 },
+  "infoURL": "https://qms.finance",
+  "shortName": "qms",
+  "chainId": 1948,
+  "networkId": 1948,
+  "status": "incubating"
+}


### PR DESCRIPTION
Registers the QMS mainnet chain ID ahead of launch.

QMS is a layer-1, EVM-compatible chain. The execution layer is unmodified upstream reth; consensus is a proof-of-useful-work protocol in a Lighthouse fork, with a separate finality layer.

Filed as `status: "incubating"` because mainnet is pre-launch: there is no public RPC or explorer to list yet. The entry will be updated to `active` with `rpc` and `explorers` when the network goes live, in the same way as the other incubating entries in the repo.

`1948` is the year Casimir published the effect our consensus client is named after. Checked against the merged registry and every open pull request: `1948`, the shortName `qms` and the name `QMS` are all unused.

The public testnet is filed separately as chain ID `19480`.
