### PR TITLE
Update Intertrain native currency to USDW

### DIFF
--- a/_data/chains/eip155-4683.json
+++ b/_data/chains/eip155-4683.json
@@ -1,10 +1,13 @@
 {
-  "name": "Intertrain",
+  "name": "Intertrain Mainnet",
   "chain": "INTE",
-  "icon": "intertrain",
   "rpc": ["https://rpc.intertrain.online/rpc"],
   "faucets": [],
-  "nativeCurrency": { "name": "MANNA", "symbol": "MNA", "decimals": 18 },
+  "nativeCurrency": {
+    "name": "WorldStreet USD",
+    "symbol": "USDW",
+    "decimals": 18
+  },
   "infoURL": "https://intertrain.online",
   "shortName": "inte",
   "chainId": 4683,

--- a/_data/chains/eip155-4683.json
+++ b/_data/chains/eip155-4683.json
@@ -1,6 +1,7 @@
 {
   "name": "Intertrain Mainnet",
   "chain": "INTE",
+  "icon": "intertrain",
   "rpc": ["https://rpc.intertrain.online/rpc"],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/icons/intertrain.json
+++ b/_data/icons/intertrain.json
@@ -1,8 +1,8 @@
 [
   {
-    "url": "ipfs://bafkreie6b72sdcor7uotvwuu3untmvf3cgao7ij7d7lqdwgq35tl4hzhly",
-    "width": 627,
-    "height": 627,
+    "url": "ipfs://bafkreicjmwxhgwcvpldndx3ybxjncngmlqnesgzxn6a4pkivhaqpznabxq",
+    "width": 397,
+    "height": 397,
     "format": "png"
   }
 ]


### PR DESCRIPTION
## Summary

Update Intertrain Mainnet metadata to use the correct native currency branding:

- Name: WorldStreet USD
- Symbol: USDW
- Decimals: 18

## Chain details

- Chain name: Intertrain Mainnet
- Chain ID: 4683
- Network ID: 4683
- RPC: https://rpc.intertrain.online/rpc
- Explorer: https://explorer.intertrain.online
- Website: https://intertrain.online

## Compatibility

This change updates display metadata only. The EVM chain ID, network ID, RPC endpoint, and explorer remain unchanged.

## Testing

- Ran Prettier on the chain JSON
- Ran the repository validation command successfully