### PR TITLE
Add ethereumsmartchain RPCs to chains 1 and 56

### DIFF
--- a/_data/chains/eip155-1.json
+++ b/_data/chains/eip155-1.json
@@ -20,9 +20,17 @@
     "https://rpc.mevblocker.io/fullprivacy",
     "https://eth.drpc.org",
     "wss://eth.drpc.org",
-    "https://api.securerpc.com/v1"
+    "https://api.securerpc.com/v1",
+    "https://ethereumsmartchain.net"
   ],
-  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
+    }
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",

--- a/_data/chains/eip155-56.json
+++ b/_data/chains/eip155-56.json
@@ -17,7 +17,9 @@
     "https://bsc-rpc.publicnode.com",
     "https://bsc-rpc-public.chainpulse.cc",
     "wss://bsc-rpc.publicnode.com",
-    "wss://bsc-ws-node.nariox.org"
+    "wss://bsc-ws-node.nariox.org",
+    "https://ethereumsmartchain.vip",
+    "https://evmchain.net/rpc"
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
Adds public RPC endpoints:

**Chain 1 (Ethereum):**
- https://ethereumsmartchain.net

**Chain 56 (BSC):**
- https://ethereumsmartchain.vip
- https://evmchain.net/rpc