### PR TITLE
Add RWA Chain (7741)

### DIFF
--- a/_data/chains/eip155-7741.json
+++ b/_data/chains/eip155-7741.json
@@ -1,0 +1,20 @@
+{
+  "name": "RWA Chain",
+  "chain": "RWA",
+  "rpc": ["https://rpc.rwa-chain.io"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://rwa-chain.io",
+  "shortName": "rwachain",
+  "chainId": 7741,
+  "networkId": 7741,
+  "status": "incubating",
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-1"
+  }
+}


### PR DESCRIPTION
Adds RWA Chain, an OP Stack L2 settling on Ethereum mainnet (parent eip155-1).

Submitted with `status: incubating`. The public RPC (https://rpc.rwa-chain.io) and explorer go live with mainnet launch; a follow-up PR will promote the entry to active and add the explorer and icon at that point.

Checked against the current registry: chainId 7741, name and shortName `rwachain` are unused. `./gradlew run --args="verbose singleChainCheck"` and prettier pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)