### PR TITLE
fix(eip155-8217): remove inactive Kaiascope explorer

### DIFF
--- a/_data/chains/eip155-1001.json
+++ b/_data/chains/eip155-1001.json
@@ -15,11 +15,6 @@
   "slip44": 1,
   "explorers": [
     {
-      "name": "Kaiascope",
-      "url": "https://kairos.kaiascope.com",
-      "standard": "EIP3091"
-    },
-    {
       "name": "Kaiascan",
       "url": "https://kairos.kaiascan.io",
       "standard": "EIP3091"

--- a/_data/chains/eip155-8217.json
+++ b/_data/chains/eip155-8217.json
@@ -15,11 +15,6 @@
   "slip44": 8217,
   "explorers": [
     {
-      "name": "Kaiascope",
-      "url": "https://kaiascope.com",
-      "standard": "EIP3091"
-    },
-    {
       "name": "Kaiascan",
       "url": "https://kaiascan.io",
       "standard": "EIP3091"


### PR DESCRIPTION
Remove `https://kaiascope.com` from Kaia Mainnet and Kaia Kairos explorers because the domain is no longer available.
After this removal, `https://kaiascan.io` will become the default explorer for Kaia Mainnet and Kaia Kairos

Source: https://docs.kaia.io/build/tools/block-explorers/kaiascope/