### PR TITLE
Add Bighive Mainnet chain ID 1062

### DIFF
--- a/_data/chains/eip155-1062.json
+++ b/_data/chains/eip155-1062.json
@@ -1,0 +1,23 @@
+{
+  "name": "Bighive Mainnet",
+  "chain": "BIGHIVE",
+  "rpc": ["https://rpc.bighive-beets.io/osc"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Beets",
+    "symbol": "BEETS",
+    "decimals": 18
+  },
+  "infoURL": "https://bighive-beets.io",
+  "shortName": "bighive",
+  "chainId": 1062,
+  "networkId": 1062,
+  "explorers": [
+    {
+      "name": "BDBS",
+      "url": "https://bdbs.bighive-beets.io",
+      "standard": "EIP3091"
+    }
+  ],
+  "status": "incubating"
+}


### PR DESCRIPTION
This pull request adds Bighive Mainnet to the EVM chain registry.

Network details:

* Chain ID: 1062
* Network ID: 1062
* Native currency: BEETS
* RPC: https://rpc.bighive-beets.io/osc
* Explorer: https://bdbs.bighive-beets.io/
* Official website: https://bighive-beets.io/
* Status: incubating

Validation completed successfully with:

`./gradlew run`

Result:

`BUILD SUCCESSFUL`