### PR TITLE
RWA Chain (7741): status active, parent chain is Base

### DIFF
--- a/_data/chains/eip155-7741.json
+++ b/_data/chains/eip155-7741.json
@@ -12,9 +12,21 @@
   "shortName": "rwachain",
   "chainId": 7741,
   "networkId": 7741,
-  "status": "incubating",
+  "status": "active",
   "parent": {
     "type": "L2",
-    "chain": "eip155-1"
-  }
+    "chain": "eip155-8453",
+    "bridges": [
+      {
+        "url": "https://rwa-chain.io/explorer/bridge"
+      }
+    ]
+  },
+  "explorers": [
+    {
+      "name": "RWA Chain Explorer",
+      "url": "https://explorer.rwa-chain.io",
+      "standard": "EIP3091"
+    }
+  ]
 }


### PR DESCRIPTION
RWA Chain mainnet (chain id 7741) is live as an OP Stack rollup settling on Base, so this sets `status` to `active`, `parent.chain` to `eip155-8453` (was Ethereum), and adds the bridge and explorer URLs.

RPC: https://rpc.rwa-chain.io (chainId 0x1e3d)
Explorer: https://explorer.rwa-chain.io
Bridge: https://rwa-chain.io/explorer/bridge