### PR TITLE
Add Winmar Chain Mainnet

### DIFF
--- a/_data/chains/eip155-12142816.json
+++ b/_data/chains/eip155-12142816.json
@@ -1,0 +1,22 @@
+{
+  "name": "Winmar Chain Mainnet",
+  "chain": "WMC",
+  "rpc": ["https://rpc.winmarchain.org"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Winmar Coin",
+    "symbol": "WMC",
+    "decimals": 18
+  },
+  "infoURL": "https://scan.winmarchain.org",
+  "shortName": "winmar",
+  "chainId": 12142816,
+  "networkId": 12142816,
+  "explorers": [
+    {
+      "name": "Winmar Chain Explorer",
+      "url": "https://scan.winmarchain.org",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add Winmar Chain Mainnet to the EVM chain registry.

- Chain ID / network ID: `12142816`
- Native currency: Winmar Coin (WMC), 18 decimals
- Public RPC: https://rpc.winmarchain.org
- Explorer: https://scan.winmarchain.org
- EIP-3091 explorer support

## Validation

- Repository validator: `./gradlew run` — BUILD SUCCESSFUL
- `eth_chainId` returns `0xb948e0` (12142816)
- Public RPC and explorer are live over HTTPS
- Chain ID and short name were checked for registry collisions

The icon field is intentionally omitted until a directly retrievable IPFS asset is available.