### PR TITLE
Add BitVault BVM20 (chainId 31338)

### DIFF
--- a/_data/chains/eip155-31338.json
+++ b/_data/chains/eip155-31338.json
@@ -1,0 +1,29 @@
+{
+  "name": "BitVault BVM20",
+  "chain": "BVM20",
+  "icon": "bitvault",
+  "rpc": [
+    "https://rpc.bitvault.club"
+  ],
+  "features": [
+    { "name": "EIP155" },
+    { "name": "EIP1559" }
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Ether",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "infoURL": "https://bitvault.club",
+  "shortName": "bvm20",
+  "chainId": 31338,
+  "networkId": 31338,
+  "explorers": [
+    {
+      "name": "BitVault Explorer",
+      "url": "https://explorer.bitvault.club",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Adds BitVault BVM20, an EVM L2 running Hyperledger Besu with Clique PoA.

Verification:
- RPC `https://rpc.bitvault.club` returns `eth_chainId` = `0x7a6a` (31338)
- Explorer `https://explorer.bitvault.club` (Blockscout, EIP-3091) — HTTP 200
- Website `https://bitvault.club` — HTTP 200
- `./gradlew run` passes locally; file is prettier-formatted
- chainId/networkId 31338 and shortName `bvm20` are not in use by any existing chain