### PR TITLE
Add Vordium (chainId 1110) icon

### DIFF
--- a/_data/chains/eip155-1110.json
+++ b/_data/chains/eip155-1110.json
@@ -1,6 +1,7 @@
 {
   "name": "Vordium",
   "chain": "VORD",
+  "icon": "vordium",
   "rpc": ["https://rpc.vordium.com"],
   "faucets": [],
   "nativeCurrency": {

--- a/_data/icons/vordium.json
+++ b/_data/icons/vordium.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "ipfs://bafkreigmgi2vyyzj3s5tehwmygiwztr3hyug5x5tedi4qjkezlotwlzpma",
+    "width": 512,
+    "height": 512,
+    "format": "png"
+  }
+]


### PR DESCRIPTION
Follow-up to #8684 (Vordium mainnet, merged). Adds the chain icon:

Adds _data/icons/vordium.json (512x512 PNG on IPFS) and references it via "icon": "vordium" in _data/chains/eip155-1110.json. Icon pinned on IPFS at ipfs://bafkreigmgi2vyyzj3s5tehwmygiwztr3hyug5x5tedi4qjkezlotwlzpma.