### PR TITLE
Add WANNA Chain (chainId 787878)

### DIFF
--- a/_data/chains/eip155-787878.json
+++ b/_data/chains/eip155-787878.json
@@ -1,8 +1,8 @@
 {
-  "name": "WANNA Chain Testnet",
+  "name": "WANNA Chain",
   "chain": "WANNA",
   "rpc": ["https://rpc.wannachain.com"],
-  "faucets": ["https://scan.wannachain.com/faucet/"],
+  "faucets": [],
   "nativeCurrency": {
     "name": "WANNA",
     "symbol": "WANNA",

--- a/_data/chains/eip155-787878.json
+++ b/_data/chains/eip155-787878.json
@@ -1,0 +1,22 @@
+{
+  "name": "WANNA Chain Testnet",
+  "chain": "WANNA",
+  "rpc": ["https://rpc.wannachain.com"],
+  "faucets": ["https://scan.wannachain.com/faucet/"],
+  "nativeCurrency": {
+    "name": "WANNA",
+    "symbol": "WANNA",
+    "decimals": 18
+  },
+  "infoURL": "https://scan.wannachain.com",
+  "shortName": "wanna",
+  "chainId": 787878,
+  "networkId": 787878,
+  "explorers": [
+    {
+      "name": "wannascan",
+      "url": "https://scan.wannachain.com",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Adds `WANNA Chain` (chainId **787878**), an OP-Stack network.

The goal is to spare users from typing six network fields by hand into MetaMask.

**On the name:** chainId 787878 is permanent for this network — the same id carries over
to mainnet — so the name deliberately does not say "Testnet", and one listing covers it
for good. `faucets` is empty: the public faucet has been retired.

### Verification done before opening this PR

| Check | Result |
|---|---|
| `./gradlew clean run --args="verbose singleChainCheck _data/chains/eip155-787878.json"` | BUILD SUCCESSFUL (connected to the RPC, read `BlockNumber`) |
| `./gradlew run` (full build) | BUILD SUCCESSFUL |
| `tools/schemaCheck.js` | Schema check completed successfully |
| `npx prettier --check` | All matched files use Prettier code style |
| `chainId` / `networkId` / `shortName` / `name` uniqueness | checked against all 2,739 entries in `chainid.network/chains.json` — no collision |

### Live endpoints

- RPC `https://rpc.wannachain.com` → `eth_chainId` returns `0xc05a6` (787878), blocks advance ~1/s
- Explorer `https://scan.wannachain.com` — EIP-3091 routes verified live: `/tx/<hash>`, `/block/<number>`, `/address/<address>`, `/token/<address>`

No `parent` field is set: this network's L1 is a private development chain, so there is no
already-listed chain to reference.
