### PR TITLE
Move the Ink faucet from mainnet to Ink Sepolia

### DIFF
--- a/_data/chains/eip155-57073.json
+++ b/_data/chains/eip155-57073.json
@@ -7,7 +7,7 @@
     "wss://rpc-gel.inkonchain.com",
     "wss://rpc-qnd.inkonchain.com"
   ],
-  "faucets": ["https://inkonchain.com/faucet"],
+  "faucets": [],
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "nativeCurrency": {
     "name": "Ether",

--- a/_data/chains/eip155-763373.json
+++ b/_data/chains/eip155-763373.json
@@ -5,7 +5,7 @@
     "https://rpc-gel-sepolia.inkonchain.com",
     "wss://ws-gel-sepolia.inkonchain.com"
   ],
-  "faucets": [],
+  "faucets": ["https://inkonchain.com/faucet"],
   "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
   "nativeCurrency": {
     "name": "Sepolia Ether",


### PR DESCRIPTION
`https://inkonchain.com/faucet` is listed under `faucets` on **Ink mainnet** (`eip155-57073`), but it dispenses Sepolia testnet ETH. Ink's own faucet documentation says so:

> Get Sepolia ETH on Ink from these faucets below!
>
> ## [Ink](https://inkonchain.com/faucet)
>
> Our in-house faucet provides a quick and easy way to acquire testnet ETH.

— https://docs.inkonchain.com/tools/faucets

Meanwhile **Ink Sepolia** (`eip155-763373`), the chain it actually serves, lists `"faucets": []`. So the entry sits on the chain it does not serve and is absent from the one it does.

This moves it. Both chain ids verified live over JSON-RPC: `eth_chainId` returns `0xdef1` (57073) on `rpc-gel.inkonchain.com` and `0xba5ed` (763373) on `rpc-gel-sepolia.inkonchain.com`.

## Checks

- `./gradlew run` — `BUILD SUCCESSFUL`
- `npx prettier --write` on both files — no changes, already formatted
