### PR TITLE
Add NOMATRIX Chain (ChainID: 19840)

### DIFF
--- a/_data/chains/eip155-19840.json
+++ b/_data/chains/eip155-19840.json
@@ -1,0 +1,19 @@
+{
+  "name": "NOMATRIX Chain",
+  "chain": "NXC",
+  "icon": "nomatrix",
+  "rpc": [
+    "https://rpc.nomatrixchain.tech"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "NOMATRIX Coin",
+    "symbol": "NXC",
+    "decimals": 18
+  },
+  "infoURL": "https://nomatrixchain.tech",
+  "shortName": "nxc",
+  "chainId": 19840,
+  "networkId": 19840,
+  "explorers": []
+}


### PR DESCRIPTION
Add NOMATRIX Chain mainnet metadata.

- Chain ID: 19840
- Native currency: NXC (NOMATRIX Coin)
- RPC: https://rpc.nomatrixchain.tech
- Info: https://nomatrixchain.tech
- EVM compatible (Go-Ethereum/Clique PoA)
- Independent blockchain for Augmented Reality ecosystem