### PR TITLE
Add RWA Chain Sepolia (77410)

### DIFF
--- a/_data/chains/eip155-77410.json
+++ b/_data/chains/eip155-77410.json
@@ -1,0 +1,26 @@
+{
+  "name": "RWA Chain Sepolia",
+  "chain": "RWA",
+  "rpc": ["https://sepolia-rpc.rwa-chain.io"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Sepolia Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://rwa-chain.io",
+  "shortName": "rwachain-sepolia",
+  "chainId": 77410,
+  "networkId": 77410,
+  "explorers": [
+    {
+      "name": "RWA Chain Sepolia Explorer",
+      "url": "https://sepolia-explorer.rwa-chain.io",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-11155111"
+  }
+}


### PR DESCRIPTION
Adds RWA Chain Sepolia, the testnet of RWA Chain (7741, merged in #8671). OP Stack L2 settling to Ethereum Sepolia (parent eip155-11155111).

RPC https://sepolia-rpc.rwa-chain.io returns chainId 0x12e62 and the explorer https://sepolia-explorer.rwa-chain.io is a Blockscout instance (EIP3091). `./gradlew run --args="verbose singleChainCheck"` and prettier pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)