### PR TITLE
   Add Autyon Testnet (chainId 77077)

### DIFF
--- a/_data/chains/eip155-77077.json
+++ b/_data/chains/eip155-77077.json
@@ -1,23 +1,23 @@
-   {
-     "name": "Autyon Testnet",
-     "chain": "AUT",
-     "rpc": ["https://rpc.autyon.io"],
-     "faucets": ["https://faucet.autyon.io"],
-     "nativeCurrency": {
-       "name": "Autyon",
-       "symbol": "AUT",
-       "decimals": 18
-     },
-     "features": [{ "name": "EIP155" }],
-     "infoURL": "https://autyon.io",
-     "shortName": "autyon",
-     "chainId": 77077,
-     "networkId": 77077,
-     "explorers": [
-       {
-         "name": "autscan",
-         "url": "https://autscan.io",
-         "standard": "EIP3091"
-       }
-     ]
-   }
+{
+  "name": "Autyon Testnet",
+  "chain": "AUT",
+  "rpc": ["https://rpc.autyon.io"],
+  "faucets": ["https://faucet.autyon.io"],
+  "nativeCurrency": {
+    "name": "Autyon",
+    "symbol": "AUT",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }],
+  "infoURL": "https://autyon.io",
+  "shortName": "autyon",
+  "chainId": 77077,
+  "networkId": 77077,
+  "explorers": [
+    {
+      "name": "autscan",
+      "url": "https://autscan.io",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-77077.json
+++ b/_data/chains/eip155-77077.json
@@ -1,0 +1,23 @@
+   {
+     "name": "Autyon Testnet",
+     "chain": "AUT",
+     "rpc": ["https://rpc.autyon.io"],
+     "faucets": ["https://faucet.autyon.io"],
+     "nativeCurrency": {
+       "name": "Autyon",
+       "symbol": "AUT",
+       "decimals": 18
+     },
+     "features": [{ "name": "EIP155" }],
+     "infoURL": "https://autyon.io",
+     "shortName": "autyon",
+     "chainId": 77077,
+     "networkId": 77077,
+     "explorers": [
+       {
+         "name": "autscan",
+         "url": "https://autscan.io",
+         "standard": "EIP3091"
+       }
+     ]
+   }


### PR DESCRIPTION
   Adds Autyon Testnet (chainId 77077), an EVM chain for AI agents.
   - RPC: https://rpc.autyon.io (eth_chainId → 0x12d15)
   - Explorer: https://autscan.io (Blockscout, EIP3091)
   - Faucet: https://faucet.autyon.io
   - Native token: AUT (18 decimals)
   - Info: https://autyon.io