### PR TITLE
Add Nagara (16868), incubating

### DIFF
--- a/_data/chains/eip155-16868.json
+++ b/_data/chains/eip155-16868.json
@@ -1,0 +1,16 @@
+{
+  "name": "Nagara",
+  "chain": "NGRX",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Nagara",
+    "symbol": "NGRX",
+    "decimals": 18
+  },
+  "infoURL": "https://nagara.network",
+  "shortName": "ngrx",
+  "chainId": 16868,
+  "networkId": 16868,
+  "status": "incubating"
+}


### PR DESCRIPTION
Adds the Nagara mainnet with `"status": "incubating"` — the network is not launched yet, so `rpc` is empty and no explorer is listed. A follow-up PR will fill in the RPC endpoints, the explorer and flip the status to `active` at launch.

Nagara is a sovereign Substrate (polkadot-sdk + Frontier) chain with an EVM layer, AccountId20 addresses and 18 decimals. Its testnet is submitted separately in #8650.

`shortName` `ngrx` and `name` `Nagara` were checked for collisions against the whole `_data/chains` set. Formatted with the repository's Prettier config.