### PR TITLE
Wanchain (888): add OrbitWan.io explorer

### DIFF
--- a/_data/chains/eip155-888.json
+++ b/_data/chains/eip155-888.json
@@ -20,6 +20,11 @@
       "icon": "wanchain",
       "url": "https://wanscan.org",
       "standard": "EIP3091"
+    },
+    {
+      "name": "OrbitWan.io",
+      "url": "https://orbitwan.io",
+      "standard": "EIP3091"
     }
   ]
 }


### PR DESCRIPTION
Adds OrbitWan.io, an independent Wanchain explorer with its own archive node, as a second explorer for chain 888. EIP3091 routes (/address, /tx, /block, /token) are live. wanscan stays as the first entry.