### PR TITLE
Add PISO Chain Mainnet (Chain ID: 2026001)

### DIFF
--- a/_data/chains/eip155-2026001.json
+++ b/_data/chains/eip155-2026001.json
@@ -1,0 +1,27 @@
+{
+  "name": "PISO Chain Mainnet",
+  "chain": "PISO",
+  "rpc": [
+    "https://piso-rpc-dev.loca.lt",
+    "http://127.0.0.1:8545"
+  ],
+  "faucets": [
+    "https://piso-chain.vercel.app/"
+  ],
+  "nativeCurrency": {
+    "name": "PISO",
+    "symbol": "PISO",
+    "decimals": 18
+  },
+  "infoURL": "https://github.com/314-hash/piso-chain",
+  "shortName": "piso",
+  "chainId": 2026001,
+  "networkId": 2026001,
+  "explorers": [
+    {
+      "name": "PISO Explorer",
+      "url": "https://piso-chain.vercel.app/explorer",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
### Chain Details
- **Network Name**: PISO Chain Mainnet
- **Chain ID**: 2026001 (`0x1EE349`)
- **Native Currency**: PISO (18 decimals)
- **RPC URL**: https://piso-rpc-dev.loca.lt
- **Explorer URL**: https://piso-chain.vercel.app/explorer
- **Faucet URL**: https://piso-chain.vercel.app/
- **Repository**: https://github.com/314-hash/piso-chain

### Verification
- [x] Valid JSON formatting adhering to schema
- [x] RPC endpoint responding to `eth_chainId` (2026001)
- [x] Native coin symbol configured as PISO
