### PR TITLE
Add Lithosphere Mainnet (chain ID 9005)

### DIFF
--- a/_data/chains/eip155-9005.json
+++ b/_data/chains/eip155-9005.json
@@ -1,0 +1,22 @@
+{
+  "name": "Lithosphere Mainnet",
+  "chain": "LITHO",
+  "rpc": ["https://rpc-mainnet.litho.ai"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "LITHO",
+    "symbol": "LITHO",
+    "decimals": 18
+  },
+  "infoURL": "https://docs.litho.ai",
+  "shortName": "litho",
+  "chainId": 9005,
+  "networkId": 9005,
+  "explorers": [
+    {
+      "name": "Lithoscan",
+      "url": "https://lithoscan.ai",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the live Lithosphere Mainnet EVM network.

- Chain ID / network ID: 9005
- Short name: litho
- Native currency: LITHO (18 decimals)
- RPC: https://rpc-mainnet.litho.ai
- Explorer: https://lithoscan.ai
- Documentation: https://docs.litho.ai

Validation performed before submission:
- `eth_chainId` returned `0x232d` (9005)
- RPC, explorer, and documentation URLs are live
- No existing chain ID, name, short name, or chain abbreviation collision was found in the current registry