### PR TITLE
Molibra (EIP-155:20226): add icon, and mark the explorer EIP-3091

### DIFF
--- a/_data/chains/eip155-20226.json
+++ b/_data/chains/eip155-20226.json
@@ -10,6 +10,7 @@
     "decimals": 18
   },
   "infoURL": "https://molibra.org",
+  "icon": "molibra",
   "shortName": "moli",
   "chainId": 20226,
   "networkId": 20226,
@@ -17,7 +18,7 @@
     {
       "name": "Moliscan",
       "url": "https://molibra.org/molibra/moliscan",
-      "standard": "none"
+      "standard": "EIP3091"
     }
   ]
 }

--- a/_data/icons/molibra.json
+++ b/_data/icons/molibra.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://QmQsqJ2omWZX8TYtft1euNVB8qcQvU8sZUYKRV9SgPuiRc",
+    "width": 64,
+    "height": 64,
+    "format": "svg"
+  }
+]


### PR DESCRIPTION
Follow-up to #8674, which is merged. Two changes:

**Icon.** Left out of #8674 because it was not pinned. It is now, on our own node, and reprovided: `ipfs://QmQsqJ2omWZX8TYtft1euNVB8qcQvU8sZUYKRV9SgPuiRc` — a 935-byte SVG. Retrievable over the network rather than via one gateway: fetched by ipfs.io and others that had never seen the CID.

**Explorer is now EIP-3091.** When #8674 was opened, Moliscan answered 404 on `/tx/`, `/address/` and `/block/`, so it was honestly declared `"standard": "none"`. It implements all three now — please check:

- https://molibra.org/molibra/moliscan/block/1
- https://molibra.org/molibra/moliscan/address/0x5851cc5884313f7a66697dE3Bb772466dD5895c7

Both files pass `prettier --check` against this repo's `.prettierrc.json`.

Source: https://github.com/BaronOdon/molibra