### PR TITLE
Add Nagara Testnet (16869)

### DIFF
--- a/_data/chains/eip155-16869.json
+++ b/_data/chains/eip155-16869.json
@@ -1,0 +1,18 @@
+{
+  "name": "Nagara Testnet",
+  "chain": "NGRX",
+  "rpc": ["https://testnet.nagara.network", "wss://testnet.nagara.network"],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "faucets": ["https://bagi-bagi.nagara.network"],
+  "nativeCurrency": {
+    "name": "Nagara Testnet Token",
+    "symbol": "tNGRX",
+    "decimals": 18
+  },
+  "infoURL": "https://nagara.network",
+  "shortName": "tngrx",
+  "chainId": 16869,
+  "networkId": 16869,
+  "slip44": 1,
+  "status": "active"
+}


### PR DESCRIPTION
Adds the Nagara Testnet, a sovereign Substrate (polkadot-sdk + Frontier) chain with an EVM layer, AccountId20 addresses and 18 decimals.

Verified against the live RPC before opening this PR:

```
$ curl -s -X POST -H 'Content-Type: application/json' \
    --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' \
    https://testnet.nagara.network
{"jsonrpc":"2.0","id":1,"result":"0x41e5"}   # 16869
```

- `https://testnet.nagara.network` and `wss://testnet.nagara.network` are public, no API key, TLS.
- EIP-1559 is supported (`pallet-base-fee`; blocks carry `baseFeePerGas`).
- Faucet: https://bagi-bagi.nagara.network
- No explorer entry yet — the current explorer is not EIP-3091 compliant, it will be submitted in a follow-up PR once the `/tx/`, `/block/` and `/address/` routes exist.
- `shortName` `tngrx` and `name` `Nagara Testnet` were checked for collisions against the whole `_data/chains` set.

Formatted with the repository's Prettier config.