### PR TITLE
Add stonkscan explorer to Robinhood Chain (4663)

### DIFF
--- a/_data/chains/eip155-4663.json
+++ b/_data/chains/eip155-4663.json
@@ -35,6 +35,11 @@
       "name": "hoodscan",
       "url": "https://hoodscan.co",
       "standard": "EIP3091"
+    },
+    {
+      "name": "stonkscan",
+      "url": "https://stonkscan.io",
+      "standard": "EIP3091"
     }
   ],
   "status": "active",


### PR DESCRIPTION
Adds stonkscan (https://stonkscan.io) as an additional explorer for Robinhood Chain mainnet (chainId 4663).

**EIP-3091 compliance** (all live):
- https://stonkscan.io/tx/{hash}
- https://stonkscan.io/block/{number}
- https://stonkscan.io/address/{address}
- https://stonkscan.io/token/{address}

stonkscan is an independent explorer/analytics front end for Robinhood Chain (also served at brokertools.info), indexing tokens, contracts, NFTs and per-address activity on chain 4663. No changes to existing entries.

Made with [Cursor](https://cursor.com)