### PR TITLE
Add Final Chain (20678) and Final Testnet (48359)

### DIFF
--- a/_data/chains/eip155-20678.json
+++ b/_data/chains/eip155-20678.json
@@ -1,0 +1,24 @@
+{
+  "name": "Final Chain",
+  "chain": "Final",
+  "rpc": ["https://chain.final-de.fi"],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "vETH",
+    "symbol": "vETH",
+    "decimals": 18
+  },
+  "infoURL": "https://final-de.fi",
+  "shortName": "final",
+  "chainId": 20678,
+  "networkId": 20678,
+  "explorers": [
+    {
+      "name": "Final Explorer",
+      "url": "https://explorer.final-de.fi",
+      "standard": "EIP3091"
+    }
+  ],
+  "status": "incubating"
+}

--- a/_data/chains/eip155-48359.json
+++ b/_data/chains/eip155-48359.json
@@ -1,0 +1,25 @@
+{
+  "name": "Final Testnet",
+  "chain": "Final",
+  "rpc": ["https://test-chain.final-de.fi"],
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Testnet vETH",
+    "symbol": "vETH",
+    "decimals": 18
+  },
+  "infoURL": "https://final-de.fi",
+  "shortName": "final-test",
+  "chainId": 48359,
+  "networkId": 48359,
+  "slip44": 1,
+  "explorers": [
+    {
+      "name": "Final Explorer",
+      "url": "https://test-explorer.final-de.fi",
+      "standard": "EIP3091"
+    }
+  ],
+  "status": "incubating"
+}


### PR DESCRIPTION
Adds Final DeFi's application chain and its public testnet.

| | chainId | shortName | RPC | explorer (EIP-3091) |
|---|---|---|---|---|
| Final Chain | 20678 | `final` | https://chain.final-de.fi | https://explorer.final-de.fi |
| Final Testnet | 48359 | `final-test` | https://test-chain.final-de.fi | https://test-explorer.final-de.fi |

- Both RPC endpoints answer `eth_chainId` with the listed ids (`0x50c6` / `0xbce7`).
- `status: incubating` is intentional: gas is currently charged in vETH; a follow-up PR will update `nativeCurrency` and `status` once the native asset is final.
- Checker run locally: `singleChainCheck` on both files and the full `./gradlew run` pass; prettier clean.
