### PR TITLE
Robinhood Chain (4663): add rpc.ordofi.network

### DIFF
--- a/_data/chains/eip155-4663.json
+++ b/_data/chains/eip155-4663.json
@@ -5,7 +5,8 @@
     "https://rpc.mainnet.chain.robinhood.com",
     "https://robinhood-rpc.publicnode.com",
     "wss://robinhood-rpc.publicnode.com",
-    "https://rpc.arrowrpc.com"
+    "https://rpc.arrowrpc.com",
+    "https://rpc.ordofi.network"
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
Adds `https://rpc.ordofi.network` to the RPC list for Robinhood Chain (chain id 4663).

OrdoFi runs an MEV-protected public RPC gateway for Robinhood Chain. Anonymous access, no API key required. Transactions are simulated before submission and delivered directly to the sequencer; reads are served from Cloudflare's edge with the origin in the US.

Check:

```
curl -s -X POST https://rpc.ordofi.network -H 'content-type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}'
{"jsonrpc":"2.0","id":1,"result":"0x1237"}
```

Operator: OrdoFi Labs — https://ordofi.network. Health at https://rpc.ordofi.network/health.

Made with [Cursor](https://cursor.com)