### PR TITLE
Add Zagros Mainnet (chainId 21072026)

### DIFF
--- a/_data/chains/eip155-21072026.json
+++ b/_data/chains/eip155-21072026.json
@@ -1,10 +1,7 @@
 {
   "name": "Zagros Mainnet",
   "chain": "ZAGROS",
-  "rpc": [
-    "https://rpc.zagros.network",
-    "https://rpc.zagrosnetwork.com"
-  ],
+  "rpc": ["https://rpc.zagros.network", "https://rpc.zagrosnetwork.com"],
   "faucets": [],
   "nativeCurrency": {
     "name": "Zagros",

--- a/_data/chains/eip155-21072026.json
+++ b/_data/chains/eip155-21072026.json
@@ -12,6 +12,7 @@
   "shortName": "zagros",
   "chainId": 21072026,
   "networkId": 21072026,
+  "icon": "zagros",
   "explorers": [
     {
       "name": "ZagrosRadar",

--- a/_data/chains/eip155-21072026.json
+++ b/_data/chains/eip155-21072026.json
@@ -1,0 +1,25 @@
+{
+  "name": "Zagros Mainnet",
+  "chain": "ZAGROS",
+  "rpc": [
+    "https://rpc.zagros.network",
+    "https://rpc.zagrosnetwork.com"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Zagros",
+    "symbol": "ZAGROS",
+    "decimals": 18
+  },
+  "infoURL": "https://zagros.network",
+  "shortName": "zagros",
+  "chainId": 21072026,
+  "networkId": 21072026,
+  "explorers": [
+    {
+      "name": "ZagrosRadar",
+      "url": "https://zagrosradar.com",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/icons/zagros.json
+++ b/_data/icons/zagros.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmWXkDq9wZP4gkKoiKNZqF3NdTtdoCqmAd7Ri3X1uSssuw",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Adds Zagros Mainnet.

- chainId: 21072026
- Native currency: ZAGROS (18 decimals)
- RPC (2 endpoints): https://rpc.zagros.network , https://rpc.zagrosnetwork.com
- Explorer: ZagrosRadar (https://zagrosradar.com), EIP-3091
- Info: https://zagros.network

Both RPC endpoints return eth_chainId 0x141889a (21072026).