### PR TITLE
Add ZENX Network (eip155-88991)

### DIFF
--- a/data/chains/eip155-88991.json
+++ b/data/chains/eip155-88991.json
@@ -1,0 +1,29 @@
+{
+  "name": "ZENX Network",
+  "chain": "ZENX",
+  "rpc": [
+    "https://zenx.network/rpc"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "ZENX",
+    "symbol": "ZENX",
+    "decimals": 18
+  },
+  "infoURL": "https://zenx.network",
+  "shortName": "zenx",
+  "chainId": 88991,
+  "networkId": 88991,
+  "explorers": [
+    {
+      "name": "ZENX Explorer",
+      "url": "https://zenx.network",
+      "standard": "none"
+    }
+  ],
+  "features": [
+    {
+      "name": "EIP1559"
+    }
+  ]
+}


### PR DESCRIPTION
Adds **ZENX Network** - an EVM-compatible Layer-1 mainnet (Geth, Clique Proof-of-Authority).

- Chain ID: 88991
- RPC: https://zenx.network/rpc (live, responds with chainId 88991)
- Explorer: https://zenx.network
- Native currency: ZENX (18 decimals)
- Status: mainnet - token, DEX, cross-chain bridge and airdrop contracts deployed and verified on-chain

Source repo: https://github.com/ZenxNetworkk/zenx-blockchain