### PR TITLE
Add SushiiCoin (chainId 21320)

### DIFF
--- a/_data/chains/eip155-21320.json
+++ b/_data/chains/eip155-21320.json
@@ -1,0 +1,23 @@
+{
+  "name": "SushiiCoin",
+  "chain": "SHCX",
+  "rpc": ["https://coin.sushii.dev/evm"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "SushiiCoin",
+    "symbol": "SHCX",
+    "decimals": 18
+  },
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "infoURL": "https://coin.sushii.dev",
+  "shortName": "shcx",
+  "chainId": 21320,
+  "networkId": 21320,
+  "explorers": [
+    {
+      "name": "SushiiCoin Explorer",
+      "url": "https://coin.sushii.dev",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Adds SushiiCoin, an independent SHA-256d proof-of-work chain with an Ethereum-compatible account layer.

- **chainId / networkId:** 21320 (0x5348) — unused in this repo and on chainid.network
- **name / shortName:** `SushiiCoin` / `shcx` — both unused
- **RPC:** https://coin.sushii.dev/evm — public, HTTPS, live
- **Explorer:** https://coin.sushii.dev — EIP-3091 routes (`/block/<n>`, `/tx/<hash>`, `/address/<addr>`) all resolve

Verification:

```
$ curl -s -X POST https://coin.sushii.dev/evm \
    -H 'Content-Type: application/json' \
    -d '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}'
{"jsonrpc": "2.0", "id": 1, "result": "0x5348"}
```

The chain implements EIP-155 and EIP-1559 transactions, EIP-55 addresses and the standard `eth_*` JSON-RPC surface. It has no EVM, so there are no contracts or tokens — `eth_call` and `eth_getCode` return `0x`.