### PR TITLE
Fix Shibarium (eip155-109): use the official RPC endpoint

### DIFF
--- a/_data/chains/eip155-109.json
+++ b/_data/chains/eip155-109.json
@@ -2,7 +2,7 @@
   "name": "Shibarium",
   "chain": "Shibarium",
   "icon": "shibarium",
-  "rpc": ["https://rpc.shibrpc.com", "https://shib.nownodes.io"],
+  "rpc": ["https://rpc.shibarium.shib.io", "https://shib.nownodes.io"],
   "faucets": [],
   "nativeCurrency": {
     "name": "BONE Shibarium",


### PR DESCRIPTION
Fix Shibarium (eip155-109): use the official RPC endpoint
Shibarium migrated its public RPC some time ago and this entry was never
updated. The endpoint currently listed first no longer resolves.

The migration was announced

Reported at the time:

https://u.today/shib-dev-sends-crucial-warning-to-shibarium-rpc-users-details


The home page of Shiba Inu's official documentation, https://docs.shib.io,
carries a "Network Information" panel publishing Shibarium's network details:

> **Network Name:** Shibarium
> **RPC URL:** https://rpc.shibarium.shib.io
> **Explorer URL:** https://shibariumscan.io
> **Chain ID:** 109
> **Currency symbol:** BONE

The chain ID, name and currency there all match this file, so this change simply
aligns the `rpc` field with the same official source. `shib.io` is the official
Shiba Inu domain and the parent of the `infoURL` already in this entry.
The endpoint responds correctly:
```
$ curl -s https://rpc.shibarium.shib.io \
    -H 'content-type: application/json' \
    -d '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}'
{"jsonrpc":"2.0","id":1,"result":"0x6d"}      # 109
```
The listed endpoint here no longer resolves this is legacy and decommed.

`https://rpc.shibrpc.com` has no DNS record. Public resolvers return SERVFAIL:
```
cloudflare-dns.com/dns-query?name=rpc.shibrpc.com&type=A -> Status 2 SERVFAIL
dns.google/resolve?name=rpc.shibrpc.com&type=A           -> Status 2 SERVFAIL
```
The apex `shibrpc.com` and `www.shibrpc.com` fail identically, so the whole
domain is affected rather than a single host.

As the first array entry it is the default many wallets select, so users adding
Shibarium from this data currently get an unreachable RPC.

`https://shib.nownodes.io` is unchanged, and no other field is touched.