### PR TITLE
Add TWIX Mainnet (chain ID 1415006552)

### DIFF
--- a/_data/chains/eip155-1415006552.json
+++ b/_data/chains/eip155-1415006552.json
@@ -1,23 +1,14 @@
 {
   "name": "TWIX Mainnet",
   "chain": "TWIX",
-  "rpc": [
-    "https://evm.twixchain.com"
-  ],
+  "rpc": ["https://evm.twixchain.com"],
   "faucets": [],
   "nativeCurrency": {
     "name": "TWIX",
     "symbol": "TWIX",
     "decimals": 18
   },
-  "features": [
-    {
-      "name": "EIP155"
-    },
-    {
-      "name": "EIP1559"
-    }
-  ],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "infoURL": "https://twixchain.com",
   "shortName": "twix",
   "chainId": 1415006552,

--- a/_data/chains/eip155-1415006552.json
+++ b/_data/chains/eip155-1415006552.json
@@ -1,0 +1,27 @@
+{
+  "name": "TWIX Mainnet",
+  "chain": "TWIX",
+  "rpc": [
+    "https://evm.twixchain.com"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "TWIX",
+    "symbol": "TWIX",
+    "decimals": 18
+  },
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
+    }
+  ],
+  "infoURL": "https://twixchain.com",
+  "shortName": "twix",
+  "chainId": 1415006552,
+  "networkId": 1415006552,
+  "slip44": 60,
+  "icon": "twix"
+}

--- a/_data/icons/twix.json
+++ b/_data/icons/twix.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreigq7hgz3cfndupac4fucez3lm3v6v2acam4wugeix4na35eyp2c5m",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
## Add TWIX Mainnet

This PR adds TWIX Mainnet to the EVM chain registry.

- Name: TWIX Mainnet
- Chain ID: 1415006552
- Network ID: 1415006552
- Short name: twix
- Native currency: TWIX (18 decimals)
- RPC: https://evm.twixchain.com
- Info: https://twixchain.com
- SLIP-44 / BIP-44 coin type: 60
- Features: EIP-155, EIP-1559
- Icon: IPFS-backed 512×512 PNG

The chain ID was checked against the upstream registry before submission and was not present at submission time.