### PR TITLE
Add HoodScan explorer for Robinhood Chain (4663)

### DIFF
--- a/_data/chains/eip155-4663.json
+++ b/_data/chains/eip155-4663.json
@@ -29,6 +29,11 @@
       "url": "https://robinhoodchain.blockscout.com",
       "icon": "blockscout",
       "standard": "EIP3091"
+    },
+    {
+      "name": "hoodscan",
+      "url": "https://hoodscan.co",
+      "standard": "EIP3091"
     }
   ],
   "status": "active",


### PR DESCRIPTION
## Summary
Add https://hoodscan.co as an additional EIP-3091 explorer for Robinhood Chain (chainId 4663).

Official / existing explorers stay as-is:
- robinscan: https://robinscan.io
- blockscout: https://robinhoodchain.blockscout.com

HoodScan is an unofficial, read-only explorer focused on Robinhood Chain stock tokens, meme coins anchored to those stocks, and decoded DEX swaps. It does not replace Blockscout.

Note: this is a separate project from the `hoodscan.ai` entry that was added in #8512 and removed in #8601 after that deployment went offline. hoodscan.co is self-hosted and live.

## EIP-3091 checks
- /tx/{hash} → https://hoodscan.co/tx/…
- /address/{address} → https://hoodscan.co/address/…
- /token/{tokenAddress} → https://hoodscan.co/token/…
- /block/{blockNumber} → https://hoodscan.co/block/…

## Notes
- No icon field in this PR (avoids needing a new `_data/icons` entry). Can follow up with an icon later.
- Site: https://hoodscan.co

🤖 Generated with [Claude Code](https://claude.com/claude-code)
