### PR TITLE
Add ZORYQ EVM Testnet (Chain ID 5919065)

### DIFF
--- a/data/chains/eip155-5919065.json
+++ b/data/chains/eip155-5919065.json
@@ -25,7 +25,7 @@
     {
       "name": "ZORYQ Testnet Explorer",
       "url": "https://zoryq-evm-node-live-production.up.railway.app/explorer",
-      "standard": "none"
+      "standard": "EIP3091"
     }
   ]
 }

--- a/data/chains/eip155-5919065.json
+++ b/data/chains/eip155-5919065.json
@@ -1,0 +1,31 @@
+{
+  "name": "ZORYQ EVM Testnet",
+  "chain": "ZORYQ",
+  "rpc": [
+    "https://zoryq-evm-node-live-production.up.railway.app/rpc"
+  ],
+  "faucets": [
+    "https://zoryq-evm-node-live-production.up.railway.app/start"
+  ],
+  "nativeCurrency": {
+    "name": "ZORYQ Testnet",
+    "symbol": "ZQ",
+    "decimals": 18
+  },
+  "infoURL": "https://zoryq-evm-node-live-production.up.railway.app/start",
+  "shortName": "zoryqt",
+  "chainId": 5919065,
+  "networkId": 5919065,
+  "features": [
+    {
+      "name": "EIP155"
+    }
+  ],
+  "explorers": [
+    {
+      "name": "ZORYQ Testnet Explorer",
+      "url": "https://zoryq-evm-node-live-production.up.railway.app/explorer",
+      "standard": "none"
+    }
+  ]
+}


### PR DESCRIPTION
Adds ZORYQ EVM Testnet to the public EVM chain registry.

Chain ID: 5919065
Network ID: 5919065
Native currency: ZQ
RPC: https://zoryq-evm-node-live-production.up.railway.app/rpc
Faucet: https://zoryq-evm-node-live-production.up.railway.app/start
Explorer: https://zoryq-evm-node-live-production.up.railway.app/explorer

ZORYQ is currently operating as a public EVM-compatible testnet.

Testnet only. ZQ has no monetary value and participation does not guarantee any future token or airdrop.