### PR TITLE
Add Molibra chain (EIP-155:20226)

### DIFF
--- a/_data/chains/eip155-20226.json
+++ b/_data/chains/eip155-20226.json
@@ -1,0 +1,23 @@
+{
+  "name": "Molibra",
+  "chain": "MOLI",
+  "rpc": ["https://molibra.org"],
+  "features": [{ "name": "EIP155" }],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Molibra",
+    "symbol": "MOLI",
+    "decimals": 18
+  },
+  "infoURL": "https://molibra.org",
+  "shortName": "moli",
+  "chainId": 20226,
+  "networkId": 20226,
+  "explorers": [
+    {
+      "name": "Moliscan",
+      "url": "https://molibra.org/molibra/moliscan",
+      "standard": "none"
+    }
+  ]
+}


### PR DESCRIPTION
Adds Molibra, an EVM chain, chainId 20226.

- RPC `https://molibra.org` answers `eth_chainId` → `0x4f02` and `net_version` → `20226` at the bare origin, over TLS.
- Explorer: Moliscan — https://molibra.org/molibra/moliscan (standard: `none`).
- `chainId` 20226, `shortName` `moli` and `name` `Molibra` were each checked against the published list and are unused.
- EIP-155 is mandatory on this chain — transactions without replay protection are rejected — so it is declared. EIP-1559 is not supported, so it is not.
- No `icon` field: the icon is not pinned to IPFS yet. Happy to follow up with a separate PR adding it once it is.
- The file passes `prettier --check` against this repo's `.prettierrc.json`.

Source: https://github.com/BaronOdon/molibra