### PR TITLE
Add Marschain icon reference

### DIFF
--- a/_data/chains/eip155-890.json
+++ b/_data/chains/eip155-890.json
@@ -23,7 +23,8 @@
   "icon": "marschain",
   "redFlags": ["reusedChainId"],
   "explorers": [
-    {
+      "icon": "marschain",
+{
       "name": "MarsChain Explorer",
       "url": "https://explorer.marschain.net",
       "standard": "EIP3091"


### PR DESCRIPTION
## Summary

- Add the existing `marschain` icon reference to MarsChain Mainnet (chain ID 890).
- Reuse the existing `_data/icons/marschain.json` metadata.

The icon metadata points to `ipfs://bafkreidjevwbk3kslq6gspdpzdn3jrm7kxepd2oaem3o7u2zspmqlk7ksa` (1024×1024 JPG).