### PR TITLE
Add QMS Testnet (19480), incubating

### DIFF
--- a/_data/chains/eip155-19480.json
+++ b/_data/chains/eip155-19480.json
@@ -1,0 +1,13 @@
+{
+  "name": "QMS Testnet",
+  "chain": "QMS",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": { "name": "QMS", "symbol": "QMS", "decimals": 18 },
+  "infoURL": "https://qms.finance",
+  "shortName": "qmstest",
+  "chainId": 19480,
+  "networkId": 19480,
+  "slip44": 1,
+  "status": "incubating"
+}


### PR DESCRIPTION
Registers the QMS public testnet chain ID ahead of its launch.

QMS is a layer-1, EVM-compatible chain. The execution layer is unmodified upstream reth; consensus is a proof-of-useful-work protocol in a Lighthouse fork, with a separate finality layer.

Filed as `status: "incubating"` because the public testnet is not up yet, so there is no public RPC or explorer to list. The entry will be updated to `active` with `rpc`, `explorers` and `faucets` once it is live.

`19480` is the mainnet ID (`1948`, filed alongside this) times ten. Checked against the merged registry and every open pull request: `19480`, the shortName `qmstest` and the name `QMS Testnet` are all unused. `slip44: 1` per the convention for testnets.
