### PR TITLE
Add Pocket Chain (ID: 7258) and Pocket Chain Testnet (ID: 7259)

### DIFF
--- a/_data/chains/eip155-7258.json
+++ b/_data/chains/eip155-7258.json
@@ -1,0 +1,17 @@
+{
+  "name": "Pocket Chain",
+  "chain": "PCKT",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "PCKT",
+    "symbol": "PCKT",
+    "decimals": 18
+  },
+  "infoURL": "https://pocket.fi",
+  "shortName": "pckt",
+  "chainId": 7258,
+  "networkId": 7258,
+  "explorers": [],
+  "status": "incubating"
+}

--- a/_data/chains/eip155-7259.json
+++ b/_data/chains/eip155-7259.json
@@ -1,0 +1,18 @@
+{
+  "name": "Pocket Chain Testnet",
+  "chain": "PCKT",
+  "rpc": [],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "PCKT",
+    "symbol": "PCKT",
+    "decimals": 18
+  },
+  "infoURL": "https://pocket.fi",
+  "shortName": "pckt-testnet",
+  "chainId": 7259,
+  "networkId": 7259,
+  "slip44": 1,
+  "explorers": [],
+  "status": "incubating"
+}


### PR DESCRIPTION
## Summary

Add Pocket Chain mainnet (chainId: 7258) and Pocket Chain Testnet (chainId: 7259) to the chain registry.

Pocket Chain is an EVM-compatible Layer 1 blockchain purpose-built for perpetual futures trading. It features a dual-engine architecture combining a high-performance matching engine with a fully compatible EVM engine, using Hotstuff-based BFT consensus with DPoS staking. Native token: PCKT.

## Chain Details

| Property | Mainnet | Testnet |
|---|---|---|
| Name | Pocket Chain | Pocket Chain Testnet |
| Chain ID | 7258 | 7259 |
| Network ID | 7258 | 7259 |
| Native Currency | PCKT (18 decimals) | PCKT (18 decimals) |
| Short Name | pckt | pckt-testnet |
| Info URL | https://pocket.fi | https://pocket.fi |
| Status | incubating | incubating |

## Notes

- RPC endpoints and block explorer URLs will be added in a follow-up PR once infrastructure is deployed.
- Both chain IDs (7258, 7259) have been verified as unregistered in this repository.