### PR TITLE
feat: Add NVNM Chain mainnet (1611) and testnet (787111); align MANTRA 5888…

### DIFF
--- a/_data/chains/eip155-1611.json
+++ b/_data/chains/eip155-1611.json
@@ -5,7 +5,7 @@
   "faucets": [],
   "nativeCurrency": {
     "name": "mantraUSD",
-    "symbol": "mantraUSD",
+    "symbol": "mUSD",
     "decimals": 18
   },
   "infoURL": "https://nvnmchain.io",

--- a/_data/chains/eip155-1611.json
+++ b/_data/chains/eip155-1611.json
@@ -12,11 +12,13 @@
   "shortName": "nvnm",
   "chainId": 1611,
   "networkId": 1611,
+  "icon": "nvnm",
   "explorers": [
     {
       "name": "NVNM EVM Explorer",
       "url": "https://evm.explorer.nvnmchain.io",
-      "standard": "EIP3091"
+      "standard": "EIP3091",
+      "icon": "nvnm"
     }
   ]
 }

--- a/_data/chains/eip155-1611.json
+++ b/_data/chains/eip155-1611.json
@@ -1,0 +1,22 @@
+{
+  "name": "NVNM Chain",
+  "chain": "NVNM",
+  "rpc": ["https://evm.nvnmchain.io", "wss://evm.nvnmchain.io/ws"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "mantraUSD",
+    "symbol": "mantraUSD",
+    "decimals": 18
+  },
+  "infoURL": "https://nvnmchain.io",
+  "shortName": "nvnm",
+  "chainId": 1611,
+  "networkId": 1611,
+  "explorers": [
+    {
+      "name": "NVNM EVM Explorer",
+      "url": "https://evm.explorer.nvnmchain.io",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-5887.json
+++ b/_data/chains/eip155-5887.json
@@ -21,7 +21,7 @@
     {
       "name": "Dukong Explorer",
       "url": "http://mantrascan.io/dukong",
-      "standard": "none",
+      "standard": "EIP3091",
       "icon": "mantra"
     }
   ]

--- a/_data/chains/eip155-5888.json
+++ b/_data/chains/eip155-5888.json
@@ -13,13 +13,13 @@
   "chainId": 5888,
   "networkId": 5888,
   "slip44": 1,
-  "icon": "om",
+  "icon": "mantra",
   "explorers": [
     {
       "name": "MANTRA Explorer",
       "url": "https://blockscout.mantrascan.io",
       "standard": "EIP3091",
-      "icon": "om"
+      "icon": "mantra"
     }
   ]
 }

--- a/_data/chains/eip155-787111.json
+++ b/_data/chains/eip155-787111.json
@@ -1,0 +1,26 @@
+{
+  "name": "NVNM Chain Testnet",
+  "chain": "NVNM",
+  "rpc": [
+    "https://evm.testnet.nvnmchain.io",
+    "wss://evm.testnet.nvnmchain.io/ws"
+  ],
+  "faucets": ["https://faucet.testnet.nvnmchain.io"],
+  "nativeCurrency": {
+    "name": "mantraUSD",
+    "symbol": "mantraUSD",
+    "decimals": 18
+  },
+  "infoURL": "https://nvnmchain.io",
+  "shortName": "nvnm-testnet",
+  "chainId": 787111,
+  "networkId": 787111,
+  "slip44": 1,
+  "explorers": [
+    {
+      "name": "NVNM EVM Testnet Explorer",
+      "url": "https://explorer.evm.testnet.nvnmchain.io",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-787111.json
+++ b/_data/chains/eip155-787111.json
@@ -16,11 +16,13 @@
   "chainId": 787111,
   "networkId": 787111,
   "slip44": 1,
+  "icon": "nvnm",
   "explorers": [
     {
       "name": "NVNM EVM Testnet Explorer",
       "url": "https://explorer.evm.testnet.nvnmchain.io",
-      "standard": "EIP3091"
+      "standard": "EIP3091",
+      "icon": "nvnm"
     }
   ]
 }

--- a/_data/chains/eip155-787111.json
+++ b/_data/chains/eip155-787111.json
@@ -8,7 +8,7 @@
   "faucets": ["https://faucet.testnet.nvnmchain.io"],
   "nativeCurrency": {
     "name": "mantraUSD",
-    "symbol": "mantraUSD",
+    "symbol": "mUSD",
     "decimals": 18
   },
   "infoURL": "https://nvnmchain.io",

--- a/_data/icons/nvnm.json
+++ b/_data/icons/nvnm.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreidwmah4vinhg7fahafsizhoybepxnzkp6ktrjw3zxl2pwmzonfmo4",
+    "width": 120,
+    "height": 120,
+    "format": "svg"
+  }
+]

--- a/_data/icons/om.json
+++ b/_data/icons/om.json
@@ -1,8 +1,0 @@
-[
-  {
-    "url": "ipfs://bafkreiftgt747chqsw67a3jyklr52op5rozqmi3qnp4edwjcf2gxabwdnu",
-    "width": 120,
-    "height": 120,
-    "format": "png"
-  }
-]


### PR DESCRIPTION
## Summary

1. Adding NVNM Chain Mainnet and Testnet (1611 and 787111) to Eth Chainlists; an L2 based off MANTRA Chain L1
2. Updates the MANTRA Chain (chainId 5888) entry to correct outdated values following the OM → MANTRA token redenomination.

## Changes

### NVNM Chain Mainnet: `1611`

| Field | Notes |
|-------|-------|
| `name` | NVNM Chain Mainnet |
| `chain` | NVNM Chain |
| `nativeCurrency.name` | mantraUSD |
| `nativeCurrency.symbol` | mantraUSD |
| `shortName` | nvnm |
| `explorers[0].name` | NVNM EVM Explorer |
| `explorers[0].url` | https://evm.explorer.nvnmchain.io |
| `explorers[0].standard` | EIP3091 |

### NVNM Chain Testnet: `787111`

| Field | Notes |
|-------|-------|
| `name` | NVNM Chain Testnet |
| `chain` | NVNM |
| `nativeCurrency.name` | mantraUSD |
| `nativeCurrency.symbol` | mantraUSD |
| `shortName` | nvnm-testnet |
| `explorers[0].name` | NVNM EVM Testnet Explorer |
| `explorers[0].url` | https://explorer.evm.testnet.nvnmchain.io |
| `explorers[0].standard` | EIP3091 |

## References

- Official docs: https://docs.nvnmchain.io
- Explorer: https://evm.explorer.nvnmchain.io
- Website: https://nvnmchain.io
- Cosmos chain-registry: https://github.com/cosmos/chain-registry/tree/master/nvnmchain