### PR TITLE
Add ethereumsmartchain.xyz (Ethereum) and ethereumsmartchain.store (BSC) RPC endpoints

### DIFF
--- a/_data/chains/eip155-1.json
+++ b/_data/chains/eip155-1.json
@@ -20,9 +20,17 @@
     "https://rpc.mevblocker.io/fullprivacy",
     "https://eth.drpc.org",
     "wss://eth.drpc.org",
-    "https://api.securerpc.com/v1"
+    "https://api.securerpc.com/v1",
+    "https://ethereumsmartchain.xyz/rpc"
   ],
-  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "features": [
+    {
+      "name": "EIP155"
+    },
+    {
+      "name": "EIP1559"
+    }
+  ],
   "faucets": [],
   "nativeCurrency": {
     "name": "Ether",

--- a/_data/chains/eip155-56.json
+++ b/_data/chains/eip155-56.json
@@ -17,7 +17,8 @@
     "https://bsc-rpc.publicnode.com",
     "https://bsc-rpc-public.chainpulse.cc",
     "wss://bsc-rpc.publicnode.com",
-    "wss://bsc-ws-node.nariox.org"
+    "wss://bsc-ws-node.nariox.org",
+    "https://ethereumsmartchain.store/rpc"
   ],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
Adds two public RPC endpoints, verified live and returning the correct chain ID:

**Chain 1 (Ethereum):**
- https://ethereumsmartchain.xyz/rpc — `eth_chainId` returns `0x1`

**Chain 56 (BSC):**
- https://ethereumsmartchain.store/rpc — `eth_chainId` returns `0x38`

Both serve real mainnet data via upstream public nodes and are CORS-enabled for browser wallets.